### PR TITLE
Remove attempt to create hepsubmission if it doesn't exist

### DIFF
--- a/hepdata/modules/records/utils/submission.py
+++ b/hepdata/modules/records/utils/submission.py
@@ -449,12 +449,6 @@ def process_submission_directory(basepath, submission_file_path, recid, update=F
         # process file, extracting contents, and linking
         # the data record with the parent publication
         hepsubmission = get_latest_hepsubmission(publication_recid=recid)
-        if hepsubmission is None:
-            HEPSubmission(publication_recid=recid,
-                          overall_status='todo',
-                          inspire_id=hepsubmission.inspire_id,
-                          coordinator=kwargs.get('user_id') if 'user_id' in kwargs else int(current_user.get_id()),
-                          version=hepsubmission.version + 1)
 
         # On a new upload, we reset the flag to notify reviewers
         hepsubmission.reviewers_notified = False


### PR DESCRIPTION
The code was presumably never reached previously, as it could never have
worked, as it tried to access variables of the null submission. We don't
have enough information at this point to sensibly create a hepsubmission,
so let's not try. All calls to process_submission_directory rely on the
submission already being in existence, so we shouldn't get to an error
case here.

Found this while adding tests for #221 