### PR TITLE
Use test index for elasticsearch when setting up test configs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,6 +53,7 @@ def app(request):
         CELERY_CACHE_BACKEND="memory",
         MAIL_SUPPRESS_SEND=True,
         CELERY_TASK_EAGER_PROPAGATES=True,
+        ELASTICSEARCH_INDEX="hepdata_test",
         SQLALCHEMY_DATABASE_URI=os.environ.get(
             'SQLALCHEMY_DATABASE_URI', 'postgresql+psycopg2://hepdata:hepdata@localhost/hepdata_test')
     ))

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -61,6 +61,7 @@ def app(request):
         CELERY_CACHE_BACKEND="memory",
         MAIL_SUPPRESS_SEND=True,
         CELERY_TASK_EAGER_PROPAGATES=True,
+        ELASTICSEARCH_INDEX="hepdata_test",
         SQLALCHEMY_DATABASE_URI=os.environ.get(
             'SQLALCHEMY_DATABASE_URI', 'postgresql+psycopg2://hepdata:hepdata@localhost/hepdata_test')
     ))


### PR DESCRIPTION
This avoids the need to reindex the local elasticsearch index after running the tests.
Fixes HEPData/hepdata#168