### PR TITLE
Further cephfs migration fixes

### DIFF
--- a/hepdata/modules/records/utils/data_files.py
+++ b/hepdata/modules/records/utils/data_files.py
@@ -410,14 +410,19 @@ def _move_files_for_record(rec_id):  # pragma: no cover
                         errors.append("Unable to move file from %s to %s\n"
                                       "Error was: %s"
                                       % (full_path, new_file_path, str(e)))
+                else:
+                    errors.append("Unrecognized file %s. Will not move file."
+                                  % filename)
 
-        # Remove old directory (along with any unrecognized files that remain)
-        try:
-            shutil.rmtree(old_path)
-        except Exception as e:
-            errors.append("Unable to remove directory %s\n"
-                          "Error was: %s"
-                          % (old_path, str(e)))
+        # Remove directories, which should be empty
+        for dirpath, _, _ in os.walk(old_path, topdown=False):
+            log.debug("Removing directory %s" % dirpath)
+            try:
+                os.rmdir(dirpath)
+            except Exception as e:
+                errors.append("Unable to remove directory %s\n"
+                              "Error was: %s"
+                              % (dirpath, str(e)))
 
     # If there's a zip file from the migration, move that to the new dir too.
     if inspire_id is not None:

--- a/hepdata/modules/records/utils/data_files.py
+++ b/hepdata/modules/records/utils/data_files.py
@@ -478,8 +478,13 @@ def _move_data_resource(resource, old_paths, new_path, is_sandbox=False):  # pra
         if os.path.exists(resource.file_location):
             try:
                 shutil.move(resource.file_location, new_file_path)
+
+                log.debug("    Updating data record")
+                resource.file_location = new_file_path
+                db.session.add(resource)
+                db.session.commit()
             except Exception as e:
