### PR TITLE
Fixed issue where sandbox data files from .oldhepdata were being deleted

### DIFF
--- a/hepdata/modules/records/api.py
+++ b/hepdata/modules/records/api.py
@@ -434,7 +434,7 @@ def process_saved_file(file_path, recid, userid, redirect_url, previous_status):
 
     # Delete any previous upload folders relating to non-final versions
     # of this hepsubmission
-    cleanup_old_files(hepsubmission, os.path.dirname(file_path))
+    cleanup_old_files(hepsubmission)
 
 
 def save_zip_file(file, id):

--- a/hepdata/modules/records/utils/data_files.py
+++ b/hepdata/modules/records/utils/data_files.py
@@ -118,7 +118,7 @@ def delete_all_files(rec_id, check_old_data_paths=True):
             shutil.rmtree(record_data_path)
 
 
-def cleanup_old_files(hepsubmission, current_folder=None, check_old_data_paths=True):
+def cleanup_old_files(hepsubmission, check_old_data_paths=True):
     """Remove old files not related to a current version of the submission"""
     rec_id = str(hepsubmission.publication_recid)
     record_data_paths = [get_data_path_for_record(rec_id)]
@@ -130,25 +130,22 @@ def cleanup_old_files(hepsubmission, current_folder=None, check_old_data_paths=T
 
     current_filepaths = set()
 
-    if hepsubmission.overall_status == 'sandbox' and current_folder:
-        current_filepaths.add(current_folder)
-    else:
-        path_prefixes = [f"{path}/" for path in record_data_paths]
-        current_resources = _find_all_current_dataresources(hepsubmission.publication_recid)
+    path_prefixes = [f"{path}/" for path in record_data_paths]
+    current_resources = _find_all_current_dataresources(hepsubmission.publication_recid)
 
-        for r in current_resources:
-            if not r.file_location.startswith('http'):
-                found = False
-                for path_prefix in path_prefixes:
-                    if r.file_location.startswith(path_prefix):
-                        subdirs = r.file_location.split(path_prefix, 1)[1]
-                        top_subdir = subdirs.split(os.sep, 1)[0]
-                        current_filepaths.add(os.path.join(path_prefix, top_subdir))
-                        found = True
-                        break
+    for r in current_resources:
+        if not r.file_location.startswith('http'):
+            found = False
+            for path_prefix in path_prefixes:
+                if r.file_location.startswith(path_prefix):
+                    subdirs = r.file_location.split(path_prefix, 1)[1]
+                    top_subdir = subdirs.split(os.sep, 1)[0]
+                    current_filepaths.add(os.path.join(path_prefix, top_subdir))
+                    found = True
+                    break
 
-                if not found:
-                    log.warning("Unknown file %s" % r.file_location)
+            if not found:
+                log.warning("Unknown file %s" % r.file_location)
 
     packaged_filepath = find_submission_data_file_path(hepsubmission)
     packaged_filename = os.path.basename(packaged_filepath)


### PR DESCRIPTION
`cleanup_old_files` had a shortcut for standard sandbox entries where the
current filepath was passed in. Unfortunately this didn't work for
oldhepdata uploads as the current_filepath pass in was the oldhepdata dir
not the converted yaml dir, so the newly created yaml files were deleted.

Decided to just remove the shortcut and use the safer option of getting
data file paths from the db.

Closes #259.