### PR TITLE
Remote schema validations

### DIFF
--- a/hepdata/modules/records/utils/validators.py
+++ b/hepdata/modules/records/utils/validators.py
@@ -39,11 +39,16 @@ ACCEPTED_REMOTE_SCHEMAS = [
     {
         'base_url': 'https://scikit-hep.org/pyhf/schemas/1.0.0/',
         'schemas': [
-            'jsonpatch.json',
-            'measurement.json',
-            'model.json',
-            'patchset.json',
-            'workspace.json',
+            # The schemas need to be rendered by HEPData.
+            # Containing fields: `independent_variables` and `dependent_variables`
+            # Ref: https://github.com/HEPData/hepdata/pull/241#issuecomment-702389464
+            #
+            # None of the following pyhf schemas at v1.0.0 comply:
+            # 'jsonpatch.json',
+            # 'measurement.json',
+            # 'model.json',
+            # 'patchset.json',
+            # 'workspace.json',
         ],
     },
 ]

--- a/hepdata/modules/records/utils/validators.py
+++ b/hepdata/modules/records/utils/validators.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of HEPData.
+# Copyright (C) 2020 CERN.
+#
+# HEPData is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# HEPData is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with HEPData; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+import logging
+import os
+
+from hepdata_validator.data_file_validator import DataFileValidator
+from hepdata_validator.schema_downloader import HTTPSchemaDownloader
+from hepdata_validator.schema_resolver import JsonSchemaResolver
+from hepdata_validator.submission_file_validator import SubmissionFileValidator
+
+logging.basicConfig()
+log = logging.getLogger(__name__)
+
+
+# Expand list to add support
+ACCEPTED_REMOTE_SCHEMAS = [
+    {
+        'base_url': 'https://scikit-hep.org/pyhf/schemas/1.0.0/',
+        'schemas': [
+            'jsonpatch.json',
+            'measurement.json',
+            'model.json',
+            'patchset.json',
+            'workspace.json',
+        ],
+    },
+]
+
+
+# Define a global DataFileValidator object so that
+# custom schemas are only loaded once
+CACHED_DATA_VALIDATOR = None
+
+
+def get_submission_validator():
+    """
+    Returns a SubmissionFileValidator object
+
+    :return: SubmissionFileValidator object
+    """
+
+    return SubmissionFileValidator()
+
+
+def get_data_validator(old_hepdata):
+    """
+    Returns a DataFileValidator object (with remote defined schemas loaded)
+
+    :param old_hepdata: whether the schema version for the submission.yaml is 0.1.0
+    :return: DataFileValidator object
+    """
+
+    global CACHED_DATA_VALIDATOR
+
+    # Use for YAML files migrated from old HepData site
+    if old_hepdata:
+        data_validator = DataFileValidator(schema_version='0.1.0')
+
+    elif CACHED_DATA_VALIDATOR:
+        data_validator = CACHED_DATA_VALIDATOR
+
+    else:
+        data_validator = DataFileValidator()
+        load_remote_schemas(data_validator)
+        CACHED_DATA_VALIDATOR = data_validator
+
+    return data_validator
+
+
+def load_remote_schemas(data_validator):
+    """
+    Loads all the remotely-defined schemas in-place
+
+    :param data_validator: DataFileValidator object to load schemas into
+    :return: None
+    """
+
+    for org_schemas in ACCEPTED_REMOTE_SCHEMAS:
+        schema_url = org_schemas['base_url']
+        schema_names = org_schemas['schemas']
+
+        resolver = JsonSchemaResolver(schema_url)
+        downloader = HTTPSchemaDownloader(resolver, schema_url)
+
+        # Retrieve and save the remote schema in the local path
+        for name in schema_names:
+            schema_type = downloader.get_schema_type(name)
+            schema_spec = downloader.get_schema_spec(name)
+            downloader.save_locally(name, schema_spec)
+
+            # Load the custom schema as a custom type
+            local_path = os.path.join(downloader.schemas_path, name)
+            data_validator.load_custom_schema(schema_type, local_path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ Flask-Login==0.3.2
 gevent==1.4.0
 gunicorn==19.5.0
 hepdata-converter-ws-client==0.1.6
-hepdata-validator==0.2.2
+hepdata-validator==0.2.3
 idna<2.8,>=2.5             # Indirect ('invenio-search', 'email-validator')
 invenio-access==1.0.2      # Indirect (needed by invenio-admin)
 invenio-accounts==1.0.2

--- a/tests/validators_test.py
+++ b/tests/validators_test.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of HEPData.
+# Copyright (C) 2020 CERN.
+#
+# HEPData is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# HEPData is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with HEPData; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+import pytest
+import hepdata.modules.records.utils.validators
+
+from hepdata.modules.records.utils.validators import DataFileValidator
+from hepdata.modules.records.utils.validators import get_data_validator
+from hepdata.modules.records.utils.validators import load_remote_schemas
+
+
+def test_get_data_validator_initial():
+    """
+    Checks that a DataValidator object is returned
+    and populated to the global cached of the `validators` modules
+    """
+
+    # Reset validator cache
+    hepdata.modules.records.utils.validators.CACHED_DATA_VALIDATOR = None
+
+    data_validator = get_data_validator(old_hepdata=False)
+
+    assert type(data_validator) == DataFileValidator
+    assert hepdata.modules.records.utils.validators.CACHED_DATA_VALIDATOR is data_validator
+
+
+def test_get_data_validator_cached():
+    """
+    Checks that once a DataValidator object has been cached,
+    the same object is returned on successive calls
+    """
+
+    # Reset validator cache
+    hepdata.modules.records.utils.validators.CACHED_DATA_VALIDATOR = None
+
+    initial_validator = get_data_validator(old_hepdata=False)
+
+    # Successive calls that should returned the cached validator
+    cached_validator_1 = get_data_validator(old_hepdata=False)
+    cached_validator_2 = get_data_validator(old_hepdata=False)
+
+    assert cached_validator_1 is initial_validator
+    assert cached_validator_2 is initial_validator
+
+
+def test_load_remote_schemas_valid():
+    """
+    Checks that loading of remote schemas when there is
+    a valid response from the remote server
+    """
+
+    # Set up a valid list of validation schemas
+    hepdata.modules.records.utils.validators.ACCEPTED_REMOTE_SCHEMAS = [
+        {
+            'base_url': 'https://scikit-hep.org/pyhf/schemas/1.0.0/',
+            'schemas': ['model.json'],
+        },
+    ]
+
+    schema_name = 'https://scikit-hep.org/pyhf/schemas/1.0.0/model.json'
+
+    data_validator = DataFileValidator()
+    load_remote_schemas(data_validator)
+
+    assert data_validator.custom_data_schemas != {}
+    assert data_validator.custom_data_schemas[schema_name] is not None
+
+
+def test_load_remote_schemas_invalid():
+    """
+    Checks that loading of remote schemas when there is
+    an invalid response from the remote server
+    """
+
+    # Set up a valid list of validation schemas
+    hepdata.modules.records.utils.validators.ACCEPTED_REMOTE_SCHEMAS = [
+        {
+            'base_url': 'https://random-org.com/project/schemas/1.0.0/',
+            'schemas': ['not-found.json'],
+        },
+    ]
+
+    data_validator = DataFileValidator()
+
+    with pytest.raises(FileNotFoundError):
+        load_remote_schemas(data_validator)


### PR DESCRIPTION
This PR substituted the previous _fork-based_ PR https://github.com/HEPData/hepdata/pull/208.

In a nutshell, it makes use of `hepdata-validator` (~0.2.2~) 0.2.3 new features to support _remotely-defined_ schemas when validating submission data.

**Clarifications:**

- I treated the `data_schema` submission field as optional ([check here](https://github.com/HEPData/hepdata/compare/remote-schemas?expand=1#diff-e4f3d23ca9cf3dde5022e99924b0bed1R529)).
- I have not bumped up the HEPData global version.