### PR TITLE
hepdata_records: don't round errors given in scientific notation

### DIFF
--- a/hepdata/modules/dashboard/views.py
+++ b/hepdata/modules/dashboard/views.py
@@ -489,7 +489,7 @@ def do_finalise(recid, publication_record=None, force_finalise=False,
                     delete_item_from_index(record["_id"],
                                            doc_type=CFG_DATA_TYPE)
 
-        current_time = "{:%Y-%m-%d}".format(datetime.now())
+        current_time = "{:%Y-%m-%d %H:%M:%S}".format(datetime.now())
 
         for submission in submissions:
             finalise_datasubmission(current_time, existing_submissions,

--- a/hepdata/modules/records/static/js/dataviewer.js
+++ b/hepdata/modules/records/static/js/dataviewer.js
@@ -304,13 +304,18 @@ HEPDATA.filter_content = function (filterInputId, listId) {
 
 /**
  * Counts the number of decimal places for a value.
+ * Check if value is given in scientific notation.
  * @param number
  * @returns {*|number}
  */
 
 HEPDATA.count_decimals = function (number) {
   if (number.toString().indexOf('.') != -1) {
-    return number.toString().split(".")[1].length || 2
+    var rightofpoint = number.toString().split(".")[1];
+    if (rightofpoint.toLowerCase().indexOf('e') != -1)
+      return rightofpoint.toLowerCase().split('e')[0].length || 2;
+    else
+      return rightofpoint.length || 2;
   }
   return 0;
 }
@@ -498,10 +503,16 @@ HEPDATA.table_renderer = {
 
               var plus_error = errors[error_idx]['asymerror']['plus'];
               var min_error = errors[error_idx]['asymerror']['minus'];
-              if (plus_error.toString().toLowerCase().indexOf('e') == -1)
-                plus_error = HEPDATA.visualization.utils.round(plus_error, decimal_places);
-              if (min_error.toString().toLowerCase().indexOf('e') == -1)
-                min_error = HEPDATA.visualization.utils.round(min_error, decimal_places);
+              if (plus_error.toString().toLowerCase().indexOf('e') == -1 && value.toString().toLowerCase().indexOf('e') == -1) {
+                var plus_error_rounded = HEPDATA.visualization.utils.round(plus_error, decimal_places);
+                if (plus_error_rounded != 0)
+                  plus_error = plus_error_rounded;
+              }
+              if (min_error.toString().toLowerCase().indexOf('e') == -1 && value.toString().toLowerCase().indexOf('e') == -1) {
+                var min_error_rounded = HEPDATA.visualization.utils.round(min_error, decimal_places);
+                if (min_error_rounded != 0)
+                  min_error = min_error_rounded;
+              }
 
               var plus_error_num = HEPDATA.dataprocessing.process_error_value(errors[error_idx]['asymerror']['plus'], value);
               var min_error_num = HEPDATA.dataprocessing.process_error_value(errors[error_idx]['asymerror']['minus'], value);
@@ -518,8 +529,11 @@ HEPDATA.table_renderer = {
             } else if ("symerror" in errors[error_idx]) {
               if (errors[error_idx]['symerror'] != 0) {
                 var sym_error = errors[error_idx]['symerror'];
-                if (sym_error.toString().toLowerCase().indexOf('e') == -1)
-                  sym_error = HEPDATA.visualization.utils.round(sym_error, decimal_places);
+                if (sym_error.toString().toLowerCase().indexOf('e') == -1 && value.toString().toLowerCase().indexOf('e') == -1) {
+                  var sym_error_rounded = HEPDATA.visualization.utils.round(sym_error, decimal_places);
+                  if (sym_error_rounded != 0)
+                    sym_error = sym_error_rounded;
+                }
                 var error = div.append('div').attr('class', err_class + ' sym');
                 error.append('div').attr('class', 'value').html('&#177;' + sym_error);
 

--- a/hepdata/modules/records/static/js/dataviewer.js
+++ b/hepdata/modules/records/static/js/dataviewer.js
@@ -496,8 +496,12 @@ HEPDATA.table_renderer = {
 
             if ("asymerror" in errors[error_idx]) {
 
-              var plus_error = HEPDATA.visualization.utils.round(errors[error_idx]['asymerror']['plus'], decimal_places);
-              var min_error = HEPDATA.visualization.utils.round(errors[error_idx]['asymerror']['minus'], decimal_places);
+              var plus_error = errors[error_idx]['asymerror']['plus'];
+              var min_error = errors[error_idx]['asymerror']['minus'];
+              if (plus_error.toString().toLowerCase().indexOf('e') == -1)
+                plus_error = HEPDATA.visualization.utils.round(plus_error, decimal_places);
+              if (min_error.toString().toLowerCase().indexOf('e') == -1)
+                min_error = HEPDATA.visualization.utils.round(min_error, decimal_places);
 
               var plus_error_num = HEPDATA.dataprocessing.process_error_value(errors[error_idx]['asymerror']['plus'], value);
               var min_error_num = HEPDATA.dataprocessing.process_error_value(errors[error_idx]['asymerror']['minus'], value);
@@ -513,7 +517,9 @@ HEPDATA.table_renderer = {
 
             } else if ("symerror" in errors[error_idx]) {
               if (errors[error_idx]['symerror'] != 0) {
-                var sym_error = HEPDATA.visualization.utils.round(errors[error_idx]['symerror'], decimal_places);
+                var sym_error = errors[error_idx]['symerror'];
+                if (sym_error.toString().toLowerCase().indexOf('e') == -1)
+                  sym_error = HEPDATA.visualization.utils.round(sym_error, decimal_places);
                 var error = div.append('div').attr('class', err_class + ' sym');
                 error.append('div').attr('class', 'value').html('&#177;' + sym_error);
 


### PR DESCRIPTION
- Previous commit (ea5daea6d80297a49143f25241e107dfcb22440d) doesn't work for errors in scientific notation, so don't try to round.  Example: [ins1296835](http://hepdata.cedar.ac.uk/view/ins1296835/d1)
- Also correct date format for submissions with a commit message (version 2 or greater).

Signed-off-by: Graeme Watt graeme.watt@durham.ac.uk
