### PR TITLE
Fix issue where review messages could not be deleted

### DIFF
--- a/hepdata/modules/submission/models.py
+++ b/hepdata/modules/submission/models.py
@@ -181,8 +181,9 @@ def receive_before_flush(session, flush_context, instances):
         if isinstance(obj, DataSubmission):
             try:
                 log.debug("Deleting data resource %s" % obj.data_file)
-                dataresource = DataResource.query.filter_by(id=obj.data_file).one()
-                db.session.delete(dataresource)
+                dataresource = DataResource.query.filter_by(id=obj.data_file).first()
+                if dataresource:
+                    db.session.delete(dataresource)
             except Exception as e:
                 log.error("Unable to delete data resource with id %s whilst "
                           "deleting data submission id %s. Error was: %s"


### PR DESCRIPTION
This is a workaround for the fact that the db does not define
"ON DELETE CASCADE" for the datareview_messages table.

When deleting a data review object directly, SQLAlchemy cascades the delete
and deletes the associated messages. However, when it's deleted as a result
of a data submission being deleted, SQLAlchemy's lazy loading means that
the data review objects aren't loaded so the associated deletions don't
happen. Instead we directly delete the data reviews in
`receive_before_flush` when a data submission is deleted, which causes
the associated messages to also be deleted.

Fixes #258 