### PR TITLE
Fix upload timeouts

### DIFF
--- a/hepdata/modules/records/api.py
+++ b/hepdata/modules/records/api.py
@@ -368,13 +368,10 @@ def process_payload(recid, file, redirect_url, synchronous=False):
             process_saved_file.delay(file_path, recid, current_user.get_id(), redirect_url, previous_status)
             flash('File saved. You will receive an email when the file has been processed.', 'info')
 
-        return redirect(redirect_url.format(recid))
+        return jsonify({'url': redirect_url.format(recid)})
     else:
-        return render_template('hepdata_records/error_page.html', redirect_url=redirect_url.format(recid),
-                               message="Incorrect file type uploaded.",
-                               errors={"Submission": [{"level": "error",
-                                                       "message": "You must upload a .zip, .tar, .tar.gz or .tgz file"
-                                                                  + " (or a .oldhepdata or single .yaml file)."}]})
+        return jsonify({"message": "You must upload a .zip, .tar, .tar.gz or .tgz file"
+                       + " (or a .oldhepdata or single .yaml file)."}), 500
 
 
 @shared_task

--- a/hepdata/modules/records/api.py
+++ b/hepdata/modules/records/api.py
@@ -371,7 +371,7 @@ def process_payload(recid, file, redirect_url, synchronous=False):
         return jsonify({'url': redirect_url.format(recid)})
     else:
         return jsonify({"message": "You must upload a .zip, .tar, .tar.gz or .tgz file"
-                       + " (or a .oldhepdata or single .yaml file)."}), 500
+                       + " (or a .oldhepdata or single .yaml file)."}), 400
 
 
 @shared_task

--- a/hepdata/modules/records/api.py
+++ b/hepdata/modules/records/api.py
@@ -340,6 +340,8 @@ def process_payload(recid, file, redirect_url, synchronous=False):
         Redirect URL to record, for use if the upload fails or in synchronous mode
     :param synchronous: bool
         Whether to process asynchronously via celery (default) or immediately (only recommended for tests)
+    :return: JSONResponse either containing 'url' (for success cases) or
+             'message' (for error cases, which will give a 400 error).
     """
     if file and (allowed_file(file.filename)):
         file_path = save_zip_file(file, recid)

--- a/hepdata/modules/records/static/js/hepdata_record_js.js
+++ b/hepdata/modules/records/static/js/hepdata_record_js.js
@@ -21,13 +21,17 @@ var hepdata_record = (function () {
       },
 
       perform_upload_action: function (placement, form_name, colors, insertion_type) {
+        if (event) {
+          event.preventDefault();
+        }
+
         var message = '<p>Uploading files...</p>'
         message += '<p>(Timeout after 60 seconds.)</p>'
         var html = '<div id="upload-progress"></div>' +
-          '<div>' + message + '</div>';
+          '<div id="upload-message">' + message + '</div>';
         if (insertion_type === 'large_area') {
           html = '<div id="upload-progress"></div>' +
-            '<div style="width: 200px; margin: 0 auto;"><p>' + message + '</p></div>';
+            '<div style="width: 300px; margin: 0 auto;" id="upload-message"><p>' + message + '</p></div>';
         }
 
         $(".upload-form").css('display', 'none');
@@ -48,9 +52,39 @@ var hepdata_record = (function () {
           {"width": 200, "height": 200}
         );
 
-        document.forms[form_name].submit();
+        var form = document.forms[form_name];
+        var data = new FormData(form);
 
-        return false;
+		    $.ajax({
+            type: "POST",
+            enctype: 'multipart/form-data',
+            url: form.action,
+            data: data,
+            dataType: "text json",
+            processData: false,
+            contentType: false,
+            cache: false,
+            timeout: 58000,
+            success: function (data) {
+              window.location.href = data['url'];
+            },
+            error: function (e) {
+              message = "<p>We were unable to upload your file.</p>";
+
+              if (e.statusText == "timeout") {
+                message += "<p>Your submission was too large to be uploaded within the timeout limit. Please try to reduce the size of your upload file (preferably to ~10 MB or less) and try again. This limit may be increased in future. Please contact info@hepdata.net if you need any further information.</p>";
+              } else if (e.responseJSON && e.responseJSON['message']) {
+                message += "<p>" + e.responseJSON['message'] + "</p>";
+              } else {
+                message += "<p>An unknown error occurred. Please try again later, or contact info@hepdata.net if the message persists.</p>"
+              }
+
+              message += '<p><a href="" onclick="window.location.reload(false);">Try again</a></p>'
+
+              $('#upload-progress').remove();
+              $('#upload-message').html(message)
+            }
+        });
 
       }
     }

--- a/hepdata/modules/records/views.py
+++ b/hepdata/modules/records/views.py
@@ -616,7 +616,9 @@ def consume_data_payload(recid):
     This method persists, then presents the loaded data back to the user.
 
     :param recid: record id to attach the data to
-    :return: page rendering
+    :return: For POST requests, returns JSONResponse either containing 'url'
+             (for success cases) or 'message' (for error cases, which will
+             give a 400 error). For GET requests, redirects to the record.
     """
 
     if request.method == 'POST':

--- a/tests/records_test.py
+++ b/tests/records_test.py
@@ -193,7 +193,7 @@ def test_upload_invalid_file(app):
             )
             response, code = process_payload(recid, test_file, '/test_redirect_url', synchronous=True)
 
-        assert(code == 500)
+        assert(code == 400)
         assert(response.json == {
                 'message': 'You must upload a .zip, .tar, .tar.gz or .tgz file'
                            ' (or a .oldhepdata or single .yaml file).'

--- a/tests/records_test.py
+++ b/tests/records_test.py
@@ -22,7 +22,7 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 """HEPData records test cases."""
-from io import open
+from io import open, StringIO
 import os
 import yaml
 
@@ -139,7 +139,9 @@ def test_upload_valid_file(app):
                 stream=stream,
                 filename="TestHEPSubmission.zip"
             )
-            process_payload(recid, test_file, '/test_redirect_url', synchronous=True)
+            response = process_payload(recid, test_file, '/test_redirect_url', synchronous=True)
+
+        assert(response.json == {'url': '/test_redirect_url'})
 
         # Check the submission has been updated
         hepdata_submission = HEPSubmission.query.filter_by(
@@ -173,3 +175,26 @@ def test_upload_valid_file(app):
         assert(hepdata_submissions[1].data_abstract.startswith('CERN-LHC.  Measurements of the cross section  for ZZ production'))
         assert(hepdata_submissions[1].version == 2)
         assert(hepdata_submissions[1].overall_status == 'todo')
+
+
+def test_upload_invalid_file(app):
+    # Test uploading an invalid file
+    with app.app_context():
+        user = User.query.first()
+        login_user(user)
+
+        recid = '12345'
+        get_or_create_hepsubmission(recid, 1)
+
+        with StringIO("test") as stream:
+            test_file = FileStorage(
+                stream=stream,
+                filename="test.txt"
+            )
+            response, code = process_payload(recid, test_file, '/test_redirect_url', synchronous=True)
+
+        assert(code == 500)
+        assert(response.json == {
+                'message': 'You must upload a .zip, .tar, .tar.gz or .tgz file'
+                           ' (or a .oldhepdata or single .yaml file).'
+        })


### PR DESCRIPTION
File uploads now time out after 59s.

The max time the server allows for uploads is 60s, so we now set a client-side timeout before that in order to allow for better error handling.

 * `perform_upload_action` now submits form via ajax and handles timeouts and errors
 * `process_payload` now returns json to be handled by perform_upload_action

Fixes #214