### PR TITLE
Add 'priority' queue for sending mail and processing uploads.

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -124,7 +124,7 @@ Run Celery (-B runs celery beat):
 
 .. code-block:: console
 
-   (hepdata)$ celery worker -l info -E -B -A hepdata.celery
+   (hepdata)$ celery worker -l info -E -B -A hepdata.celery -Q celery,priority
 
 PostgreSQL
 ----------

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -230,22 +230,6 @@ Alternatively, after `installing Docker <https://docs.docker.com/install/>`_, yo
 then specify ``CFG_CONVERTER_URL = 'http://localhost:5500'`` in ``hepdata/config_local.py`` (see above).
 
 
-Run using honcho
-----------------
-
-Note added: I haven't tested if this method works.  The ``Procfile`` has not been updated since 2016.
-This section should be removed if it no longer works, unless any problems can be fixed.
-
-Honcho will run elasticsearch, redis, celery, and the web application for you automatically.
-Just workon your virtual environment, go to the root directory of hepdata source where you can see a file called
-Procfile. Then install flower if you haven't done so already, and then start honcho.
-
-.. code-block:: console
-
-   (hepdata)$ pip install flower
-   (hepdata)$ honcho start
-
-
 .. _running-docker-compose:
 
 **************************

--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,0 @@
-web: gunicorn hepdata.wsgi -c gunicorn.cfg
-cache: redis-server
-worker: celery worker -E -B -A hepdata.celery --loglevel=INFO --workdir="${VIRTUAL_ENV}" --autoreload --pidfile="${VIRTUAL_ENV}/worker.pid" --purge
-workermon: flower --broker=amqp://guest:guest@localhost:5672
-indexer: elasticsearch -Dcluster.name="hepdata" -Ddiscovery.zen.ping.multicast.enabled=false -Dpath.data="$VIRTUAL_ENV/var/data/elasticsearch"  -Dpath.logs="$VIRTUAL_ENV/var/log/elasticsearch"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     - ".:/code"
   worker:
     build: .
-    command: "celery worker -A hepdata.celery --loglevel=INFO"
+    command: "celery worker -A hepdata.celery --loglevel=INFO -Q celery,priority"
     environment:
     - "APP_CELERY_BROKER_URL=redis://cache:6379/0"
     - "APP_CACHE_REDIS_URL=redis://cache:6379/0"

--- a/hepdata/config.py
+++ b/hepdata/config.py
@@ -58,6 +58,12 @@ I18N_LANGUAGES = [
 CELERY_BROKER_URL = "redis://localhost:6379/0"
 CELERY_RESULT_BACKEND = "redis://localhost:6379/1"
 CELERY_ACCEPT_CONTENT = ['json', 'msgpack', 'yaml']
+CELERY_WORKER_PREFETCH_MULTIPLIER = 1
+CELERY_TASK_CREATE_MISSING_QUEUES = True
+CELERY_TASK_ROUTES = {
+    'hepdata.modules.email.utils.send_email': {'queue': 'priority'},
+    'hepdata.modules.records.api.process_saved_file': {'queue': 'priority'},
+}
 
 CELERY_BEAT_SCHEDULE = {
     'update_analyses': {


### PR DESCRIPTION
By putting these tasks in a separate queue and turning off prefetching, the workers will alternate between the default (celery) queue and the priority queue, ensuring maintenance tasks do not interfere with user-initiated tasks.

This will require a change to the [Kubernetes config](https://github.com/inspirehep/kubernetes/blob/master/hepdata/overlays/worker/add_command.yml) to add the option `-Q celery,priority`, which must be deployed either before or simultaneous to this change.

Fixes #234 
