### PR TITLE
Fix broken review status calls

### DIFF
--- a/hepdata/modules/records/static/js/hepdata_reviews.js
+++ b/hepdata/modules/records/static/js/hepdata_reviews.js
@@ -24,25 +24,7 @@ HEPDATA.set_review_status = function (status, set_all_tables) {
       success: function (data) {
         var status = data.status;
         if (status) {
-          for (var review_status in HEPDATA.review_classes) {
-            $("#reviewer-button").removeClass(review_status);
-          }
-          $("#reviewer-button").addClass(status);
-
-          $("#" + status + "-option").removeClass("deactivate");
-          $("#review-status span").each(function () {
-            if (this.id.indexOf(status) == -1)
-              $(this).addClass("deactivate");
-          });
-
-          for (var review_status in HEPDATA.review_classes) {
-            $("#" + HEPDATA.current_table_id + "-status").removeClass(review_status);
-          }
-          $("#" + HEPDATA.current_table_id + "-status").addClass(status);
-          $("#" + HEPDATA.current_table_id + "-status #icon").removeClass();
-          $("#" + HEPDATA.current_table_id + "-status #icon").addClass("fa " + HEPDATA.review_classes[status].icon);
-          $("#" + HEPDATA.current_table_id + "-status .text").text(HEPDATA.review_classes[status].text);
-          HEPDATA.toggleApproveAllButton();
+          HEPDATA.update_review_statuses(status)
         } else {
           if (data.success) {
             $("#approve-all-container .col-md-12 div p").html('All tables passed. Reloading in 1s...');
@@ -55,6 +37,28 @@ HEPDATA.set_review_status = function (status, set_all_tables) {
       }
     }
   );
+};
+
+HEPDATA.update_review_statuses = function(status) {
+  for (var review_status in HEPDATA.review_classes) {
+    $("#reviewer-button").removeClass(review_status);
+  }
+  $("#reviewer-button").addClass(status);
+
+  $("#" + status + "-option").removeClass("deactivate");
+  $("#review-status span").each(function () {
+    if (this.id.indexOf(status) == -1)
+      $(this).addClass("deactivate");
+  });
+
+  for (var review_status in HEPDATA.review_classes) {
+    $("#" + HEPDATA.current_table_id + "-status").removeClass(review_status);
+  }
+  $("#" + HEPDATA.current_table_id + "-status").addClass(status);
+  $("#" + HEPDATA.current_table_id + "-status #icon").removeClass();
+  $("#" + HEPDATA.current_table_id + "-status #icon").addClass("fa " + HEPDATA.review_classes[status].icon);
+  $("#" + HEPDATA.current_table_id + "-status .text").text(HEPDATA.review_classes[status].text);
+  HEPDATA.toggleApproveAllButton();
 };
 
 HEPDATA.load_all_review_messages = function (placement, record_id) {

--- a/hepdata/modules/records/static/js/hepdata_tables.js
+++ b/hepdata/modules/records/static/js/hepdata_tables.js
@@ -180,7 +180,7 @@ HEPDATA.table_renderer = {
   },
 
   update_reviewer_button: function (review_info) {
-    HEPDATA.set_review_status(review_info.review_flag);
+    HEPDATA.update_review_statuses(review_info.review_flag);
   },
 
   clean_data: function (value, remove_qualifier_uniqueness_attr) {

--- a/hepdata/modules/records/templates/hepdata_records/components/table_list.html
+++ b/hepdata/modules/records/templates/hepdata_records/components/table_list.html
@@ -19,7 +19,7 @@
 
         {% endif %}
 
-        {% if (ctx.show_review_widget or ctx.is_submission_coordinator_or_admin) and ctx.status != 'finished' and ctx.version >= ctx.version_count %}
+        {% if ctx.mode != 'sandbox' and (ctx.show_review_widget or ctx.is_submission_coordinator_or_admin) and ctx.status != 'finished' and ctx.version >= ctx.version_count %}
             <button type="button" class="btn btn-danger btn-md" data-toggle="modal" style="width: 100%"
                     id="approve-all-btn" data-target="#approveAllTables"><span
                     class="fa fa-check-circle"></span> Approve All Tables

--- a/hepdata/modules/records/views.py
+++ b/hepdata/modules/records/views.py
@@ -377,8 +377,9 @@ def set_data_review_status():
                  "status": record.status})
 
     return jsonify(
-        {"recid": recid, "data_id": data_id, 'message': 'You are not authorised to update the review status for '
-                                                        'this data record.'})
+        {"recid": recid,
+         'message': 'You are not authorised to update the review status for '
+                    'this data record.'})
 
 
 @blueprint.route('/data/review/', methods=['GET', ])


### PR DESCRIPTION
Graeme said:

> Can you please take a look at these Sentry events (177 since Monday, when the "Approve All Tables" button was deployed)?  The exception happens because `data_id` is not defined in [this line](https://github.com/HEPData/hepdata/blob/585b4cc43be8f13bacedbfd882aa90799864ba7c/hepdata/modules/records/views.py#L380).  This is easily fixed, but the exception should only be raised when a user does not have Reviewer permissions.  But in this case, the user should not be able to click on the reviewer buttons, so I don't see how they would get to the `/data/review/status/` endpoint.

It looks like endpoint was being called whenever a table was loaded: [`update_reviewer_button`](https://github.com/HEPData/hepdata/blob/585b4cc43be8f13bacedbfd882aa90799864ba7c/hepdata/modules/records/static/js/hepdata_tables.js#L182) is [called](https://github.com/HEPData/hepdata/blob/585b4cc43be8f13bacedbfd882aa90799864ba7c/hepdata/modules/records/static/js/hepdata_tables.js#L138), which calls `set_review_status` without checking whether the user is logged in, presumably to make sure the current page reflects the current review status. I've fixed the JS so that `update_reviewer_button` just does the UI updates without attempting to make a call to change the status (and checks whether the review pane is visible first!), as well as fixing the python error.

> Another issue I noticed is that when loading a Sandbox record (after logging in), the "Approve All Tables" button is shown for a fraction of a second before it is hidden.

Also fixed.