### PR TITLE
Fix minor bug for failed data table conversion and mention .oldhepdata file on upload page

### DIFF
--- a/hepdata/modules/converter/views.py
+++ b/hepdata/modules/converter/views.py
@@ -193,10 +193,10 @@ def download_datatable(data_id, file_format):
     if successful:
         new_path = output_path + "." + file_format
         new_path = extract(filename + ".tar.gz", output_path + '-dir', new_path)
+        file_to_send = get_file_in_directory(new_path, file_format)
     else:
-        new_path = output_path + '.html'
-
-    file_to_send = get_file_in_directory(new_path, file_format)
+        file_to_send = output_path + '-dir'
+        file_format = 'html'
 
     return send_file(file_to_send, as_attachment=True,
                      attachment_filename=filename + '.' + file_format)

--- a/hepdata/modules/records/templates/hepdata_records/publication_record.html
+++ b/hepdata/modules/records/templates/hepdata_records/publication_record.html
@@ -257,11 +257,21 @@
             <div class="upload-area" id="main-upload-area">
                 <div class="root_upload_form" align="center">
                     <img src="{{ url_for('static', filename='img/icon-upload.svg') }}" width="70">
-                    <h4>Upload an archive to HEPdata</h4>
+                    <h4>Upload an archive to HEPData</h4>
 
                     <div class="info">
-                        <p>You can upload an archive that should contain the
-                            files stated in these guidelines.</p>
+                        <p>Upload an archive (<strong>zip</strong>, <strong>tar.gz</strong>, <strong>tar</strong>)
+                            containing YAML files formatted according to these <a
+                                    href="https://github.com/HEPData/hepdata-submission"
+                                    target="_blank">guidelines</a>.
+                            An example submission is available <a
+                                    href="https://www.dropbox.com/s/ph6zphwfjnigki1/1203852_hm.zip?dl=0"
+                                    target="_blank">here</a>.</p>
+
+                        <p>Alternatively, upload a single text file with extension <strong>.oldhepdata</strong> containing
+                            the "input" format that was used for data submissions from the old <a
+                                    href="http://hepdata.cedar.ac.uk"
+                                    target="_blank">HepData</a> site.</p>
                     </div>
 
                     <form action="/record/{{ ctx.record.recid }}/consume"

--- a/hepdata/modules/records/templates/hepdata_records/sandbox.html
+++ b/hepdata/modules/records/templates/hepdata_records/sandbox.html
@@ -84,15 +84,18 @@
                 <br/>
 
                 <div class="info">
-                    <p>Upload a <strong>zip</strong>, <strong>tar.gz</strong>, or <strong>tar</strong> archive
-                        containing files
-                        formatted per these <a
+                    <p>Upload an archive (<strong>zip</strong>, <strong>tar.gz</strong>, <strong>tar</strong>)
+                        containing YAML files formatted according to these <a
                                 href="https://github.com/HEPData/hepdata-submission"
-                                target="_blank">these guidelines</a>.</p>
-
-                    <p>An example submission is available <a
+                                target="_blank">guidelines</a>.
+                        An example submission is available <a
                             href="https://www.dropbox.com/s/ph6zphwfjnigki1/1203852_hm.zip?dl=0"
                             target="_blank">here</a>.</p>
+
+                    <p>Alternatively, upload a single text file with extension <strong>.oldhepdata</strong> containing
+                        the "input" format that was used for data submissions from the old <a
+                            href="http://hepdata.cedar.ac.uk"
+                            target="_blank">HepData</a> site.</p>
                 </div>
 
                 <form action="/record/sandbox/consume" method="post"

--- a/hepdata/modules/records/views.py
+++ b/hepdata/modules/records/views.py
@@ -819,7 +819,8 @@ def process_payload(recid, file, redirect_url):
         return render_template('hepdata_records/error_page.html', recid=recid,
                                message="Incorrect file type uploaded.",
                                errors={"Submission": [{"level": "error",
-                                                       "message": "You must upload a .zip, .tar, or .tar.gz file."}]})
+                                                       "message": "You must upload a .zip, .tar, or .tar.gz file"
+                                                                      + " (or a .oldhepdata file)."}]})
 
 
 def process_zip_archive(file, id):


### PR DESCRIPTION
- conversion: fix bug returning HTML for a failed data table conversion
- records: mention possibility to upload .oldhepdata file (instead of YAML archive)

Signed-off-by: Graeme Watt graeme.watt@durham.ac.uk
