### PR TITLE
Add doc build to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,9 @@ jobs:
         COVERALLS_SERVICE_NAME: github
       run: |
         coveralls
+    - name: Build docs
+      run: |
+        cd docs && make html SPHINXOPTS="-W"
 
   deploy:
     needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,7 @@ jobs:
         coveralls
     - name: Build docs
       run: |
+        python -m pip install -e .[docs]
         cd docs && make html SPHINXOPTS="-W"
 
   deploy:

--- a/hepdata/modules/converter/tasks.py
+++ b/hepdata/modules/converter/tasks.py
@@ -37,8 +37,6 @@ def convert_and_store(inspire_id, file_format, force):
     :param file_format:
     :param force:
     :return:
-    - this is a broken list
-    Because here is some text immediately below it
     """
     submission = get_latest_hepsubmission(inspire_id=inspire_id)
     if submission:

--- a/hepdata/modules/converter/tasks.py
+++ b/hepdata/modules/converter/tasks.py
@@ -37,6 +37,8 @@ def convert_and_store(inspire_id, file_format, force):
     :param file_format:
     :param force:
     :return:
+    - this is a broken list
+    Because here is some text immediately below it
     """
     submission = get_latest_hepsubmission(inspire_id=inspire_id)
     if submission:


### PR DESCRIPTION
Fixes #298

See [failing action](https://github.com/HEPData/hepdata/runs/1730088576?check_suite_focus=true#step:15:101) for an example of how a dodgy docstring which generates a warning causes the build to fail.