### PR TITLE
Avoid using default parameters in javascript

### DIFF
--- a/hepdata/modules/records/static/js/hepdata_reviews.js
+++ b/hepdata/modules/records/static/js/hepdata_reviews.js
@@ -3,7 +3,7 @@
  */
 
 
-HEPDATA.set_review_status = function (status, set_all_tables=false, onSuccess=null, onError=null) {
+HEPDATA.set_review_status = function (status, set_all_tables) {
   var data = {
     "publication_recid": HEPDATA.current_record_id,
     "status": status,

--- a/hepdata/modules/records/templates/hepdata_records/components/approve-all-widget.html
+++ b/hepdata/modules/records/templates/hepdata_records/components/approve-all-widget.html
@@ -61,7 +61,7 @@
               {"width": 100, "height": 100}
             );
             $("#approve-all-container .col-md-12 div").append("<p>Approving all tables...</p>");
-            HEPDATA.set_review_status('passed', all_tables=true);
+            HEPDATA.set_review_status('passed', true);
           } else {
             $('#confirmWarning').show();
           }


### PR DESCRIPTION
They upset older versions of uglifyjs (see https://github.com/HEPData/hepdata/runs/1690568020#step:3:677)
Also removed unused parameters.

Tested locally against uglify-js v3.11.0.