### PR TITLE
Dashboard pagination

### DIFF
--- a/hepdata/modules/dashboard/api.py
+++ b/hepdata/modules/dashboard/api.py
@@ -93,7 +93,7 @@ def create_record_for_dashboard(record_id, submissions, current_user, coordinato
                 submissions[record_id]["metadata"]["role"].append(user_role)
 
 
-def prepare_submissions(current_user):
+def prepare_submissions(current_user, items_per_page=25, current_page=1):
     """
     Finds all the relevant submissions for a user, or all submissions if the logged in user is a 'super admin'.
 
@@ -128,9 +128,13 @@ def prepare_submissions(current_user):
                 HEPSubmission.publication_recid.in_(inner_query))
         )
 
+    total = query.count()
+
+    offset = (current_page - 1) * items_per_page
+
     hepdata_submission_records = query.order_by(
         HEPSubmission.last_updated.desc()
-    )
+    ).limit(items_per_page).offset(offset).all()
 
     for hepdata_submission in hepdata_submission_records:
 
@@ -171,7 +175,7 @@ def prepare_submissions(current_user):
                     submissions[str(hepdata_submission.publication_recid)][
                         "stats"][status] += status_count
 
-    return submissions
+    return (total, submissions)
 
 
 def get_pending_invitations_for_user(user):

--- a/hepdata/modules/dashboard/bundles.py
+++ b/hepdata/modules/dashboard/bundles.py
@@ -26,6 +26,7 @@ from invenio_assets import NpmBundle
 
 dashboard_js = NpmBundle(
     'js/dashboard.js',
+    'js/lib/typeahead.bundle.min.js',
     filters='jsmin,uglifyjs',
     output="gen/hepdata.dashboard.%(version)s.js"
 )

--- a/hepdata/modules/dashboard/static/js/dashboard.js
+++ b/hepdata/modules/dashboard/static/js/dashboard.js
@@ -250,6 +250,11 @@ var dashboard = (function () {
       $(loader_placement).hide();
       $('#submissions-wrapper').html(data).fadeIn(500);
 
+      $(".inspire-btn").bind("click", function () {
+        $("#inspire-add-button").attr('data-recid', $(this).attr("data-recid"));
+        $("#inspireDialog").modal();
+      });
+
       dashboard.render_submission_stats();
 
       $('.pagination li a').click(function(event) {
@@ -352,11 +357,6 @@ var dashboard = (function () {
       load_submissions();
       load_watched_records();
       load_permissions();
-
-      $(".inspire-btn").bind("click", function () {
-        $("#inspire-add-button").attr('data-recid', $(this).attr("data-recid"));
-        $("#inspireDialog").modal();
-      });
 
       $(".reindex-btn").bind("click", function () {
         $("#reindexDialog").modal();

--- a/hepdata/modules/dashboard/static/js/dashboard.js
+++ b/hepdata/modules/dashboard/static/js/dashboard.js
@@ -126,13 +126,21 @@ var dashboard = (function () {
   };
 
   var load_submissions_from_params = function(params) {
-    $('#submissions-wrapper').hide()
-    display_loader();
+    var loader_placement = "#submissions-loader";
+
+    // If there's already a submission list put the loader there (to keep the pagination)
+    var submission_list = $('#hep-submissions');
+    if (submission_list.length > 0) {
+      submission_list.empty().addClass('loader').css('width', '200px');
+      loader_placement = '#hep-submissions'
+    }
+    display_loader(loader_placement);
 
     var url = "/dashboard/dashboard-submissions?" + $.param(params);
     $.get(url).done(function (data) {
-      $('#submissions-loader').hide();
+      $(loader_placement).hide();
       $('#submissions-wrapper').html(data).fadeIn(500);
+
       dashboard.render_submission_stats();
 
       $('.pagination li a').click(function(event) {
@@ -140,7 +148,7 @@ var dashboard = (function () {
         load_submissions(this);
       });
     }).fail(function () {
-      $('#submissions-loader').hide();
+      $(loader_placement).hide();
       $('#submissions-wrapper').html("Unable to load submissions. Please try again later.").fadeIn(500);
     });
   }
@@ -157,10 +165,10 @@ var dashboard = (function () {
     load_submissions_from_params({'page': page});
   };
 
-  var display_loader = function() {
-    $('#submissions-loader').show();
+  var display_loader = function(placement) {
+    $(placement).show();
     HEPDATA.render_loader(
-      "#submissions-loader",
+      placement,
       [
         {x: 26, y: 30, color: "#955BA5"},
         {x: -60, y: 55, color: "#FFFFFF"},

--- a/hepdata/modules/dashboard/static/js/dashboard.js
+++ b/hepdata/modules/dashboard/static/js/dashboard.js
@@ -144,14 +144,32 @@ var dashboard = (function () {
     });
   };
 
-  var load_submissions = function() {
-    $.get("/dashboard/dashboard-submissions").done(function (data) {
+  var load_submissions = function(element) {
+    var href = window.location.href;
+    if (element && element.href) {
+      href = element.href;
+    }
+    const url = new URL(href);
+    var page = url.searchParams.get('page');
+    if (!page) page = 1;
+
+    $.get("/dashboard/dashboard-submissions?page="+page).done(function (data) {
       $('#submissions-loader').hide();
-      $('#hep-submissions').html(data).fadeIn(500);
+      $('#submissions-wrapper').html(data).fadeIn(500);
       dashboard.render_submission_stats();
+
+      $('#submission-filter').attr(
+        'placeholder',
+        "Filter " + dashboard.data.length + " submission" + (dashboard.data.length > 1 ? 's' : '')
+      );      
+
+      $('.pagination li a').click(function(event) {
+        event.preventDefault();
+        load_submissions(this);
+      });
     }).fail(function () {
       $('#submissions-loader').hide();
-      $('#hep-submissions').html("Unable to load submissions. Please try again later.").fadeIn(500);
+      $('#submissions-wrapper').html("Unable to load submissions. Please try again later.").fadeIn(500);
     });
   }
 

--- a/hepdata/modules/dashboard/static/js/dashboard.js
+++ b/hepdata/modules/dashboard/static/js/dashboard.js
@@ -1,4 +1,6 @@
 var dashboard = (function () {
+  var data = {};
+
   var initialise_list_filter = function () {
     $(".filter-list li").bind('click', function () {
       var id_parts = this.id.split("-");
@@ -142,20 +144,46 @@ var dashboard = (function () {
     });
   };
 
+  var load_submissions = function() {
+    $.get("/dashboard/dashboard-submissions").done(function (data) {
+      $('#submissions-loader').hide();
+      $('#hep-submissions').html(data).fadeIn(500);
+      dashboard.render_submission_stats();
+    }).fail(function () {
+      $('#submissions-loader').hide();
+      $('#hep-submissions').html("Unable to load submissions. Please try again later.").fadeIn(500);
+    });
+  }
+
+  var display_loader = function() {
+    $('#submissions-loader').show();
+    HEPDATA.render_loader(
+      "#submissions-loader",
+      [
+        {x: 26, y: 30, color: "#955BA5"},
+        {x: -60, y: 55, color: "#FFFFFF"},
+        {x: 37, y: -10, color: "#955BA5"},
+        {x: -60, y: 10, color: "#955BA5"},
+        {x: -27, y: -30, color: "#955BA5"},
+        {x: 60, y: -55, color: "#FFFFFF"}
+      ],
+      {"width": 200, "height": 200}
+    );
+  };
+
   return {
-    initialise: function (data) {
+    initialise: function () {
+      display_loader();
+
       MathJax.Hub.Config({
         tex2jax: {inlineMath: [['$', '$'], ['\\(', '\\)']]}
       });
 
       MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
 
-      for (var submission_idx in data) {
-        HEPDATA.visualization.submission_status.render(data[submission_idx]);
-      }
-
       initialise_list_filter();
       initialise_finalise_btn();
+      load_submissions();
       load_watched_records();
       load_permissions();
 
@@ -176,6 +204,12 @@ var dashboard = (function () {
       }).fail(function (data) {
         alert("Unable to unwatch this record. An error occurred.");
       })
+    },
+
+    render_submission_stats: function () {
+      for (var submission_idx in this.data) {
+        HEPDATA.visualization.submission_status.render(this.data[submission_idx]);
+      }
     }
   }
 })();

--- a/hepdata/modules/dashboard/templates/hepdata_dashboard/dashboard-submissions.html
+++ b/hepdata/modules/dashboard/templates/hepdata_dashboard/dashboard-submissions.html
@@ -1,3 +1,8 @@
+{% if ctx.pages and ctx.pages.total > 0 %}
+    {% include "hepdata_theme/pagination.html" %}
+{% endif %}
+
+<ul id="hep-submissions">
 {% for submission in ctx.submissions %}
     <li id="{{ submission.recid }}" class="submission-item">
         <div class="container-fluid">
@@ -109,6 +114,11 @@
         </div>
     </li>
 {% endfor %}
+</ul>
+
+{% if ctx.pages and ctx.pages.total > 0 %}
+    {% include "hepdata_theme/pagination.html" %}
+{% endif %}
 
 <script>
 

--- a/hepdata/modules/dashboard/templates/hepdata_dashboard/dashboard-submissions.html
+++ b/hepdata/modules/dashboard/templates/hepdata_dashboard/dashboard-submissions.html
@@ -1,0 +1,119 @@
+{% for submission in ctx.submissions %}
+    <li id="{{ submission.recid }}" class="submission-item">
+        <div class="container-fluid">
+            <div class="row">
+
+                <div class="col-md-2 text-center">
+                    {% if submission.review_flag == 'todo' %}
+                        <img src="{{ url_for('static', filename='img/nodata.svg') }}"
+                             alt="No data uploaded yet"
+                             width="50px"/><br/>
+                        {% if submission.submission_status=='processing' %}
+                            <span class="in-progress">Processing</span>
+                        {% else %}
+                            <span class="in-progress">No data</span>
+                        {% endif %}
+                    {% else %}
+                        <p class="status">
+                            {% if submission.submission_status=='todo' %}
+                                <span class="in-progress">In Progress</span>
+                            {% elif submission.submission_status=='processing' %}
+                                <span class="in-progress">Processing</span>
+                            {% else %}
+                                <span class="complete">Complete</span>
+                            {% endif %}
+                        </p>
+                        <div id="submission-{{ submission.recid }}">
+                        </div>
+                    {% endif %}
+                </div>
+
+                <div class="col-md-7">
+
+                    <p class="start-date">
+                        {% if submission.show_coord_view %}
+                            <span class="label label-info">Coordinator</span>
+                        {% endif %}
+                        {% for role in submission.role %}
+                            <span class="label label-info">
+                            <span class="fa fa-{% if role == 'coordinator' %}gavel {% elif role == 'reviewer' %}check{% else %}upload{% endif %}"
+                                  style="padding-right: 5px;"></span>{{ role }}</span>
+                        {% endfor %}
+                        <span class="label label-default">Version {{ submission.versions }}</span>
+                    </p>
+
+                    <p class="start-date">
+                        Started
+                        {{ submission.start_date.strftime('%d %B %Y at %H:%M UTC') }}
+                        <br/>
+                        Last updated
+                        {{ submission.last_updated.strftime('%d %B %Y at %H:%M UTC') }}
+
+
+                    </p>
+                    <h4><a href="/record/{{ submission.recid }}"
+                           target="_blank">{{ submission.title }}</a>
+
+                        {% if submission.requires_inspire_id and submission.submission_status=='todo' %}
+                            <button class="btn btn-primary btn-xs inspire-btn"
+                                    id="inspire-btn-{{ submission.recid }}"
+                                    data-recid="{{ submission.recid }}">
+                                Attach INSPIRE Record
+                            </button>
+                        {% endif %}
+                    </h4>
+                </div>
+
+
+                <div class="col-md-3 actions">
+                    {% if ctx.user_is_admin or submission.show_coord_view %}
+                        {% if not submission.requires_inspire_id %}
+
+                            {% if submission.review_flag == 'passed' and submission.submission_status=='todo' %}
+                                <button class="btn btn-success btn-sm finalise-btn pull-right"
+                                        id="finalise-btn-{{ submission.recid }}"
+                                        data-recid="{{ submission.recid }}"
+                                        data-versions="{{ submission.versions }}">
+                                    Finalise
+                                </button>
+
+                            {% endif %}
+                        {% endif %}
+
+                        <button class="btn btn-sm btn-default pull-right manage-submission-trigger"
+                                data-recid="{{ submission.recid }}"
+                                data-toggle="modal"
+                                data-target="#manageWidget"><span
+                                class="fa fa-cogs"></span>
+                        </button>
+
+                        <button class="btn btn-sm btn-danger pull-right delete-submission-trigger"
+                                data-recid="{{ submission.recid }}"
+                                data-toggle="modal"
+                                data-target="#deleteWidget"
+                                style="margin-right: 5px;">
+                          <span class="fa fa-trash-o"></span>
+                        </button>
+
+                    {% else %}
+                        <button class="btn btn-sm btn-default pull-right conversation-trigger"
+                                data-recid="{{ submission.recid }}"
+                                data-toggle="modal"
+                                data-target="#conversationDialog"><span
+                                class="fa fa-comment" s></span>
+                        </button>
+                    {% endif %}
+                </div>
+
+            </div>
+        </div>
+    </li>
+{% endfor %}
+
+<script>
+
+    $(document).ready(function () {
+        dashboard.data = {{ctx.submission_stats | safe}};
+    });
+
+</script>

--- a/hepdata/modules/dashboard/templates/hepdata_dashboard/dashboard.html
+++ b/hepdata/modules/dashboard/templates/hepdata_dashboard/dashboard.html
@@ -192,9 +192,7 @@
                         <br/>
 
                         <div class="filter" align="center">
-                            <input id="submission-filter"
-                                   name="data-table-filter"
-                                   onkeyup="HEPDATA.filter_content('#submission-filter','#hep-submissions')">
+                            <input id="submission-filter">
                         </div>
 
                         <div id="submissions-list">

--- a/hepdata/modules/dashboard/templates/hepdata_dashboard/dashboard.html
+++ b/hepdata/modules/dashboard/templates/hepdata_dashboard/dashboard.html
@@ -193,14 +193,13 @@
 
                         <div class="filter" align="center">
                             <input id="submission-filter"
-                                   placeholder="Filter {{ ctx.submissions |length }} submission{% if ctx.submissions |length > 1 %}s{% endif %}"
                                    name="data-table-filter"
                                    onkeyup="HEPDATA.filter_content('#submission-filter','#hep-submissions')">
                         </div>
 
                         <div id="submissions-list">
                           <div id="submissions-loader"></div>
-                          <ul id="hep-submissions"></ul>
+                          <div id="submissions-wrapper"></div>
                         </div>
                     </div>
                 </div>

--- a/hepdata/modules/dashboard/templates/hepdata_dashboard/dashboard.html
+++ b/hepdata/modules/dashboard/templates/hepdata_dashboard/dashboard.html
@@ -196,7 +196,7 @@
                         </div>
 
                         <div id="submissions-list">
-                          <div id="submissions-loader"></div>
+                          <div id="submissions-loader" class="loader"></div>
                           <div id="submissions-wrapper"></div>
                         </div>
                     </div>

--- a/hepdata/modules/dashboard/templates/hepdata_dashboard/dashboard.html
+++ b/hepdata/modules/dashboard/templates/hepdata_dashboard/dashboard.html
@@ -198,120 +198,10 @@
                                    onkeyup="HEPDATA.filter_content('#submission-filter','#hep-submissions')">
                         </div>
 
-
-                        <ul id="hep-submissions">
-                            {% for submission in ctx.submissions %}
-                                <li id="{{ submission.recid }}" class="submission-item">
-                                    <div class="container-fluid">
-                                        <div class="row">
-
-                                            <div class="col-md-2 text-center">
-                                                {% if submission.review_flag == 'todo' %}
-                                                    <img src="{{ url_for('static', filename='img/nodata.svg') }}"
-                                                         alt="No data uploaded yet"
-                                                         width="50px"/><br/>
-                                                    {% if submission.submission_status=='processing' %}
-                                                        <span class="in-progress">Processing</span>
-                                                    {% else %}
-                                                        <span class="in-progress">No data</span>
-                                                    {% endif %}
-                                                {% else %}
-                                                    <p class="status">
-                                                        {% if submission.submission_status=='todo' %}
-                                                            <span class="in-progress">In Progress</span>
-                                                        {% elif submission.submission_status=='processing' %}
-                                                            <span class="in-progress">Processing</span>
-                                                        {% else %}
-                                                            <span class="complete">Complete</span>
-                                                        {% endif %}
-                                                    </p>
-                                                    <div id="submission-{{ submission.recid }}">
-                                                    </div>
-                                                {% endif %}
-                                            </div>
-
-                                            <div class="col-md-7">
-
-                                                <p class="start-date">
-                                                    {% if submission.show_coord_view %}
-                                                        <span class="label label-info">Coordinator</span>
-                                                    {% endif %}
-                                                    {% for role in submission.role %}
-                                                        <span class="label label-info">
-                                                        <span class="fa fa-{% if role == 'coordinator' %}gavel {% elif role == 'reviewer' %}check{% else %}upload{% endif %}"
-                                                              style="padding-right: 5px;"></span>{{ role }}</span>
-                                                    {% endfor %}
-                                                    <span class="label label-default">Version {{ submission.versions }}</span>
-                                                </p>
-
-                                                <p class="start-date">
-                                                    Started
-                                                    {{ submission.start_date.strftime('%d %B %Y at %H:%M UTC') }}
-                                                    <br/>
-                                                    Last updated
-                                                    {{ submission.last_updated.strftime('%d %B %Y at %H:%M UTC') }}
-
-
-                                                </p>
-                                                <h4><a href="/record/{{ submission.recid }}"
-                                                       target="_blank">{{ submission.title }}</a>
-
-                                                    {% if submission.requires_inspire_id and submission.submission_status=='todo' %}
-                                                        <button class="btn btn-primary btn-xs inspire-btn"
-                                                                id="inspire-btn-{{ submission.recid }}"
-                                                                data-recid="{{ submission.recid }}">
-                                                            Attach INSPIRE Record
-                                                        </button>
-                                                    {% endif %}
-                                                </h4>
-                                            </div>
-
-
-                                            <div class="col-md-3 actions">
-                                                {% if ctx.user_is_admin or submission.show_coord_view %}
-                                                    {% if not submission.requires_inspire_id %}
-
-                                                        {% if submission.review_flag == 'passed' and submission.submission_status=='todo' %}
-                                                            <button class="btn btn-success btn-sm finalise-btn pull-right"
-                                                                    id="finalise-btn-{{ submission.recid }}"
-                                                                    data-recid="{{ submission.recid }}"
-                                                                    data-versions="{{ submission.versions }}">
-                                                                Finalise
-                                                            </button>
-
-                                                        {% endif %}
-                                                    {% endif %}
-
-                                                    <button class="btn btn-sm btn-default pull-right manage-submission-trigger"
-                                                            data-recid="{{ submission.recid }}"
-                                                            data-toggle="modal"
-                                                            data-target="#manageWidget"><span
-                                                            class="fa fa-cogs"></span>
-                                                    </button>
-
-                                                    <button class="btn btn-sm btn-danger pull-right delete-submission-trigger"
-                                                            data-recid="{{ submission.recid }}"
-                                                            data-toggle="modal"
-                                                            data-target="#deleteWidget"
-                                                            style="margin-right: 5px;">
-                                                      <span class="fa fa-trash-o"></span>
-                                                    </button>
-
-                                                {% else %}
-                                                    <button class="btn btn-sm btn-default pull-right conversation-trigger"
-                                                            data-recid="{{ submission.recid }}"
-                                                            data-toggle="modal"
-                                                            data-target="#conversationDialog"><span
-                                                            class="fa fa-comment" s></span>
-                                                    </button>
-                                                {% endif %}
-                                            </div>
-
-                                        </div>
-                                    </div>
-                                </li>
-                            {% endfor %}
-                        </ul>
+                        <div id="submissions-list">
+                          <div id="submissions-loader"></div>
+                          <ul id="hep-submissions"></ul>
+                        </div>
                     </div>
                 </div>
 
@@ -415,8 +305,7 @@
     <script>
 
         $(document).ready(function () {
-            var data = {{ctx.submission_stats | safe}};
-            dashboard.initialise(data);
+            dashboard.initialise();
         });
 
     </script>

--- a/hepdata/modules/dashboard/views.py
+++ b/hepdata/modules/dashboard/views.py
@@ -37,7 +37,9 @@ from hepdata.modules.records.utils.users import has_role
 from hepdata.modules.records.utils.common import get_record_by_id
 from hepdata.modules.records.utils.workflow import update_record
 from hepdata.modules.inspire_api.views import get_inspire_record_information
+from hepdata.utils.url import modify_query
 import json
+import math
 
 from invenio_userprofiles import current_userprofile
 
@@ -68,7 +70,9 @@ def dashboard():
 @blueprint.route('/dashboard-submissions')
 @login_required
 def dashboard_submissions():
-    submissions = prepare_submissions(current_user)
+    current_page = request.args.get('page', default=1, type=int)
+    size = request.args.get('size', 25)
+    total, submissions = prepare_submissions(current_user, size, current_page)
 
     submission_meta = []
     submission_stats = []
@@ -103,7 +107,15 @@ def dashboard_submissions():
 
         submission_meta.append(submissions[record_id]["metadata"])
 
+    total_pages = int(math.ceil(total / size))
+
     ctx = {
+        'pages': {
+            'total': total_pages,
+            'current': current_page,
+            'endpoint': '.dashboard'
+        },
+        'modify_query': modify_query,
         'submissions': submission_meta,
         'submission_stats': submission_stats
     }

--- a/hepdata/modules/dashboard/views.py
+++ b/hepdata/modules/dashboard/views.py
@@ -54,7 +54,20 @@ def dashboard():
     dashboard that reflects the
     current status of all submissions of which they are a participant.
     """
+    user_profile = current_userprofile.query.filter_by(user_id=current_user.get_id()).first()
 
+    ctx = {'user_is_admin': has_role(current_user, 'admin'),
+           'user_profile': user_profile,
+           'user_has_coordinator_request': get_pending_request(),
+           'pending_coordinator_requests': get_pending_coordinator_requests(),
+           'pending_invites': get_pending_invitations_for_user(current_user)}
+
+    return render_template('hepdata_dashboard/dashboard.html', ctx=ctx)
+
+
+@blueprint.route('/dashboard-submissions')
+@login_required
+def dashboard_submissions():
     submissions = prepare_submissions(current_user)
 
     submission_meta = []
@@ -90,17 +103,12 @@ def dashboard():
 
         submission_meta.append(submissions[record_id]["metadata"])
 
-    user_profile = current_userprofile.query.filter_by(user_id=current_user.get_id()).first()
+    ctx = {
+        'submissions': submission_meta,
+        'submission_stats': submission_stats
+    }
 
-    ctx = {'user_is_admin': has_role(current_user, 'admin'),
-           'submissions': submission_meta,
-           'user_profile': user_profile,
-           'user_has_coordinator_request': get_pending_request(),
-           'pending_coordinator_requests': get_pending_coordinator_requests(),
-           'submission_stats': json.dumps(submission_stats),
-           'pending_invites': get_pending_invitations_for_user(current_user)}
-
-    return render_template('hepdata_dashboard/dashboard.html', ctx=ctx)
+    return render_template('hepdata_dashboard/dashboard-submissions.html', ctx=ctx)
 
 
 @blueprint.route('/delete/<int:recid>')

--- a/hepdata/modules/search/templates/hepdata_search/search_results.html
+++ b/hepdata/modules/search/templates/hepdata_search/search_results.html
@@ -64,7 +64,7 @@
                     <p>No results found. Please edit your search and try again.</p>
                     {% endif %}
                     {% if ctx.pages and not no_results %}
-                        {% include "hepdata_search/pagination.html" %}
+                        {% include "hepdata_theme/pagination.html" %}
                     {% endif %}
                     {% for record in ctx.results %}
                         {% set pub_index = loop.index %}
@@ -146,7 +146,7 @@
                     {% endfor %}
 
                     {% if ctx.pages and not no_results %}
-                        {% include "hepdata_search/pagination.html" %}
+                        {% include "hepdata_theme/pagination.html" %}
                     {% endif %}
                 </div>
             </div>
@@ -207,5 +207,3 @@
 
 
 {% endblock %}
-
-

--- a/hepdata/modules/search/views.py
+++ b/hepdata/modules/search/views.py
@@ -263,7 +263,8 @@ def search():
             'q': query_params['q'],
             'max_results': query_params['size'],
             'pages': {'current': query_params['current_page'],
-                      'total': total_pages},
+                      'total': total_pages,
+                      'endpoint': '.search'},
             'filters': dict(query_params['filters']),
         }
 

