### PR TITLE
Dashboard fixes

### DIFF
--- a/hepdata/modules/dashboard/api.py
+++ b/hepdata/modules/dashboard/api.py
@@ -49,7 +49,7 @@ def add_user_to_metadata(type, user_info, record_id, submissions):
 def create_record_for_dashboard(record_id, submissions, current_user, coordinator=None, user_role=None,
                                 status="todo"):
     if user_role is None:
-        user_role = ["coordinator"]
+        user_role = []
 
     publication_record = get_record_by_id(int(record_id))
 

--- a/hepdata/modules/dashboard/api.py
+++ b/hepdata/modules/dashboard/api.py
@@ -204,7 +204,7 @@ def _prepare_submission_query(current_user):
             SubmissionParticipant.publication_recid
         )
 
-        query.filter(
+        query = query.filter(
             or_(HEPSubmission.coordinator == int(current_user.get_id()),
                 HEPSubmission.publication_recid.in_(inner_query))
         )

--- a/hepdata/modules/dashboard/api.py
+++ b/hepdata/modules/dashboard/api.py
@@ -174,10 +174,11 @@ def list_submission_titles(current_user):
     titles = []
     for hepsubmission in hepdata_submission_records:
         publication_record = get_record_by_id(int(hepsubmission.publication_recid))
-        titles.append({
-            'id': int(hepsubmission.publication_recid),
-            'title': publication_record['title']
-        })
+        if publication_record:
+            titles.append({
+                'id': int(hepsubmission.publication_recid),
+                'title': publication_record['title']
+            })
 
     return titles
 

--- a/hepdata/modules/dashboard/api.py
+++ b/hepdata/modules/dashboard/api.py
@@ -74,8 +74,9 @@ def create_record_for_dashboard(record_id, submissions, current_user, coordinato
                 submissions[record_id]["metadata"]["coordinator"] = {
                     'id': coordinator.id, 'name': coordinator.email,
                     'email': coordinator.email}
-                submissions[record_id]["metadata"][
-                    "show_coord_view"] = int(current_user.get_id()) == coordinator.id
+                if int(current_user.get_id()) == coordinator.id:
+                    submissions[record_id]["metadata"]["show_coord_view"] = True
+                    submissions[record_id]["metadata"]["role"].append("coordinator")
             else:
                 submissions[record_id]["metadata"]["coordinator"] = {
                     'name': 'No coordinator'}

--- a/hepdata/modules/dashboard/api.py
+++ b/hepdata/modules/dashboard/api.py
@@ -76,7 +76,10 @@ def create_record_for_dashboard(record_id, submissions, current_user, coordinato
                     'email': coordinator.email}
                 if int(current_user.get_id()) == coordinator.id:
                     submissions[record_id]["metadata"]["show_coord_view"] = True
-                    submissions[record_id]["metadata"]["role"].append("coordinator")
+                    if 'coordinator' not in submissions[record_id]["metadata"]["role"]:
+                        submissions[record_id]["metadata"]["role"].append("coordinator")
+                else:
+                    submissions[record_id]["metadata"]["show_coord_view"] = False
             else:
                 submissions[record_id]["metadata"]["coordinator"] = {
                     'name': 'No coordinator'}

--- a/hepdata/modules/dashboard/templates/hepdata_dashboard/dashboard-submissions.html
+++ b/hepdata/modules/dashboard/templates/hepdata_dashboard/dashboard-submissions.html
@@ -36,9 +36,6 @@
                 <div class="col-md-7">
 
                     <p class="start-date">
-                        {% if submission.show_coord_view %}
-                            <span class="label label-info">Coordinator</span>
-                        {% endif %}
                         {% for role in submission.role %}
                             <span class="label label-info">
                             <span class="fa fa-{% if role == 'coordinator' %}gavel {% elif role == 'reviewer' %}check{% else %}upload{% endif %}"

--- a/hepdata/modules/dashboard/templates/hepdata_dashboard/dashboard-submissions.html
+++ b/hepdata/modules/dashboard/templates/hepdata_dashboard/dashboard-submissions.html
@@ -36,7 +36,7 @@
                 <div class="col-md-7">
 
                     <p class="start-date">
-                        {% for role in submission.role %}
+                        {% for role in submission.role|sort %}
                             <span class="label label-info">
                             <span class="fa fa-{% if role == 'coordinator' %}gavel {% elif role == 'reviewer' %}check{% else %}upload{% endif %}"
                                   style="padding-right: 5px;"></span>{{ role }}</span>

--- a/hepdata/modules/dashboard/views.py
+++ b/hepdata/modules/dashboard/views.py
@@ -117,6 +117,7 @@ def dashboard_submissions():
     total_pages = int(math.ceil(total_records / size))
 
     ctx = {
+        'user_is_admin': has_role(current_user, 'admin'),
         'modify_query': modify_query,
         'submissions': submission_meta,
         'submission_stats': submission_stats

--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20201123"
+__version__ = "0.9.4dev20201124"

--- a/tests/dashboard_test.py
+++ b/tests/dashboard_test.py
@@ -91,7 +91,7 @@ def test_create_record_for_dashboard(app):
                 'metadata': {
                     'coordinator': {'name': 'No coordinator'},
                     'recid': record_information['recid'],
-                    'role': ['coordinator'],
+                    'role': [],
                     'start_date': hepsubmission.created,
                     'last_updated': hepsubmission.last_updated,
                     'title': u'My Journal Paper',
@@ -111,7 +111,7 @@ def test_create_record_for_dashboard(app):
         create_record_for_dashboard(record['recid'], test_submissions, user)
         assert(test_submissions == {
             record_information['recid']: {
-                "metadata": {"role": [['coordinator']]}
+                "metadata": {"role": [[]]}
             }
         })
 
@@ -151,7 +151,7 @@ def test_submissions_admin(app, load_submission):
                                 'name': u'test@hepdata.net',
                                 'id': 1},
                 'recid': str(record_information['recid']),
-                'role': ['coordinator'],
+                'role': [],
                 'show_coord_view': False,
                 'start_date': hepsubmission.created,
                 'last_updated': hepsubmission.last_updated,

--- a/tests/dashboard_test.py
+++ b/tests/dashboard_test.py
@@ -171,11 +171,17 @@ def test_submissions_participant(app, load_submission):
             'inspire_id': '1487726'
         })
         hepsubmission = get_or_create_hepsubmission(record_information['recid'])
+        db.session.add(hepsubmission)
 
         user = User(email='test@test.com', password='hello1', active=True)
         db.session.add(user)
         db.session.commit()
 
+        # Check the user doesn't see the record before they are a participant
+        assert(get_submission_count(user) == 0)
+        assert(list_submission_titles(user) == [])
+
+        # Add the user as a participant
         participant = SubmissionParticipant(
             publication_recid=record_information['recid'],
             role="uploader",


### PR DESCRIPTION
Fixed issues with dashboard:

 * There was a 500 error on QA where the record id for a submission did not exist. Method is now more robust.
 * The new `dashboard-submissions` endpoint now passes `user_is_admin` to the template so admin users can once again edit submissions in which they are not a participant.
 * The query to filter submissions for non-admin users has now been fixed so they can no longer see submissions in which they are not participating.