### PR TITLE
mail: add config option for TLS encryption with SMTP server

### DIFF
--- a/hepdata/config.py
+++ b/hepdata/config.py
@@ -116,6 +116,7 @@ MAIL_SERVER = 'mail.smtp2go.com'
 MAIL_PORT = 2525
 MAIL_DEFAULT_SENDER = 'submissions@hepdata.net'
 SMTP_NO_PASSWORD = True
+SMTP_ENCRYPTION = False
 MAIL_USERNAME = 'submissions@hepdata.net'
 MAIL_PASSWORD = ''
 
@@ -161,6 +162,8 @@ PIDSTORE_DATACITE_USERNAME = "CERN.HEPDATA"
 PIDSTORE_DATACITE_PASSWORD = ""
 PIDSTORE_DATACITE_TESTMODE = False
 PIDSTORE_DATACITE_URL = "https://mds.datacite.org"
+
+NO_DOI_MINTING = False
 
 # To get twitter to work, go to https://apps.twitter.com/ and create an application owned by the user account to
 # which the tweets will be sent. Then, follow the instructions here to get hold of access tokens:

--- a/hepdata/modules/dashboard/views.py
+++ b/hepdata/modules/dashboard/views.py
@@ -566,7 +566,7 @@ def do_finalise(recid, publication_record=None, force_finalise=False,
             create_celery_app(current_app)
 
             # only mint DOIs if not testing.
-            if not current_app.config.get('TESTING', False):
+            if not current_app.config.get('TESTING', False) and not current_app.config.get('NO_DOI_MINTING', False):
                 for submission in submissions:
                     generate_doi_for_data_submission.delay(submission.id, submission.version)
 

--- a/hepdata/utils/mail.py
+++ b/hepdata/utils/mail.py
@@ -46,6 +46,8 @@ def connect():
     smtp = SMTP()
     smtp.connect(current_app.config['MAIL_SERVER'], current_app.config['MAIL_PORT'])
     if not current_app.config['SMTP_NO_PASSWORD']:
+        if current_app.config['SMTP_ENCRYPTION']:
+            smtp.starttls()
         smtp.login(current_app.config['MAIL_USERNAME'], current_app.config['MAIL_PASSWORD'])
 
     return smtp


### PR DESCRIPTION
- Some SMTP servers require login with TLS encryption, so add SMTP_ENCRYPTION flag to config file.
- Also add NO_DOI_MINTING flag to switch off DOI minting but keep sending emails (TESTING flag switches both off).

Signed-off-by: Graeme Watt graeme.watt@durham.ac.uk