--- a/hepdata/modules/theme/static/scss/dashboard.scss
+++ b/hepdata/modules/theme/static/scss/dashboard.scss
@@ -177,7 +177,7 @@ body, html {
       padding: 0px;
     }
 
-    #submissions-loader {
+    .loader {
       padding-top: 60px;
       padding-bottom: 40px;
       width: 200px;

--- a/hepdata/modules/theme/static/scss/dashboard.scss
+++ b/hepdata/modules/theme/static/scss/dashboard.scss
@@ -175,7 +175,13 @@ body, html {
       -webkit-padding-start: 0px;
       width: 100%;
       padding: 0px;
+    }
 
+    #submissions-loader {
+      padding-top: 60px;
+      padding-bottom: 40px;
+      width: 200px;
+      margin: 0 auto;
     }
 
     .watch-list, .permission-list {
@@ -774,4 +780,3 @@ body, html {
   }
 
 }
-

--- a/hepdata/modules/theme/static/scss/dashboard.scss
+++ b/hepdata/modules/theme/static/scss/dashboard.scss
@@ -374,21 +374,68 @@ body, html {
       overflow-y: scroll;
     }
 
+    .form-group {
+      margin-bottom: 0;
+    }
+
     .filter {
 
-      padding-bottom: 2em;
+      padding-bottom: 0;
       width: 100%;
 
       input {
+        background-color: $navy;
+        background-image: none;
         border: none;
-        background: $navy url(/static/img/icons/icon_filter.svg) 8px 10px no-repeat;
-        background-size: 23px;
-        padding: 10px 10px 10px 35px;
-        width: 100%;
         border-radius: 5px;
         color: white;
         font-size: 1.2em;
         margin: 0 auto;
+      }
+
+      .tt-input {
+        background-image: url(/static/img/icons/icon_filter.svg);
+        background-position: 8px 10px;
+        background-repeat: no-repeat;
+        background-size: 23px;
+        padding: 10px 35px;
+      }
+
+      .twitter-typeahead {
+        width: 100%;
+      }
+
+      .tt-menu {
+        background-color: white;
+        color: $navy;
+        text-align: left;
+        border-radius: 0 0 5px 5px;
+        top: 66% !important;
+        width: 100%;
+      }
+
+      .tt-suggestion {
+        margin: 0;
+        padding: 2px 35px;
+        font-size: 1.2em;
+
+        &:hover {
+          background-color: #894B9D;
+          color: #fff;
+          cursor: pointer;
+        }
+
+        &:last-child {
+          border-radius: 0 0 5px 5px;
+        }
+      }
+
+      .fa {
+        position: relative;
+        left: 48%;
+        top: -30px;
+        color: #955BA5;
+        font-size: 16px;
       }
     }
 

