### PR TITLE
Fixes for issues found testing cephfs migration

### DIFF
--- a/hepdata/modules/records/utils/data_files.py
+++ b/hepdata/modules/records/utils/data_files.py
@@ -134,7 +134,7 @@ def cleanup_old_files(hepsubmission, check_old_data_paths=True):
     current_resources = _find_all_current_dataresources(hepsubmission.publication_recid)
 
     for r in current_resources:
-        if not r.file_location.startswith('http'):
+        if not r.file_location.lower().startswith('http'):
             found = False
             for path_prefix in path_prefixes:
                 if r.file_location.startswith(path_prefix):
@@ -453,7 +453,7 @@ def _move_data_resource(resource, old_paths, new_path):  # pragma: no cover
         log.debug("    File already in new location. Continuing.")
         return errors
 
-    if resource.file_location.startswith('http'):
+    if resource.file_location.lower().startswith('http'):
         log.debug("    File is remote URL. Continuing.")
         return errors
 

--- a/hepdata/modules/records/utils/data_files.py
+++ b/hepdata/modules/records/utils/data_files.py
@@ -410,19 +410,14 @@ def _move_files_for_record(rec_id):  # pragma: no cover
                         errors.append("Unable to move file from %s to %s\n"
                                       "Error was: %s"
                                       % (full_path, new_file_path, str(e)))
-                else:
-                    errors.append("Unrecognized file %s. Will not move file."
-                                  % filename)
 
-        # Remove directories, which should be empty
-        for dirpath, _, _ in os.walk(old_path, topdown=False):
-            log.debug("Removing directory %s" % dirpath)
-            try:
-                os.rmdir(dirpath)
-            except Exception as e:
-                errors.append("Unable to remove directory %s\n"
-                              "Error was: %s"
-                              % (dirpath, str(e)))
+        # Remove old directory (along with any unrecognized files that remain)
+        try:
+            shutil.rmtree(old_path)
+        except Exception as e:
+            errors.append("Unable to remove directory %s\n"
+                          "Error was: %s"
+                          % (old_path, str(e)))
 
     # If there's a zip file from the migration, move that to the new dir too.
     if inspire_id is not None:

--- a/hepdata/modules/submission/models.py
+++ b/hepdata/modules/submission/models.py
@@ -255,8 +255,14 @@ def receive_data_resource_after_delete(mapper, connection, target):
     log.debug("Deleting data resource id %s" % target.id)
     if not target.file_location.lower().startswith('http'):
         if os.path.isfile(target.file_location):
-            log.debug('Deleting file %s' % target.file_location)
-            os.remove(target.file_location)
+            # Check whether there's another dataresource with the same file
+            # location before deleting.
+            file_count = DataResource.query.filter_by(
+                    file_location=target.file_location
+                ).count()
+            if file_count == 0:
+                log.debug('Deleting file %s' % target.file_location)
+                os.remove(target.file_location)
         else:
             log.error("Could not remove file %s" % target.file_location)
 

--- a/hepdata/modules/submission/models.py
+++ b/hepdata/modules/submission/models.py
@@ -253,7 +253,7 @@ class DataResource(db.Model):
 def receive_data_resource_after_delete(mapper, connection, target):
     "Delete the file on disk when a DataResource is deleted"
     log.debug("Deleting data resource id %s" % target.id)
-    if not target.file_location.startswith('http'):
+    if not target.file_location.lower().startswith('http'):
         if os.path.isfile(target.file_location):
             log.debug('Deleting file %s' % target.file_location)
             os.remove(target.file_location)


### PR DESCRIPTION
 * Changed behaviour to be stricter about deleting old directories, even if not empty.
 * Code deleting `DataResource` files on disk now checks whether another resource is using the same file before deleting.