### PR TITLE
Turn off verbose mode in hepdata collect

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ install:
   - "hepdata npm"
   - "cd /home/travis/virtualenv/python3.6.7/var/hepdata-instance/static/"
   - "travis_retry npm install"
-  - "hepdata collect -v"
+  - "hepdata collect"
   - "hepdata assets build"
   - "cd /home/travis/build/HEPData/hepdata"
 


### PR DESCRIPTION
Bit of a hunch but the error in [build 1228](https://travis-ci.org/github/HEPData/hepdata/builds/740926415) looked like it might just be outputting too much for Travis's output stream to handle. Not sure what changed since the previous build but removing the `-v` flag to `hepdata collect` reduced the amount of output and allowed the build to complete. 