### PR TITLE
config: allow optional local config file to be imported

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Local config file
+hepdata/config_local.py

--- a/hepdata/config.py
+++ b/hepdata/config.py
@@ -83,7 +83,7 @@ SECURITY_RESET_SALT = "CHANGE_ME"
 
 # Theme
 THEME_SITENAME = _("HEPData")
-THEME_TWITTERHANDLE = "@hepdata"
+THEME_TWITTERHANDLE = "@HEPData"
 THEME_LOGO = "img/hepdata_logo.svg"
 THEME_GOOGLE_SITE_VERIFICATION = [
     "5fPGCLllnWrvFxH9QWI0l1TadV7byeEvfPcyK2VkS_s",
@@ -172,9 +172,16 @@ CONSUMER_SECRET = ""
 USE_TWITTER = True
 TWITTER_HANDLE_MAPPINGS = {
     "lhcb": "@LHCbPhysics",
-    'atlas': "@ATLASpapers",
-    'cms': "@CMSpapers",
+    "atlas": "@ATLASpapers",
+    "cms": "@CMSpapers",
+    "alice": "@ALICEexperiment",
 }
 
 THEME_404_TEMPLATE = "hepdata_theme/404.html"
 THEME_500_TEMPLATE = "hepdata_theme/500.html"
+
+# Import local config file if it is present.
+try:
+    from hepdata.config_local import *
+except ImportError:
+    pass

--- a/hepdata/modules/theme/templates/hepdata_theme/footer.html
+++ b/hepdata/modules/theme/templates/hepdata_theme/footer.html
@@ -12,7 +12,7 @@
         <ul>
             <li class="bg-purple"><a href="/about"><span class="fa fa-info-circle"></span> About</a></li>
             <li class="bg-purple-lighter"><a href="/submission"><span class="fa fa-upload"></span> Submission Guidelines</a></li>
-            <li class="bg-purple"><a href="http://twitter.com/hepdata" target="_new"><span class="fa fa-twitter"></span></a></li>
+            <li class="bg-purple"><a href="http://twitter.com/HEPData" target="_new"><span class="fa fa-twitter"></span></a></li>
         </ul>
     </div>
 </div>

--- a/hepdata/modules/theme/templates/hepdata_theme/home.html
+++ b/hepdata/modules/theme/templates/hepdata_theme/home.html
@@ -142,7 +142,7 @@
                                                             target="_blank"><img
                             src="static/img/about/durham-logo.svg" width="180px"></a>
                     </div>
-                    <div class="col-md-4" align="center"><a href="http://www.cern.ch"
+                    <div class="col-md-4" align="center"><a href="http://home.cern"
                                                             target="_blank"> <img
                             src="static/img/about/cern-logo.svg" width="90px"></a>
                     </div>

--- a/hepdata/modules/theme/templates/hepdata_theme/pages/about.html
+++ b/hepdata/modules/theme/templates/hepdata_theme/pages/about.html
@@ -70,7 +70,7 @@
                 comprises the data points from plots and tables related to
                 several thousand publications including those
                 from the Large Hadron Collider (LHC). HEPData is funded by a
-                <a href="http://gtr.rcuk.ac.uk/projects?ref=ST/N000315/1">grant</a> from the UK
+                 <a href="http://gtr.rcuk.ac.uk/projects?ref=ST/N000315/1" target="_blank">grant</a> from the UK
                 <a href="http://www.stfc.ac.uk/" target="_blank">STFC</a> and
                 is based at the
                 <a href="http://www.ippp.dur.ac.uk/" target="_blank">IPPP</a>
@@ -85,7 +85,7 @@
         <p style="font-size: 1.3em; font-weight: lighter">
             HEPData has been in existence for decades with the invaluable support from many people and grants. The
             current team is comprised of members from
-            Durham University, England and CERN. Durham's role is largely on content, whereas CERNs role is in
+            Durham University, England and CERN. Durham's role is largely on content, whereas CERN's role is in
             development and hosting.</p>
 
 
@@ -200,9 +200,9 @@
             <div class="section-header" style="width:250px"><p>Other Contributors</p></div>
             <br/>
             <ul style="list-style: none; -webkit-padding-start: 0">
-                <li>Laura Rueda (now at DataCite)</li>
-                <li>Michal Szozsak (Summer Student @ CERN, 2015)</li>
-                <li>Juan Luis (University of Salamanca, Spain)</li>
+                <li>Laura Rueda Garcia (now at DataCite)</li>
+                <li>Michał Szostak (Summer Student @ CERN, 2015)</li>
+                <li>Juan Luis Boya García (University of Salamanca, Spain)</li>
                 <li>Lukas Heinrich (NYU, New York, USA)</li>
             </ul>
         </div>
@@ -317,7 +317,7 @@
                 </a>
             </div>
             <div class="col-md-6" align="center">
-                <a href="http://www.cern.ch" target="_blank">
+                <a href="http://home.cern" target="_blank">
                     <img src="static/img/about/cern-logo.svg" width="130px">
                 </a>
             </div>


### PR DESCRIPTION
- Useful for local config options (e.g. TESTING = True).
- Some other minor tweaks to About page etc.

Signed-off-by: Graeme Watt graeme.watt@durham.ac.uk
