### PR TITLE
Added endpoint to get all IDs

### DIFF
--- a/hepdata/ext/elasticsearch/api.py
+++ b/hepdata/ext/elasticsearch/api.py
@@ -500,7 +500,7 @@ def get_count_for_collection(doc_type, index=None):
 
 
 @default_index
-def get_all_ids(index=None, id_field='recid'):
+def get_all_ids(index=None, id_field='recid', last_updated=None):
     """Get all record or inspire ids of publications in the search index
 
     :param index: name of index to use.
@@ -513,5 +513,8 @@ def get_all_ids(index=None, id_field='recid'):
     search = Search(using=es, index=index) \
         .filter("term", doc_type=CFG_PUB_TYPE) \
         .source(fields=[id_field])
+
+    if last_updated:
+        search = search.filter("range", **{'last_updated': {'gte': last_updated.isoformat()}})
 
     return [int(h[id_field]) for h in search.scan()]

--- a/hepdata/ext/elasticsearch/api.py
+++ b/hepdata/ext/elasticsearch/api.py
@@ -500,9 +500,18 @@ def get_count_for_collection(doc_type, index=None):
 
 
 @default_index
-def get_all_ids(index=None):
+def get_all_ids(index=None, id_field='recid'):
+    """Get all record or inspire ids of publications in the search index
+
+    :param index: name of index to use.
+    :param id_field: elasticsearch field to return. Should be 'recid' or 'inspire_id'
+    :return: list of integer ids
+    """
+    if id_field not in ('recid', 'inspire_id'):
+        raise ValueError('Invalid ID field %s' % id_field)
+
     search = Search(using=es, index=index) \
         .filter("term", doc_type=CFG_PUB_TYPE) \
-        .source(fields=['inspire_id'])
+        .source(fields=[id_field])
 
-    return [int(h.inspire_id) for h in search.scan()]
+    return [int(h[id_field]) for h in search.scan()]

--- a/hepdata/ext/elasticsearch/api.py
+++ b/hepdata/ext/elasticsearch/api.py
@@ -497,3 +497,12 @@ def get_count_for_collection(doc_type, index=None):
     :return: the number of records in that collection
     """
     return es.count(index=index, q='doc_type:'+doc_type)
+
+
+@default_index
+def get_all_ids(index=None):
+    search = Search(using=es, index=index) \
+        .filter("term", doc_type=CFG_PUB_TYPE) \
+        .source(fields=['inspire_id'])
+
+    return [int(h.inspire_id) for h in search.scan()]

--- a/hepdata/ext/elasticsearch/api.py
+++ b/hepdata/ext/elasticsearch/api.py
@@ -500,7 +500,7 @@ def get_count_for_collection(doc_type, index=None):
 
 
 @default_index
