### PR TITLE
global: fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,8 @@ python:
   - "2.7"
 
 before_install:
+  # See: https://docs.travis-ci.com/user/database-setup/#Installing-specific-versions-of-ElasticSearch
+  - "curl -O https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.1.1/elasticsearch-2.1.1.deb && sudo dpkg -i --force-confnew elasticsearch-2.1.1.deb && sudo service elasticsearch restart"
   - "travis_retry pip install --upgrade pip setuptools py"
   - "travis_retry pip install twine wheel coveralls requirements-builder"
   - "travis_retry psql -c 'CREATE DATABASE hepdata_test;' -U postgres"

--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,8 @@ install_requires = [
     'Flask-Login<0.4.0',
     'oauthlib!=2.0.0,>=1.1.2',
     'twitter',
-    'psycopg2'
+    'psycopg2',
+    'simplekv<0.11',
 ]
 
 packages = find_packages()


### PR DESCRIPTION
The latest version of simplekv appears to be incompatible with
Python 2, so we fix the build by pinning the previous version.

(I just fixed the same error in INSPIRE: https://github.com/inspirehep/inspire-next/commit/0def4c58e504d45f88c1439641d4d43dafc76a50.)

Also pins Elasticsearch to 2.1.1, as the latest Travis image has version
5.5.0 installed by default, but HEPData uses queries that were removed
since version 5.