### PR TITLE
Fix 404s on elasticsearch

### DIFF
--- a/hepdata/ext/elasticsearch/admin_view/api.py
+++ b/hepdata/ext/elasticsearch/admin_view/api.py
@@ -151,7 +151,8 @@ class AdminIndexer:
         for sub_participant in submission.participants:
             participants.append({'full_name': sub_participant.full_name, 'role': sub_participant.role})
 
-        record_information = get_record_contents(submission.publication_recid)
+        record_information = get_record_contents(submission.publication_recid,
+                                                 submission.overall_status)
 
         data_count = DataSubmission.query.filter(DataSubmission.publication_recid == submission.publication_recid,
                                                  DataSubmission.version == submission.version).count()

--- a/hepdata/ext/elasticsearch/api.py
+++ b/hepdata/ext/elasticsearch/api.py
@@ -216,8 +216,13 @@ def get_record(record_id, index=None):
     :return: [dict] Fetched record
     """
     try:
-        result = es.get(index=index, id=record_id)
-        return result.get('_source', result)
+        search = RecordsSearch(using=es, index=index).source(includes="*")
+        result = search.get_record(record_id).execute()
+        if result.hits.total.value > 0:
+            return result.hits[0].to_dict()
+        else:
+            return None
+
     except (NotFoundError, RequestError):
         return None
 

--- a/hepdata/ext/elasticsearch/api.py
+++ b/hepdata/ext/elasticsearch/api.py
@@ -23,7 +23,7 @@ import re
 from celery import shared_task
 from dateutil.parser import parse
 from flask import current_app
-from elasticsearch.exceptions import NotFoundError, RequestError
+from elasticsearch.exceptions import TransportError
 from elasticsearch_dsl import Search
 from elasticsearch_dsl.query import QueryString, Q
 from invenio_pidstore.models import RecordIdentifier
@@ -223,7 +223,7 @@ def get_record(record_id, index=None):
         else:
             return None
 
-    except (NotFoundError, RequestError):
+    except TransportError:
         return None
 
 

--- a/hepdata/modules/converter/views.py
+++ b/hepdata/modules/converter/views.py
@@ -271,7 +271,8 @@ def download_submission(submission, file_format, offline=False, force=False, riv
         if rivet_analysis_name:
             converter_options['rivet_analysis_name'] = rivet_analysis_name
         elif submission.inspire_id:
-            record = get_record_contents(submission.publication_recid)
+            record = get_record_contents(submission.publication_recid,
+                                         submission.overall_status)
             if record:
                 # Check if this record has a Rivet analysis, then extract the Rivet analysis name from the URL.
                 if 'analyses' in record:
@@ -516,7 +517,8 @@ def download_datatable(datasubmission, file_format, *args, **kwargs):
         if rivet_analysis_name:
             options['rivet_analysis_name'] = rivet_analysis_name
         elif datasubmission.publication_inspire_id:
-            record = get_record_contents(datasubmission.publication_recid)
+            record = get_record_contents(datasubmission.publication_recid,
+                                         hepsubmission.overall_status)
             if record:
                 # Check if this record has a Rivet analysis, then extract the Rivet analysis name from the URL.
                 if 'analyses' in record:

--- a/hepdata/modules/records/utils/common.py
+++ b/hepdata/modules/records/utils/common.py
@@ -204,14 +204,19 @@ def truncate_string(string, words):
     return truncated_string
 
 
-def get_record_contents(recid):
+def get_record_contents(recid, status=None):
     """
     Tries to get record from Elasticsearch first. Failing that, it tries from the database.
 
     :param recid: Record ID to get.
+    :param status: Status of submission. If provided and not 'finished', will not check elasticsearch first.
     :return: a dictionary containing the record contents if the recid exists, None otherwise.
     """
-    record = get_record(recid)
+    record = None
+
+    if status is None or status == 'finished':
+        record = get_record(recid)
+
     if record is None:
         try:
             record = get_record_by_id(recid)

--- a/tests/search_test.py
+++ b/tests/search_test.py
@@ -380,3 +380,11 @@ def test_reindex_all(app, load_default_data, identifiers):
     # Search should work again
     results = es_api.search('', index=index)
     assert(results['total'] == len(identifiers))
+
+
+def test_get_record(app, load_default_data, identifiers):
+    record = es_api.get_record(1)
+    for key in ["inspire_id", "title"]:
+        assert (record[key] == identifiers[0][key])
+
+    assert(es_api.get_record(9999999) is None)


### PR DESCRIPTION
Fixes #244. `get_record_contents` was trying to get records from
elasticsearch even when the submission was not finalised; the call to ES
was generating 404s if the doc did not exist.

 * For cases where we have a submission object when calling
   get_record_contents, get_record_contents now accepts a status
   argument and checks for soverall_status=finisheds before searching
   ES.
 * ES `get_record` method now uses a search query by id rather than
   directly getting the document, so that ES returns an empty result
   set rather than a 404.