-def get_all_ids(index=None, id_field='recid', last_updated=None):
+def get_all_ids(index=None, id_field='recid', last_updated=None, latest_first=False):
     """Get all record or inspire ids of publications in the search index
 
     :param index: name of index to use.
@@ -517,4 +517,7 @@ def get_all_ids(index=None, id_field='recid', last_updated=None):
     if last_updated:
         search = search.filter("range", **{'last_updated': {'gte': last_updated.isoformat()}})
 
-    return [int(h[id_field]) for h in search.scan()]
+    if latest_first:
+        search = search.sort({'last_updated' : {'order' : 'desc'}}).params(preserve_order=True)
+
+    return [h[id_field] for h in search.scan()]

--- a/hepdata/ext/elasticsearch/api.py
+++ b/hepdata/ext/elasticsearch/api.py
@@ -518,6 +518,10 @@ def get_all_ids(index=None, id_field='recid', last_updated=None, latest_first=Fa
         search = search.filter("range", **{'last_updated': {'gte': last_updated.isoformat()}})
 
     if latest_first:
-        search = search.sort({'last_updated' : {'order' : 'desc'}}).params(preserve_order=True)
+        search = search.sort({'last_updated' : {'order' : 'desc'}})
+    else:
+        search = search.sort('recid')
 
-    return [h[id_field] for h in search.scan()]
+    search = search.params(preserve_order=True)
+
+    return [int(h[id_field]) for h in search.scan()]

--- a/hepdata/modules/records/api.py
+++ b/hepdata/modules/records/api.py
@@ -737,3 +737,38 @@ def process_data_tables(ctx, data_record_query, first_data_id,
 
 def truncate_author_list(record, length=10):
     record['authors'] = record['authors'][:length]
+
+
+def get_all_ids(index=None, id_field='recid', last_updated=None, latest_first=False):
+    """Get all record or inspire ids of publications in the search index
+
+    :param index: name of index to use.
+    :param id_field: elasticsearch field to return. Should be 'recid' or 'inspire_id'
+    :return: list of integer ids
+    """
+    if id_field not in ('recid', 'inspire_id'):
+        raise ValueError('Invalid ID field %s' % id_field)
+
+    db_col = HEPSubmission.publication_recid if id_field == 'recid' \
+        else HEPSubmission.inspire_id
+
+    # Get unique version
+    query = db.session.query(db_col) \
+        .filter(HEPSubmission.overall_status == 'finished')
+
+    if last_updated:
+        query = query.filter(HEPSubmission.last_updated >= last_updated)
+
+    if latest_first:
+        # Use a set to check for duplicates, as sorting by last_updated
+        # means distinct doesn't work (as it looks for distinct across both
+        # cols)
+        query = query.order_by(HEPSubmission.last_updated.desc())
+        seen = set()
+        seen_add = seen.add
+        return [
+            x[0] for x in query.all() if not (x[0] in seen or seen_add(x[0]))
+        ]
+    else:
+        query = query.distinct()
+        return [int(x[0]) for x in query.all()]

--- a/hepdata/modules/records/api.py
+++ b/hepdata/modules/records/api.py
@@ -743,7 +743,7 @@ def get_all_ids(index=None, id_field='recid', last_updated=None, latest_first=Fa
     """Get all record or inspire ids of publications in the search index
 
     :param index: name of index to use.
-    :param id_field: elasticsearch field to return. Should be 'recid' or 'inspire_id'
+    :param id_field: id type to return. Should be 'recid' or 'inspire_id'
     :return: list of integer ids
     """
     if id_field not in ('recid', 'inspire_id'):
@@ -767,8 +767,8 @@ def get_all_ids(index=None, id_field='recid', last_updated=None, latest_first=Fa
         seen = set()
         seen_add = seen.add
         return [
-            x[0] for x in query.all() if not (x[0] in seen or seen_add(x[0]))
+            int(x[0]) for x in query.all() if not (x[0] in seen or seen_add(x[0]))
         ]
     else:
-        query = query.distinct()
+        query = query.order_by(HEPSubmission.publication_recid).distinct()
         return [int(x[0]) for x in query.all()]

--- a/hepdata/modules/search/views.py
+++ b/hepdata/modules/search/views.py
@@ -24,7 +24,7 @@ import sys
 from flask import Blueprint, request, render_template, jsonify
 from hepdata.config import CFG_DATA_KEYWORDS
 from hepdata.ext.elasticsearch.api import search as es_search, \
-    search_authors as es_search_authors
+    search_authors as es_search_authors, get_all_ids
 from hepdata.modules.records.utils.common import decode_string
 from hepdata.utils.session import get_session_item, set_session_item
 from hepdata.utils.url import modify_query
@@ -275,3 +275,8 @@ def search():
         ctx['modify_query'] = modify_query
 
         return render_template('hepdata_search/search_results.html', ctx=ctx)
+
+
+@blueprint.route('/allids', methods=['GET', 'POST'])
+def all_ids():
+    return jsonify(get_all_ids())

--- a/hepdata/modules/search/views.py
+++ b/hepdata/modules/search/views.py
@@ -277,8 +277,14 @@ def search():
         return render_template('hepdata_search/search_results.html', ctx=ctx)
 
 
-@blueprint.route('/allids', methods=['GET', 'POST'])
+@blueprint.route('/ids', methods=['GET', 'POST'])
 def all_ids():
+    """
+    Get IDs for all records (since a given date) as a JSON list.
+    Accepts query parameters:
+        inspire_ids: if set, return inspire IDs rather than HEPData record IDs
+        last_updated: return IDs updated since given date (in format YYYY-mm-dd)
+    """
     id_field = 'recid'
     if request.args.get('inspire_ids'):
         id_field = 'inspire_id'

--- a/hepdata/modules/search/views.py
+++ b/hepdata/modules/search/views.py
@@ -17,10 +17,10 @@
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 #
 """HEPData Search Views."""
-
+import datetime
 import json
-
 import sys
+
 from flask import Blueprint, request, render_template, jsonify
 from hepdata.config import CFG_DATA_KEYWORDS
 from hepdata.ext.elasticsearch.api import search as es_search, \
@@ -283,4 +283,17 @@ def all_ids():
     if request.args.get('inspire_ids'):
         id_field = 'inspire_id'
 
-    return jsonify(get_all_ids(id_field=id_field))
+    last_updated = None
+    last_updated_str = request.args.get('last_updated')
+    if last_updated_str:
+        try:
+            last_updated = datetime.datetime.strptime(last_updated_str,
+                                                      '%Y-%m-%d')
+        except ValueError:
+            return jsonify({
+                "error": "Unable to parse date from last_updated value %s. "
+                         "last_updated should be in format YYYY-mm-dd"
+                         % last_updated_str
+            }), 400
+
+    return jsonify(get_all_ids(id_field=id_field, last_updated=last_updated))

--- a/hepdata/modules/search/views.py
+++ b/hepdata/modules/search/views.py
@@ -281,10 +281,14 @@ def search():
 @blueprint.route('/ids', methods=['GET'])
 def all_ids():
     """
