### PR TITLE
travis: link to travis-ci.com not travis-ci.org

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -89,6 +89,6 @@ Before you submit a pull request, check that it meets these guidelines:
 1. The pull request should include tests and must not decrease test coverage.
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring.
-3. The pull request should work for Python 2.7. Check
-   https://travis-ci.org/HEPData/hepdata/pull_requests
+3. The pull request should work for Python 3.6. Check
+   https://travis-ci.com/github/HEPData/hepdata/pull_requests
    and make sure that the tests pass.

--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@
 HEPData
 =======
 
-.. image:: https://img.shields.io/travis/HEPData/hepdata/master
-   :target: https://travis-ci.org/HEPData/hepdata/branches
+.. image:: https://img.shields.io/travis/com/HEPData/hepdata/master
+   :target: https://travis-ci.com/github/HEPData/hepdata/branches
    :alt: Travis Status
 
 .. image:: https://coveralls.io/repos/github/HEPData/hepdata/badge.svg?branch=master

--- a/docs/info.rst
+++ b/docs/info.rst
@@ -1,6 +1,6 @@
 
-.. image:: https://img.shields.io/travis/HEPData/hepdata/master
-   :target: https://travis-ci.org/HEPData/hepdata/branches
+.. image:: https://img.shields.io/travis/com/HEPData/hepdata/master
+   :target: https://travis-ci.com/github/HEPData/hepdata/branches
    :alt: Travis Status
 
 .. image:: https://coveralls.io/repos/github/HEPData/hepdata/badge.svg?branch=master

--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20201102"
+__version__ = "0.9.4dev20201104"


### PR DESCRIPTION
I've migrated this repo to travis-ci.com since travis-ci.org will be closed down at the end of 2020 (see [FAQ](https://docs.travis-ci.com/user/migrate/open-source-repository-migration#frequently-asked-questions)).  Queued jobs on travis-ci.org were taking a long time to start running.  This PR updates the links in the docs.  It is also a first check that the build on travis-ci.com is working correctly.