### PR TITLE
Fix cmenergies filters

### DIFF
--- a/hepdata/ext/elasticsearch/aggregations.py
+++ b/hepdata/ext/elasticsearch/aggregations.py
@@ -146,32 +146,41 @@ def create_dummy_cmenergies_facets(query_filters=None):
     buckets = []
 
     if query_filters:
-        cmenergy_filter_vals = [v for (k,v) in query_filters if k == 'cmenergies' and len(v) > 1]
+        cmenergy_filter_vals = [v for (k,v) in query_filters if k == 'cmenergies']
         if cmenergy_filter_vals:
             # Create filters based on current selection
-            min_limit = int(math.floor(min([v[0] for v in cmenergy_filter_vals])))
-            max_limit = int(math.ceil(max([v[1] for v in cmenergy_filter_vals])))
+            min_limit = int(math.floor(min(
+                [v[0] for v in cmenergy_filter_vals])
+            ))
+            max_limit = int(math.ceil(max(
+                [v[1] if len(v) > 1 else v[0] for v in cmenergy_filter_vals])
+            ))
             if max_limit == MAX_CMENERGY:
                 filter_limits = [min_limit, MAX_CMENERGY]
             else:
                 span = max_limit - min_limit
-                interval = math.ceil(span / 5)
-                base = 5
-
-                if span > 1000:
-                    base = 500
-                elif span > 200:
-                    base = 50
-                elif span > 50:
-                    base = 10
-                elif span > 10:
+                if span > 0:
+                    interval = math.ceil(span / 5)
                     base = 5
-                else:
-                    base = 1
 
-                interval = int(base * math.floor(interval / base))
-                filter_limits = list(range(min_limit, max_limit, interval))
-                filter_limits.append(max_limit)
+                    if span > 1000:
+                        base = 500
+                    elif span > 200:
+                        base = 50
+                    elif span > 50:
+                        base = 10
+                    elif span > 10:
+                        base = 5
+                    else:
+                        base = 1
+
+                    interval = int(base * math.floor(interval / base))
+                    filter_limits = list(range(min_limit, max_limit, interval))
+                    filter_limits.append(max_limit)
+                else:
+                    # If the span is 0, we've only got a single value, so the
+                    # aggregations won't make sense - don't show them.
+                    filter_limits = []
 
     for i in range(len(filter_limits)-1):
         lower_limit = filter_limits[i]

--- a/hepdata/ext/elasticsearch/config/es_config.py
+++ b/hepdata/ext/elasticsearch/config/es_config.py
@@ -75,6 +75,8 @@ def get_filter_field(name, value):
         if len(value) > 1:
             key = "lt" if value[1] > value[0] else "lte"
             val_dict[key] = value[1]
+        else:
+            val_dict["lte"] = value[0]
 
         value = val_dict
 

--- a/hepdata/modules/records/static/js/hepdata_tables.js
+++ b/hepdata/modules/records/static/js/hepdata_tables.js
@@ -212,7 +212,11 @@ HEPDATA.table_renderer = {
         .enter().append('li').attr('class', 'chip');
 
       var individual_kw_link = individual_kw.append('a').attr('href', function (d) {
-        return '/search?q=&' + d.key + "=" + d.value.trim().replace(/\+/g, "%2B").replace(/\s/g, "+");
+        val = d.value.trim().replace(/\+/g, "%2B").replace(/\s/g, "+")
+        if (d.key == 'cmenergies') {
+          val = val.replace(/-/g, "%2C")
+        }
+        return '/search?q=&' + d.key + "=" + val;
       });
 
       individual_kw_link.append('i').attr('class', 'fa fa-tag').style({'margin-right': '5px', 'display': 'inline'});

--- a/tests/aggregations_test.py
+++ b/tests/aggregations_test.py
@@ -131,7 +131,6 @@ def test_parse_cmenergies_aggregations_filtered():
     assert(parse_cmenergies_aggregations(buckets, query_filters2) == expected2)
 
 
-
 def test_parse_collaboration_aggregations():
     buckets = [
         {'key': 'collab1', 'doc_count': 3},
@@ -403,7 +402,6 @@ def test_create_dummy_cmenergies_facets():
     }
     assert(create_dummy_cmenergies_facets() == expected)
 
-    # Uncomment these tests once we reinstate the cmenergies aggregations with ES>=7.4
     expected_filtered1 = {
         'vals': [
             {'doc_count': None,
@@ -442,3 +440,12 @@ def test_create_dummy_cmenergies_facets():
         'type': 'cmenergies'
     }
     assert(create_dummy_cmenergies_facets([('cmenergies', [1000.0, 7000.0])]) == expected_filtered2)
+
+    expected_filtered3 = {
+        'vals': [],
+        'max_values': 5,
+        'printable_name': 'CM Energies (GeV)',
+        'type': 'cmenergies'
+    }
+    assert(create_dummy_cmenergies_facets([('cmenergies', [1000.0, 1000.0])]) == expected_filtered3)
+    assert(create_dummy_cmenergies_facets([('cmenergies', [1000.0])]) == expected_filtered3)

--- a/tests/search_test.py
+++ b/tests/search_test.py
@@ -67,7 +67,8 @@ def test_query_builder_add_filters():
         ("collaboration", "test_collaboration"),
         ("subject_areas", "test_subject_area"),
         ("date", [2000, 2001, 2002]),
-        ("reactions", "test_reaction")
+        ("reactions", "test_reaction"),
+        ("cmenergies", [1000.0])
     ])
 
     assert(s.to_dict() == {
@@ -77,7 +78,13 @@ def test_query_builder_add_filters():
                     {"term": {"collaborations.raw": "test_collaboration"}},
                     {"term": {"subject_area.raw": "test_subject_area"}},
                     {"terms": {"year": ["2000", "2001", "2002"]}},
-                    {"term": {"data_keywords.reactions.raw": "test_reaction"}}
+                    {"term": {"data_keywords.reactions.raw": "test_reaction"}},
+                    {"range": {
+                        "data_keywords.cmenergies": {
+                            'gte': 1000.0,
+                            'lte': 1000.0
+                        }
+                    }}
                 ],
                 'must': [{
                     "nested": {


### PR DESCRIPTION
Fixes for #240 :

- Fixed links in JS for tables
- Fixed error in dummy aggregations if using `cmenergies=1.0,1.0` in the URL
- Fixed searches for a single value of cmenergies