-    Get IDs for all records (since a given date) as a JSON list.
+    Get IDs for all records (since a given date) as a JSON list of integers.
+
     Accepts query parameters:
-        inspire_ids: if set, return inspire IDs rather than HEPData record IDs
-        last_updated: return IDs updated since given date (in format YYYY-mm-dd)
+
+    - ``inspire_ids``: if set to a truthy value, return inspire IDs rather than HEPData record IDs
+    - ``last_updated``: return IDs updated since given date (in format YYYY-mm-dd)
+    - ``sort_by``: if set to ``latest``, sort the results latest first
+    - ``use_es``: if set to a truthy values, use ElasticSearch rather than the database to return the ids
     """
     id_field = 'recid'
     if _get_bool_parameter(request, 'inspire_ids'):

--- a/hepdata/modules/search/views.py
+++ b/hepdata/modules/search/views.py
@@ -279,4 +279,8 @@ def search():
 
 @blueprint.route('/allids', methods=['GET', 'POST'])
 def all_ids():
-    return jsonify(get_all_ids())
+    id_field = 'recid'
+    if request.args.get('inspire_ids'):
+        id_field = 'inspire_id'
+
+    return jsonify(get_all_ids(id_field=id_field))

--- a/tests/records_test.py
+++ b/tests/records_test.py
@@ -513,12 +513,12 @@ def test_get_all_ids(app, load_default_data, identifiers):
     expected_record_ids = [1, 16]
     # Order is not guaranteed unless we use latest_first,
     # so sort the results before checking
-    assert(sorted(get_all_ids()) == expected_record_ids)
+    assert(get_all_ids() == expected_record_ids)
 
     # Check id_field works
-    assert(sorted(get_all_ids(id_field='recid')) == expected_record_ids)
-    assert(sorted(get_all_ids(id_field='inspire_id'))
-           == sorted([x["inspire_id"] for x in identifiers]))
+    assert(get_all_ids(id_field='recid') == expected_record_ids)
+    assert(get_all_ids(id_field='inspire_id')
+           == [x["inspire_id"] for x in identifiers])
     with pytest.raises(ValueError):
         get_all_ids(id_field='authors')
 
@@ -535,3 +535,5 @@ def test_get_all_ids(app, load_default_data, identifiers):
 
     # Check sort by latest works
     assert(get_all_ids(latest_first=True) == expected_record_ids)
+    assert(get_all_ids(id_field='inspire_id', latest_first=True)
+           == [x["inspire_id"] for x in identifiers])

--- a/tests/search_test.py
+++ b/tests/search_test.py
@@ -388,3 +388,7 @@ def test_get_record(app, load_default_data, identifiers):
         assert (record[key] == identifiers[0][key])
 
     assert(es_api.get_record(9999999) is None)
+
+
+def test_get_all_ids(app, load_default_data, identifiers):
+    assert(sorted(es_api.get_all_ids()) == sorted([x["inspire_id"] for x in identifiers]))

--- a/tests/search_test.py
+++ b/tests/search_test.py
@@ -391,4 +391,8 @@ def test_get_record(app, load_default_data, identifiers):
 
 
 def test_get_all_ids(app, load_default_data, identifiers):
-    assert(sorted(es_api.get_all_ids()) == sorted([x["inspire_id"] for x in identifiers]))
+    assert(sorted(es_api.get_all_ids()) == [1, 16])
+    assert(sorted(es_api.get_all_ids(id_field='recid')) == [1, 16])
+    assert(sorted(es_api.get_all_ids(id_field='inspire_id')) == sorted([x["inspire_id"] for x in identifiers]))
+    with pytest.raises(ValueError):
+        es_api.get_all_ids(id_field='authors')

--- a/tests/search_test.py
+++ b/tests/search_test.py
@@ -395,21 +395,21 @@ def test_get_all_ids(app, load_default_data, identifiers):
     expected_record_ids = [1, 16]
     # Order is not guaranteed by ES unless we use latest_first,
     # so sort the results before checking
-    assert(sorted(es_api.get_all_ids()) == expected_record_ids)
+    assert(es_api.get_all_ids() == expected_record_ids)
 
     # Check id_field works
-    assert(sorted(es_api.get_all_ids(id_field='recid')) == expected_record_ids)
-    assert(sorted(es_api.get_all_ids(id_field='inspire_id'))
-           == sorted([x["inspire_id"] for x in identifiers]))
+    assert(es_api.get_all_ids(id_field='recid') == expected_record_ids)
+    assert(es_api.get_all_ids(id_field='inspire_id')
+           == [x["inspire_id"] for x in identifiers])
     with pytest.raises(ValueError):
         es_api.get_all_ids(id_field='authors')
 
     # Check last_updated works
     # Default records were last updated on 2016-07-13 and 2013-12-17
     date_2013_1 = datetime.datetime(year=2013, month=12, day=16)
-    assert(sorted(es_api.get_all_ids(last_updated=date_2013_1)) == expected_record_ids)
+    assert(es_api.get_all_ids(last_updated=date_2013_1) == expected_record_ids)
     date_2013_2 = datetime.datetime(year=2013, month=12, day=17)
-    assert(sorted(es_api.get_all_ids(last_updated=date_2013_2)) == expected_record_ids)
+    assert(es_api.get_all_ids(last_updated=date_2013_2) == expected_record_ids)
     date_2013_3 = datetime.datetime(year=2013, month=12, day=18)
     assert(es_api.get_all_ids(last_updated=date_2013_3) == [1])
     date_2020 = datetime.datetime(year=2020, month=1, day=1)

--- a/tests/search_test.py
+++ b/tests/search_test.py
@@ -393,11 +393,14 @@ def test_get_record(app, load_default_data, identifiers):
 
 def test_get_all_ids(app, load_default_data, identifiers):
     expected_record_ids = [1, 16]
+    # Order is not guaranteed by ES unless we use latest_first,
+    # so sort the results before checking
     assert(sorted(es_api.get_all_ids()) == expected_record_ids)
 
     # Check id_field works
     assert(sorted(es_api.get_all_ids(id_field='recid')) == expected_record_ids)
-    assert(sorted(es_api.get_all_ids(id_field='inspire_id')) == sorted([x["inspire_id"] for x in identifiers]))
+    assert(sorted(es_api.get_all_ids(id_field='inspire_id'))
+           == sorted([x["inspire_id"] for x in identifiers]))
     with pytest.raises(ValueError):
         es_api.get_all_ids(id_field='authors')
 
@@ -411,3 +414,6 @@ def test_get_all_ids(app, load_default_data, identifiers):
     assert(es_api.get_all_ids(last_updated=date_2013_3) == [1])
     date_2020 = datetime.datetime(year=2020, month=1, day=1)
     assert(es_api.get_all_ids(last_updated=date_2020) == [])
+
+    # Check sort by latest works - first record is newer than previous
+    assert(es_api.get_all_ids(latest_first=True) == expected_record_ids)


### PR DESCRIPTION
Adds an endpoint at `/search/ids` to return record or inspire IDs as a JSON list.

Accepts the following query parameters:

- `inspire_ids`: if set, returns inspire IDs rather than HEPData record IDs
- `last_updated`: if set (to date formatted as `YYYY-mm-dd`), returns IDs of records updated since the given date; otherwise returns IDs for all records

Note that for efficiency the code uses the [`scan`](https://elasticsearch-dsl.readthedocs.io/en/latest/api.html?highlight=scan#elasticsearch_dsl.Search.scan) method of elasticsearch DSL, which does not guarantee the order of search results.

Fixes #290 