--- a/hepdata/modules/theme/templates/hepdata_theme/pagination.html
+++ b/hepdata/modules/theme/templates/hepdata_theme/pagination.html
@@ -1,6 +1,7 @@
 {% set current_page = ctx.pages.current %}
 {% set first_page = (current_page == 1) %}
 {% set last_page = (current_page == ctx.pages.total) %}
+{% set endpoint = ctx.pages.endpoint %}
 
 <div class="pagination-bar" align="center">
     <div class="form-group">
@@ -9,26 +10,26 @@
             <li {% if first_page %} class="disabled" {% endif %}>
                 {% set this_page = '1' %}
                 <a title="first"
-                   href={{ ctx.modify_query('.search', page=this_page) }}>«</a>
+                   href={{ ctx.modify_query(endpoint, page=this_page) }}>«</a>
             </li>
 
             <li {% if first_page %} class="disabled" {% endif %}>
                 {% set this_page = '1' if first_page else (current_page - 1) %}
                 <a title="prev"
-                   href={{ ctx.modify_query('.search', page=this_page) }}>‹</a>
+                   href={{ ctx.modify_query(endpoint, page=this_page) }}>‹</a>
             </li>
 
             {% if not first_page %}
                 <li>
                     {% set this_page =  (current_page - 1) %}
