### PR TITLE
Allow for data file that doesn't have a data resource.

### DIFF
--- a/hepdata/modules/records/utils/data_files.py
+++ b/hepdata/modules/records/utils/data_files.py
@@ -183,9 +183,12 @@ def _find_all_current_dataresources(rec_id):
                             publication_recid=rec_id
                             ).all()
     for data_submission in data_submissions:
-        resources.append(DataResource.query.filter_by(
-                            id=data_submission.data_file
-                            ).first())
+        data_file_resource = DataResource.query.filter_by(
+                                id=data_submission.data_file
+                                ).first()
+        if data_file_resource:
+            resources.append(data_file_resource)
+
         resources.extend(data_submission.resources)
 
     return resources


### PR DESCRIPTION
Avoid adding Nones, to avoid errors being thrown elsewhere in the code.