### PR TITLE
records: fix another logger for Sentry 6

### DIFF
--- a/hepdata/modules/records/utils/yaml_utils.py
+++ b/hepdata/modules/records/utils/yaml_utils.py
@@ -114,7 +114,7 @@ def split_files(file_location, output_location,
     except yaml.scanner.ScannerError as se:
         return se, last_updated
     except Exception as e:
-        log.error('Error parsing {0}, {1}'.format(file_location, e.message))
+        log.error('Error parsing %s, %s', file_location, e.message)
         return e, last_updated
     return None, last_updated
 


### PR DESCRIPTION
Same thing as https://github.com/HEPData/hepdata/pull/77: I currently see* a distinct error on Sentry for each file that the YAML utils failed to parse. With this call, all these errors will be clustered together.

\* and I also receive a distinct email... : )