### PR TITLE
Allow log scales when there are 0s in data set

### DIFF
--- a/hepdata/modules/records/static/js/hepdata_vis_common.js
+++ b/hepdata/modules/records/static/js/hepdata_vis_common.js
@@ -332,7 +332,7 @@ HEPDATA.dataprocessing = {
           HEPDATA.stats['min_' + key] = processed_value_obj[key + '_min'];
         }
 
-      } else if (!isNaN(parseFloat(val["value"]))) {
+      } else if (!isNaN(val["value"])) {
         processed_value_obj[key] = +val["value"];
 
         if (processed_value_obj[key] > HEPDATA.stats['max_' + key]) HEPDATA.stats['max_' + key] = processed_value_obj[key];

--- a/hepdata/modules/records/static/js/hepdata_vis_common.js
+++ b/hepdata/modules/records/static/js/hepdata_vis_common.js
@@ -205,14 +205,14 @@ HEPDATA.dataprocessing = {
                   errors_obj.err_minus = Math.min(down_err, up_err, 0);
                 }
 
-                if (errors_obj.y + errors_obj.err_plus > HEPDATA.stats.max_y) HEPDATA.stats.max_y = errors_obj.err_plus + errors_obj.y;
-                if (errors_obj.y + errors_obj.err_minus < HEPDATA.stats.min_y &&
-                    (options.y_scale != 'log' || errors_obj.y + errors_obj.err_minus > 0)) {
-                  HEPDATA.stats.min_y = errors_obj.err_minus + errors_obj.y;
-                }
-
                 summed_uncertainties["up"] += Math.pow(errors_obj.err_plus, 2);
                 summed_uncertainties["down"] += Math.pow(errors_obj.err_minus, 2);
+
+                // If error bars would go to 0, just omit them
+                if (options.y_scale == 'log' && errors_obj.y + errors_obj.err_minus <= 0) continue;
+
+                if (errors_obj.y + errors_obj.err_plus > HEPDATA.stats.max_y) HEPDATA.stats.max_y = errors_obj.err_plus + errors_obj.y;
+                if (errors_obj.y + errors_obj.err_minus < HEPDATA.stats.min_y) HEPDATA.stats.min_y = errors_obj.err_minus + errors_obj.y;
 
                 errors.push(errors_obj);
                 all_errors.push(errors_obj);
@@ -228,6 +228,9 @@ HEPDATA.dataprocessing = {
                 'name': data_header_value
               };
 
+              if (options.y_scale == 'log' &&
+                  processed_value["quad_error"].y + processed_value["quad_error"]["err_minus"] <= 0) continue;
+
               if (summed_uncertainties["up"] == 0 && summed_uncertainties["down"] == 0) {
                 processed_value["quad_error"]["label"] = "hidden";
               }
@@ -236,8 +239,7 @@ HEPDATA.dataprocessing = {
                 HEPDATA.stats.max_y = processed_value["quad_error"].y + processed_value["quad_error"]["err_plus"];
               }
 
-              if (processed_value["quad_error"].y + processed_value["quad_error"]["err_minus"] < HEPDATA.stats.min_y &&
-                  (options.y_scale != 'log' || processed_value["quad_error"].y + processed_value["quad_error"]["err_minus"] > 0)) {
+              if (processed_value["quad_error"].y + processed_value["quad_error"]["err_minus"] < HEPDATA.stats.min_y) {
                 HEPDATA.stats.min_y = processed_value["quad_error"].y + processed_value["quad_error"]["err_minus"];
               }
 

--- a/hepdata/modules/records/static/js/hepdata_vis_common.js
+++ b/hepdata/modules/records/static/js/hepdata_vis_common.js
@@ -166,8 +166,8 @@ HEPDATA.dataprocessing = {
 
               processed_value = HEPDATA.dataprocessing.processed_key(processed_value, 'x', options);
               if (isNaN(processed_value.y) ||
-                  (options.y_scale == 'log' && processed_value.y == 0) ||
-                  (options.x_scale == 'log' && (processed_value.x == 0 || processed_value.x_min == 0))) {
+                  (options.y_scale == 'log' && processed_value.y <= 0) ||
+                  (options.x_scale == 'log' && (processed_value.x <= 0 || processed_value.x_min <= 0))) {
                     continue;
               }
               processed_value = HEPDATA.dataprocessing.processed_key(processed_value, 'y', options);

--- a/hepdata/modules/records/static/js/hepdata_vis_common.js
+++ b/hepdata/modules/records/static/js/hepdata_vis_common.js
@@ -150,8 +150,7 @@ HEPDATA.dataprocessing = {
 
               processed_value = HEPDATA.dataprocessing.processed_key(processed_value, 'x', options);
               processed_value = HEPDATA.dataprocessing.processed_key(processed_value, 'y', options);
-              if (isNaN(processed_value.value) ||
-                  (options.y_scale == 'log' && processed_value.value == 0)) continue;
+              if (isNaN(processed_value.value)) continue;
 
 
               if (processed_value.value < HEPDATA.stats.min_value) HEPDATA.stats.min_value = processed_value.value;

--- a/hepdata/modules/records/static/js/hepdata_vis_common.js
+++ b/hepdata/modules/records/static/js/hepdata_vis_common.js
@@ -27,13 +27,13 @@ HEPDATA.visualization.utils = {
         return d.x;
       })).rangePoints([0, max_range]);
     } else {
-      var scale = scale_type == 'log' && HEPDATA.stats.min_x > 0 ? d3.scale.log() : d3.scale.linear();
+      var scale = scale_type == 'log' ? d3.scale.log() : d3.scale.linear();
       var range = [0, max_range];
       if (min == null) {
         min = 0; max = 1;
       } else if (min == max) {
         // If only one value, rescale so value is drawn in middle of axis.
-        if (scale_type == 'log' && HEPDATA.stats.min_x > 0) {
+        if (scale_type == 'log') {
           min = 0.5*min;
           max = 2.0*max;
         } else {
@@ -167,7 +167,10 @@ HEPDATA.dataprocessing = {
 
               processed_value = HEPDATA.dataprocessing.processed_key(processed_value, 'x', options);
               if (isNaN(processed_value.y) ||
-                  (options.y_scale == 'log' && processed_value.y == 0)) continue;
+                  (options.y_scale == 'log' && processed_value.y == 0) ||
+                  (options.x_scale == 'log' && (processed_value.x == 0 || processed_value.x_min == 0))) {
+                    continue;
+              }
               processed_value = HEPDATA.dataprocessing.processed_key(processed_value, 'y', options);
 
             }
@@ -412,7 +415,7 @@ HEPDATA.legends = {
       HEPDATA.visualization.histogram.render_option("Fill bars", 'bool', "fill_bars", rendering_options, "HEPDATA.visualization.histogram.toggle_bool_option('fill_bars', this)");
     }
 
-    if (HEPDATA.stats.min_x > 0 && HEPDATA.stats.min_x < HEPDATA.stats.max_x) HEPDATA.visualization.histogram.render_option("Log Scale (X)", 'scale', "x_scale", rendering_options, "HEPDATA.visualization.histogram.toggle_scale_option('x_scale', this)");
+    if (HEPDATA.stats.min_x < HEPDATA.stats.max_x) HEPDATA.visualization.histogram.render_option("Log Scale (X)", 'scale', "x_scale", rendering_options, "HEPDATA.visualization.histogram.toggle_scale_option('x_scale', this)");
     if (HEPDATA.stats.min_y < HEPDATA.stats.max_y) HEPDATA.visualization.histogram.render_option("Log Scale (Y)", 'scale', "y_scale", rendering_options, "HEPDATA.visualization.histogram.toggle_scale_option('y_scale', this)");
 
     rendering_options.append("hr");

--- a/hepdata/modules/records/static/js/hepdata_vis_heatmap.js
+++ b/hepdata/modules/records/static/js/hepdata_vis_heatmap.js
@@ -44,7 +44,7 @@ HEPDATA.visualization.heatmap = {
 
     HEPDATA.visualization.heatmap.placement = placement;
 
-    var processed_dict = HEPDATA.dataprocessing.process_data_values(data);
+    var processed_dict = HEPDATA.dataprocessing.process_data_values(data, HEPDATA.visualization.heatmap.options);
 
     HEPDATA.visualization.heatmap.render_axis_selector(data, "#legend");
 

--- a/hepdata/modules/records/static/js/hepdata_vis_histogram.js
+++ b/hepdata/modules/records/static/js/hepdata_vis_histogram.js
@@ -33,11 +33,11 @@ HEPDATA.visualization.histogram = {
     HEPDATA.visualization.histogram.data = data;
     HEPDATA.visualization.histogram.placement = placement;
     HEPDATA.visualization.histogram.histogram_added = false;
+    HEPDATA.reset_stats();
 
     HEPDATA.visualization.histogram.options = $.extend(HEPDATA.visualization.histogram.options, options);
 
-    var processed_dict = HEPDATA.dataprocessing.process_data_values(data);
-
+    var processed_dict = HEPDATA.dataprocessing.process_data_values(data, HEPDATA.visualization.histogram.options);
 
     if ((data.headers[0] == undefined || data.headers[0].name == '') && data.values.length == 0) {
       d3.select(placement).append("div").attr("class", "alert alert-warning").text("Unable to render a plot since there is no data to render.");
@@ -48,7 +48,7 @@ HEPDATA.visualization.histogram = {
     HEPDATA.visualization.histogram.x_index = data.headers[0].name;
 
     HEPDATA.visualization.histogram.x_scale = HEPDATA.visualization.utils.calculate_x_scale(HEPDATA.visualization.histogram.options.x_scale, HEPDATA.stats.min_x, HEPDATA.stats.max_x, HEPDATA.visualization.histogram.options, processed_dict["processed"]);
-    HEPDATA.visualization.histogram.y_scale = HEPDATA.visualization.utils.calculate_y_scale(HEPDATA.visualization.histogram.options.y_scale, HEPDATA.stats.min_y, HEPDATA.stats.max_y, HEPDATA.visualization.histogram.options);
+    HEPDATA.visualization.histogram.y_scale = HEPDATA.visualization.utils.calculate_y_scale(HEPDATA.visualization.histogram.options.y_scale, HEPDATA.stats.min_y, HEPDATA.stats.max_y, HEPDATA.visualization.histogram.options, processed_dict["processed"]);
 
     HEPDATA.visualization.histogram.x_axis = d3.svg.axis().scale(HEPDATA.visualization.histogram.x_scale).orient("bottom").tickPadding(2);
     HEPDATA.visualization.histogram.y_axis = d3.svg.axis().scale(HEPDATA.visualization.histogram.y_scale).orient("left").tickPadding(2);
@@ -291,7 +291,8 @@ HEPDATA.visualization.histogram = {
         dot_groups.append("line")
           .attr("x1", 0)
           .attr("y1", function (d) {
-            if (!isNaN(d.quad_error.err_minus)) {
+            if (!isNaN(d.quad_error.err_minus) &&
+                (HEPDATA.visualization[type].options.y_scale != 'log' || (d.y + d.quad_error.err_minus) > 0)) {
               return HEPDATA.visualization[type].y_scale(d.y + d.quad_error.err_minus) - HEPDATA.visualization[type].y_scale(d.y);
             } else {
               return 0;
@@ -299,7 +300,8 @@ HEPDATA.visualization.histogram = {
           })
           .attr("x2", 0)
           .attr("y2", function (d) {
-            if (!isNaN(d.quad_error.err_plus)) {
+            if (!isNaN(d.quad_error.err_plus) &&
+                (HEPDATA.visualization[type].options.y_scale != 'log' || (d.y + d.quad_error.err_plus) > 0)) {
               return HEPDATA.visualization[type].y_scale(d.y + d.quad_error.err_plus) - HEPDATA.visualization[type].y_scale(d.y);
             } else {
               return 0;

--- a/hepdata/modules/records/static/js/hepdata_vis_histogram.js
+++ b/hepdata/modules/records/static/js/hepdata_vis_histogram.js
@@ -77,7 +77,9 @@ HEPDATA.visualization.histogram = {
 
       if (_aggregated_values[value_obj.name]["y_errors"]) {
         _aggregated_values[value_obj.name]["values"].push(value_obj);
-      } else if (HEPDATA.visualization.histogram.options.mode != HEPDATA.visualization.histogram.modes.scatter && value_obj.x_min != undefined) {
+      } else if (HEPDATA.visualization.histogram.options.mode != HEPDATA.visualization.histogram.modes.scatter &&
+                 value_obj.x_min != undefined &&
+                 (HEPDATA.visualization.histogram.options.x_scale != 'log' || value_obj.x_min > 0)) {
         _aggregated_values[value_obj.name]["values"].push({
           x: value_obj.x_min,
           y: value_obj.y,


### PR DESCRIPTION
These changes modify the plotting javascript to allow log scales to be selected even if the data set contains 0s, by removing any points with values <=0 before plotting.

Fixes #131 