-                errors.append("Unable to move file from %s to %s for data resource id %s\n"
+                errors.append("Unable to move file from %s to %s or to update file_location for data resource id %s\n"
                               "Error was: %s"
                               % (resource.file_location, new_file_path, resource.id, str(e)))
 
@@ -490,11 +495,6 @@ def _move_data_resource(resource, old_paths, new_path, is_sandbox=False):  # pra
             errors.append("File for for data resource id %s does not exist at "
                           "either old path (%s) or new path (%s)"
                           % (resource.id, resource.file_location, new_file_path))
-
-        log.debug("    Updating data record")
-        resource.file_location = new_file_path
-        db.session.add(resource)
-        db.session.commit()
 
     else:
         log.debug("    Location %s not recognised" % resource.file_location)

--- a/hepdata/modules/records/utils/data_files.py
+++ b/hepdata/modules/records/utils/data_files.py
@@ -545,19 +545,17 @@ def clean_remaining_files(synchronous=True):  # pragma: no cover
                         for sub_entry in subdir_entries:
                             if not sub_entry.name.isdigit():
                                 unknown_files.append(sub_entry.path)
-                else:
-                    # Is it a deleted sandbox entry?
-                    if len(entry.name) == 10 and \
-                            entry.name.isdigit():
-                        # This is probably a deleted sandbox entry
-                        recognised = True
-                        rec_id = int(entry.name)
-                        submission_count = HEPSubmission.query.filter_by(publication_recid=rec_id).count()
-                        if submission_count == 0:
-                            log.debug("Deleting %s" %entry.path)
-                            shutil.rmtree(entry.path)
-                        else:
-                            log.warning("Sandbox entry %s is still in old file location" % entry.name)
+                elif entry.name.isdigit():
+                    # This is probably either a deleted sandbox entry or a hangover from
+                    # a migration from hepdata.cedar.ac.uk that was later deleted
+                    recognised = True
+                    rec_id = int(entry.name)
+                    submission_count = HEPSubmission.query.filter_by(publication_recid=rec_id).count()
+                    if submission_count == 0:
+                        log.debug("Deleting %s" % entry.path)
+                        shutil.rmtree(entry.path)
+                    else:
+                        log.warning("Record id %s is still in old file location" % entry.name)
 
             if not recognised:
                 unknown_files.append(entry.path)

--- a/hepdata/modules/records/utils/data_files.py
+++ b/hepdata/modules/records/utils/data_files.py
@@ -474,13 +474,8 @@ def _move_data_resource(resource, old_paths, new_path, is_sandbox=False):  # pra
         if os.path.exists(resource.file_location):
             try:
                 shutil.move(resource.file_location, new_file_path)
-
-                log.debug("    Updating data record")
-                resource.file_location = new_file_path
-                db.session.add(resource)
-                db.session.commit()
             except Exception as e:
-                errors.append("Unable to move file from %s to %s or to update file_location for data resource id %s\n"
+                errors.append("Unable to move file from %s to %s for data resource id %s\n"
                               "Error was: %s"
                               % (resource.file_location, new_file_path, resource.id, str(e)))
 
@@ -491,6 +486,11 @@ def _move_data_resource(resource, old_paths, new_path, is_sandbox=False):  # pra
             errors.append("File for for data resource id %s does not exist at "
                           "either old path (%s) or new path (%s)"
                           % (resource.id, resource.file_location, new_file_path))
+
+        log.debug("    Updating data record")
+        resource.file_location = new_file_path
+        db.session.add(resource)
+        db.session.commit()
 
     else:
         log.debug("    Location %s not recognised" % resource.file_location)

--- a/hepdata/modules/records/utils/data_files.py
+++ b/hepdata/modules/records/utils/data_files.py
@@ -400,22 +400,18 @@ def _move_files_for_record(rec_id):  # pragma: no cover
     for old_path in old_paths:
         for dir_name, subdir_list, file_list in os.walk(old_path):
             for filename in file_list:
-                if allowed_file(filename):
-                    full_path = os.path.join(dir_name, filename)
-                    log.debug("Found remaining file: %s" % full_path)
-                    sub_path = full_path.split(old_path + '/', 1)[1]
-                    new_file_path = os.path.join(new_path, sub_path)
-                    log.debug("Moving %s to %s" % (full_path, new_file_path))
-                    try:
-                        os.makedirs(os.path.dirname(new_file_path), exist_ok=True)
-                        shutil.move(full_path, new_file_path)
-                    except Exception as e:
-                        errors.append("Unable to move file from %s to %s\n"
-                                      "Error was: %s"
-                                      % (full_path, new_file_path, str(e)))
-                else:
-                    errors.append("Unrecognized file %s. Will not move file."
-                                  % filename)
+                full_path = os.path.join(dir_name, filename)
+                log.debug("Found remaining file: %s" % full_path)
+                sub_path = full_path.split(old_path + '/', 1)[1]
+                new_file_path = os.path.join(new_path, sub_path)
+                log.debug("Moving %s to %s" % (full_path, new_file_path))
+                try:
+                    os.makedirs(os.path.dirname(new_file_path), exist_ok=True)
+                    shutil.move(full_path, new_file_path)
+                except Exception as e:
+                    errors.append("Unable to move file from %s to %s\n"
+                                  "Error was: %s"
+                                  % (full_path, new_file_path, str(e)))
 
         # Remove directories, which should be empty
         for dirpath, _, _ in os.walk(old_path, topdown=False):

--- a/hepdata/modules/submission/models.py
+++ b/hepdata/modules/submission/models.py
@@ -264,7 +264,7 @@ def receive_data_resource_after_delete(mapper, connection, target):
                 log.debug('Deleting file %s' % target.file_location)
                 os.remove(target.file_location)
         else:
-            log.error("Could not remove file %s" % target.file_location)
+            log.warning("Could not remove file %s as it is not a valid file." % target.file_location)
 
 
 datareview_messages = db.Table('review_messages',


### PR DESCRIPTION
 * Change error to warning if file doesn't exist, and provide more detail.
 * Revert the change that deletes all files that aren't recognised, as it will also delete files that could not be moved
 * Only flag up missing files for real records, not sandbox records.
 * Final cleanup now deletes any numeric directories that don't correspond to a current record