-                    <a href={{ ctx.modify_query('.search', page=this_page) }}>
+                    <a href={{ ctx.modify_query(endpoint, page=this_page) }}>
                         {{ current_page - 1 }}
                     </a>
                 </li>
             {% endif %}
 
             <li class="active">
-                <a href={{ ctx.modify_query('.search', page=current_page) }}>
+                <a href={{ ctx.modify_query(endpoint, page=current_page) }}>
                     {{ current_page }}
                 </a>
             </li>
@@ -36,7 +37,7 @@
             {% if not last_page %}
                 <li>
                     {% set this_page = (current_page + 1) %}
-                    <a href={{ ctx.modify_query('.search', page=this_page) }}>
+                    <a href={{ ctx.modify_query(endpoint, page=this_page) }}>
                         {{ current_page + 1 }}
                     </a>
                 </li>
@@ -46,13 +47,13 @@
                 {% set this_page = ctx.pages.total if last_page
                                                    else (current_page + 1) %}
                 <a title="next"
-                   href={{ ctx.modify_query('.search', page=this_page) }}>›</a>
+                   href={{ ctx.modify_query(endpoint, page=this_page) }}>›</a>
             </li>
 
             <li {% if last_page %} class="disabled" {% endif %}>
                 {% set this_page = ctx.pages.total %}
                 <a title="last"
-                   href={{ ctx.modify_query('.search', page=this_page) }}>»</a>
+                   href={{ ctx.modify_query(endpoint, page=this_page) }}>»</a>
             </li>
         </ul>
     </div>


### PR DESCRIPTION
Added pagination to "Submissions in progress" and "Permissions" sections.

The "Submissions in progress" section was causing the long load times so we now fetch results a page at a time from the server. The filter was altered to work on a full list of titles only and behaves more like the Authors filter on the main search page.

The "Permissions" section was already loaded asynchronously, and though it is slightly slow it does not prevent the page from loading, so the pagination is just done using javascript.

Fixes #178 

