### PR TITLE
Add CLI tool to import from hepdata net

### DIFF
--- a/hepdata/cli.py
+++ b/hepdata/cli.py
@@ -236,7 +236,7 @@ def bulk_import_records(base_url, update_existing, date, n_latest):
     Populate the DB with records from HEPData.net (or another instance as
     specified by base_url)
 
-    Usage: ``hepdata importer bulk-import-records -u -d 2020-01-01``
+    Usage: ``hepdata importer bulk-import-records -u true -d 2020-01-01``
     """
     if current_app.config.get('ENV') == 'production':
         click.confirm('You are currently running in production mode on'

--- a/hepdata/cli.py
+++ b/hepdata/cli.py
@@ -220,31 +220,28 @@ def import_records(inspireids, recreate_index, base_url, update_existing):
 
 @importer.command()
 @with_appcontext
-@click.option('--start', '-s', type=int, default=None,
-              help='The start page from the total set of records.')
-@click.option('--end', '-e', default=None, type=int,
-              help='The end page from the total set of records.')
+@click.option('--date', '-d', type=click.DateTime(formats=['%Y-%m-%d']), default=None,
+              help='Filter all records modified since some point in time, '
+              'e.g. 2016-07-05 for the 5th July 2016.')
 @click.option('--update-existing', '-u', default=False, type=bool,
               help='Whether to update records which already exist'
               '(defaults to False)')
 @click.option('--base-url', '-b', default="https://hepdata.net", type=str,
               help='Base URL from which to get data (defaults to '
               'https://hepdata.net)')
-# @click.option('--date', '-d', type=str, default=None,
-#               help='Filter all records modified since some point in time, e.g. 20160705 for the 5th July 2016.')
-def bulk_import_records(start, end, base_url, update_existing):
+def bulk_import_records(base_url, update_existing, date):
     """
     Populate the DB with records from HEPData.net (or another instance as
     specified by base_url)
 
-    Usage: ``hepdata importer bulk-import-records -s 1 -e 2``
+    Usage: ``hepdata importer bulk-import-records -u -d 2020-01-01``
     """
-    inspire_ids = importer_api.get_inspire_ids(start, end)
-
-    print("Found {} inspire ids to load.".format(len(inspire_ids)))
-    importer_api.import_records(inspire_ids, synchronous=False,
-                                update_existing=update_existing,
-                                base_url=base_url)
+    inspire_ids = importer_api.get_inspire_ids(base_url=base_url, last_updated=date)
+    if inspire_ids is not False:
+        print("Found {} inspire ids to load.".format(len(inspire_ids)))
+        importer_api.import_records(inspire_ids, synchronous=False,
+                                    update_existing=update_existing,
+                                    base_url=base_url)
 
 
 @cli.group()

--- a/hepdata/cli.py
+++ b/hepdata/cli.py
@@ -200,6 +200,11 @@ def import_records(inspireids, recreate_index, base_url):
     Usage: ``hepdata importer import-records -i 'ins1262703' -rc False``
     """
     from hepdata.ext.elasticsearch.api import recreate_index as reindex
+    if current_app.config.get('ENV') == 'production':
+        click.confirm('You are currently running in production mode on'
+                      ' %s. Are you sure you want to import records from %s?'
+                      % (current_app.config.get('SITE_URL'), base_url),
+                      abort=True)
 
     if recreate_index:
         reindex()

--- a/hepdata/cli.py
+++ b/hepdata/cli.py
@@ -229,14 +229,20 @@ def import_records(inspireids, recreate_index, base_url, update_existing):
 @click.option('--base-url', '-b', default="https://hepdata.net", type=str,
               help='Base URL from which to get data (defaults to '
               'https://hepdata.net)')
-def bulk_import_records(base_url, update_existing, date):
+@click.option('--n-latest', '-n', default=None, type=int,
+              help='Get only the n most recently updated records')
+def bulk_import_records(base_url, update_existing, date, n_latest):
     """
     Populate the DB with records from HEPData.net (or another instance as
     specified by base_url)
 
     Usage: ``hepdata importer bulk-import-records -u -d 2020-01-01``
     """
-    inspire_ids = importer_api.get_inspire_ids(base_url=base_url, last_updated=date)
+    inspire_ids = importer_api.get_inspire_ids(
+        base_url=base_url,
+        last_updated=date,
+        n_latest=n_latest
+    )
     if inspire_ids is not False:
         print("Found {} inspire ids to load.".format(len(inspire_ids)))
         importer_api.import_records(inspire_ids, synchronous=False,

--- a/hepdata/cli.py
+++ b/hepdata/cli.py
@@ -189,10 +189,13 @@ def importer():
 @click.option('--recreate_index', '-rc', default=False, type=bool,
               help='Whether or not to recreate the index before importing'
               '(defaults to False)')
-@click.option('--base-url', '-u', default="https://hepdata.net", type=str,
+@click.option('--update-existing', '-u', default=False, type=bool,
+              help='Whether to update records which already exist'
+              '(defaults to False)')
+@click.option('--base-url', '-b', default="https://hepdata.net", type=str,
               help='Base URL from which to get data (defaults to '
               'https://hepdata.net)')
-def import_records(inspireids, recreate_index, base_url):
+def import_records(inspireids, recreate_index, base_url, update_existing):
     """
     Populate the DB with records from HEPData.net (or another instance as
     specified by base_url)
@@ -210,7 +213,9 @@ def import_records(inspireids, recreate_index, base_url):
         reindex()
 
     files_to_load = parse_inspireids_from_string(inspireids)
-    importer_api.import_records(files_to_load, synchronous=True, base_url=base_url)
+    importer_api.import_records(files_to_load, synchronous=True,
+                                update_existing=update_existing,
+                                base_url=base_url)
 
 
 @cli.group()

--- a/hepdata/cli.py
+++ b/hepdata/cli.py
@@ -238,6 +238,12 @@ def bulk_import_records(base_url, update_existing, date, n_latest):
 
     Usage: ``hepdata importer bulk-import-records -u -d 2020-01-01``
     """
+    if current_app.config.get('ENV') == 'production':
+        click.confirm('You are currently running in production mode on'
+                      ' %s. Are you sure you want to import records from %s?'
+                      % (current_app.config.get('SITE_URL'), base_url),
+                      abort=True)
+
     inspire_ids = importer_api.get_inspire_ids(
         base_url=base_url,
         last_updated=date,

--- a/hepdata/cli.py
+++ b/hepdata/cli.py
@@ -186,8 +186,9 @@ def importer():
 @with_appcontext
 @click.option('--inspireids', '-i', default=default_recids,
               help='A comma separated list of recids to load.')
-@click.option('--recreate_index', '-rc', default=True, type=bool,
-              help='Whether or not to recreate the index')
+@click.option('--recreate_index', '-rc', default=False, type=bool,
+              help='Whether or not to recreate the index before importing'
+              '(defaults to False)')
 @click.option('--base-url', '-u', default="https://hepdata.net", type=str,
               help='Base URL from which to get data (defaults to '
               'https://hepdata.net)')

--- a/hepdata/cli.py
+++ b/hepdata/cli.py
@@ -213,7 +213,7 @@ def import_records(inspireids, recreate_index, base_url, update_existing):
         reindex()
 
     files_to_load = parse_inspireids_from_string(inspireids)
-    importer_api.import_records(files_to_load, synchronous=True,
+    importer_api.import_records(files_to_load, synchronous=False,
                                 update_existing=update_existing,
                                 base_url=base_url)
 

--- a/hepdata/cli.py
+++ b/hepdata/cli.py
@@ -197,8 +197,8 @@ def importer():
               'https://hepdata.net)')
 def import_records(inspireids, recreate_index, base_url, update_existing):
     """
-    Populate the DB with records from HEPData.net (or another instance as
-    specified by base_url)
+    Populate the DB with specific records from HEPData.net (or another
+    instance as specified by base_url)
 
     Usage: ``hepdata importer import-records -i 'ins1262703' -rc False``
     """
@@ -214,6 +214,35 @@ def import_records(inspireids, recreate_index, base_url, update_existing):
 
     files_to_load = parse_inspireids_from_string(inspireids)
     importer_api.import_records(files_to_load, synchronous=True,
+                                update_existing=update_existing,
+                                base_url=base_url)
+
+
+@importer.command()
+@with_appcontext
+@click.option('--start', '-s', type=int, default=None,
+              help='The start page from the total set of records.')
+@click.option('--end', '-e', default=None, type=int,
+              help='The end page from the total set of records.')
+@click.option('--update-existing', '-u', default=False, type=bool,
+              help='Whether to update records which already exist'
+              '(defaults to False)')
+@click.option('--base-url', '-b', default="https://hepdata.net", type=str,
+              help='Base URL from which to get data (defaults to '
+              'https://hepdata.net)')
+# @click.option('--date', '-d', type=str, default=None,
+#               help='Filter all records modified since some point in time, e.g. 20160705 for the 5th July 2016.')
+def bulk_import_records(start, end, base_url, update_existing):
+    """
+    Populate the DB with records from HEPData.net (or another instance as
+    specified by base_url)
+
+    Usage: ``hepdata importer bulk-import-records -s 1 -e 2``
+    """
+    inspire_ids = importer_api.get_inspire_ids(start, end)
+
+    print("Found {} inspire ids to load.".format(len(inspire_ids)))
+    importer_api.import_records(inspire_ids, synchronous=False,
                                 update_existing=update_existing,
                                 base_url=base_url)
 

--- a/hepdata/modules/converter/views.py
+++ b/hepdata/modules/converter/views.py
@@ -253,7 +253,7 @@ def download_submission(submission, file_format, offline=False, force=False, riv
 
     converted_dir = get_converted_directory_path(submission.publication_recid)
     if not os.path.exists(converted_dir):
-        os.makedirs(converted_dir)
+        os.makedirs(converted_dir, exist_ok=True)
 
     if file_format == 'yoda' and rivet_analysis_name:
         # Don't store in converted_dir since rivet_analysis_name might possibly change between calls.

--- a/hepdata/modules/records/api.py
+++ b/hepdata/modules/records/api.py
@@ -454,7 +454,7 @@ def save_zip_file(file, id):
     return file_path
 
 
-def process_zip_archive(file_path, id):
+def process_zip_archive(file_path, id, old_submission_schema=False):
     (file_save_directory, filename) = os.path.split(file_path)
 
     if not filename.endswith('.oldhepdata'):
@@ -524,7 +524,8 @@ def process_zip_archive(file_path, id):
             from_oldhepdata = True
 
     return process_submission_directory(basepath, submission_file_path, id,
-                                        from_oldhepdata=from_oldhepdata)
+                                        from_oldhepdata=from_oldhepdata,
+                                        old_submission_schema=old_submission_schema)
 
 
 def check_and_convert_from_oldhepdata(input_directory, id, timestamp):

--- a/hepdata/modules/records/importer/api.py
+++ b/hepdata/modules/records/importer/api.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of HEPData.
+# Copyright (C) 2020 CERN.
+#
+# HEPData is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# HEPData is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with HEPData; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+import logging
+import os
+import requests
+import shutil
+import socket
+import tempfile
+import time
+
+from celery import shared_task
+from flask import current_app
+from invenio_db import db
+
+from hepdata.modules.dashboard.views import do_finalise
+from hepdata.modules.records.api import process_zip_archive
+from hepdata.modules.records.migrator.api import Migrator
+from hepdata.modules.records.utils.data_files import get_data_path_for_record
+from hepdata.modules.records.utils.submission import get_or_create_hepsubmission
+from hepdata.modules.records.utils.workflow import create_record
+from hepdata.modules.submission.api import get_latest_hepsubmission
+
+logging.basicConfig()
+log = logging.getLogger(__name__)
+
+
+def import_records(inspire_ids, synchronous=True, base_url='https://hepdata.net'):
+    """
+    Import records from hepdata.net
+    :param base_url: override default base URL
+    :param synchronous: if should be run immediately
+    :param inspire_ids: array of inspire ids to load (in the format insXXX).
+    :return: None
+    """
+    for index, inspire_id in enumerate(inspire_ids):
+        _cleaned_id = inspire_id.replace("ins", "")
+        try:
+            import_record(_cleaned_id, base_url=base_url)
+        except socket.error as se:
+            log.error("Socket error...")
+            log.error(se)
+        except Exception as e:
+            log.error("Failed to load {0}. {1} ".format(inspire_id, e))
+
+
+@shared_task
+def import_record(inspire_id, base_url='https://hepdata.net'):
+    migrator = Migrator(base_url)
+
+    publication_information, status = migrator.retrieve_publication_information(inspire_id)
+    if status != "success":
+        log.error("Failed to retrieve publication information for " + inspire_id)
+        return False
+
+    current_submission = get_latest_hepsubmission(inspire_id=inspire_id)
+
+    if not current_submission:
+        log.info("The record with id {0} does not exist in the database, so we're loading it.".format(inspire_id))
+        record_information = create_record(publication_information)
+        recid = record_information['recid']
+    else:
+        log.info("The record with inspire id {0} already exists.".format(inspire_id))
+        log.info("Updating instead")
+        recid = current_submission.publication_recid
+
+    # Download file to temp dir
+    url = "{0}/download/submission/ins{1}/original".format(base_url, inspire_id)
+    # Use the next line to allow imports from HEPData.net (for records without
+    # additional resources) before PR 289 is merged/released
+    # url = "{0}/download/submission/ins{1}/yaml".format(base_url, inspire_id)
+    log.info("Trying URL " + url)
+    response = requests.get(url)
+    if not response.ok:
+        log.error('Unable to retrieve download from {0}'.format(url))
+        return False
+    elif not response.headers['content-type'].startswith('application/'):
+        log.error('Did not receive zipped file in response from {0}'.format(url))
+        return False
+
+    # save to tmp file
+    tmp_file = tempfile.NamedTemporaryFile(mode='wb+', suffix='.zip',
+                                           dir=current_app.config["CFG_TMPDIR"],
+                                           delete=False)
+    tmp_file.write(response.content)
+    tmp_file.close()
+
+    time_stamp = str(int(round(time.time())))
+    file_save_directory = get_data_path_for_record(str(recid), time_stamp)
+    if not os.path.exists(file_save_directory):
+        os.makedirs(file_save_directory)
+    file_path = os.path.join(file_save_directory,
+                             os.path.basename(tmp_file.name))
+    shutil.move(tmp_file.name, file_path)
+
+    # Create submission
+    admin_user_id = 1
+    hepsubmission = get_or_create_hepsubmission(recid, admin_user_id)
+    db.session.add(hepsubmission)
+    db.session.commit()
+
+    # Then process the payload as for any other record
+    errors = process_zip_archive(file_path, recid)
+    if errors:
+        log.error("Could not process zip archive: ")
+        for error in errors:
+            log.error("    %s" % error)
+        return False
+
+    do_finalise(recid, force_finalise=True,
+                update=(current_submission is not None))
+

--- a/hepdata/modules/records/importer/api.py
+++ b/hepdata/modules/records/importer/api.py
@@ -54,6 +54,7 @@ def import_records(inspire_ids, synchronous=False, update_existing=False,
                    base_url='https://hepdata.net'):
     """
     Import records from hepdata.net
+
     :param inspire_ids: array of inspire ids to load (in the format insXXX).
     :param synchronous: if should be run immediately rather than via celery
     :param update_existing: whether to update records that already exist
@@ -75,6 +76,7 @@ def import_records(inspire_ids, synchronous=False, update_existing=False,
 def get_inspire_ids(base_url='https://hepdata.net', last_updated=None, n_latest=None):
     """
     Get inspire IDs from hepdata.net
+
     :param last_updated: get IDs of records updated on/after this date
     :param n_latest: get the n most recently updated IDs
     :param base_url: override default base URL

--- a/hepdata/modules/records/importer/api.py
+++ b/hepdata/modules/records/importer/api.py
@@ -24,6 +24,7 @@
 
 import logging
 import os
+import re
 import requests
 import shutil
 import socket
@@ -110,8 +111,17 @@ def import_record(inspire_id, base_url='https://hepdata.net'):
     file_save_directory = get_data_path_for_record(str(recid), time_stamp)
     if not os.path.exists(file_save_directory):
         os.makedirs(file_save_directory)
+
+    # Try getting file name from headers (but fall back to tmp file name)
+    filename = os.path.basename(tmp_file.name)
+    if 'content-disposition' in response.headers:
+        match = re.search("filename=(.+)", response.headers['content-disposition'])
+        if match:
+            filename = match.group(1)
+
     file_path = os.path.join(file_save_directory,
-                             os.path.basename(tmp_file.name))
+                             filename)
+    log.info("Moving file to %s" % file_path)
     shutil.move(tmp_file.name, file_path)
 
     # Create submission

--- a/hepdata/modules/records/importer/api.py
+++ b/hepdata/modules/records/importer/api.py
@@ -49,7 +49,7 @@ logging.basicConfig()
 log = logging.getLogger(__name__)
 
 
-def import_records(inspire_ids, synchronous=True, update_existing=False,
+def import_records(inspire_ids, synchronous=False, update_existing=False,
                    base_url='https://hepdata.net'):
     """
     Import records from hepdata.net
@@ -71,10 +71,13 @@ def import_records(inspire_ids, synchronous=True, update_existing=False,
             log.error("Failed to load {0}. {1} ".format(inspire_id, e))
 
 
-def get_inspire_ids(base_url='https://hepdata.net', last_updated=None):
+def get_inspire_ids(base_url='https://hepdata.net', last_updated=None, n_latest=None):
     url = base_url + '/search/ids?inspire_ids=true'
     if last_updated:
         url += '&last_updated=' + last_updated.strftime('%Y-%m-%d')
+
+    if n_latest > 0:
+        url += '&sort_by=latest'
 
     try:
         response = requests.get(url)
@@ -92,6 +95,8 @@ def get_inspire_ids(base_url='https://hepdata.net', last_updated=None):
 
     inspire_ids = response.json()
     try:
+        if n_latest:
+            inspire_ids = inspire_ids[:n_latest]
         return([str(x) for x in inspire_ids])
     except TypeError:
         log.error('Unexpected response from {0}: {1}'.format(url, inspire_ids))

--- a/hepdata/modules/records/utils/submission.py
+++ b/hepdata/modules/records/utils/submission.py
@@ -406,7 +406,9 @@ def _read_data_file(data_file_path):
     return data, ex
 
 
-def process_submission_directory(basepath, submission_file_path, recid, update=False, from_oldhepdata=False, old_submission_schema=False):
+def process_submission_directory(basepath, submission_file_path, recid,
+                                 update=False, from_oldhepdata=False,
+                                 old_submission_schema=False):
     """
     Goes through an entire submission directory and processes the
     files within to create DataSubmissions
@@ -416,7 +418,9 @@ def process_submission_directory(basepath, submission_file_path, recid, update=F
     :param submission_file_path:
     :param recid:
     :param update:
-    :param from_oldhepdata:
+    :param from_oldhepdata: whether to use old (v0) data schema
+    :param old_submission_schema: whether to use old (v0) submission schema
+        (should only be used when importing old records)
     :return:
     """
     added_file_names = []

--- a/hepdata/modules/records/utils/submission.py
+++ b/hepdata/modules/records/utils/submission.py
@@ -406,7 +406,7 @@ def _read_data_file(data_file_path):
     return data, ex
 
 
-def process_submission_directory(basepath, submission_file_path, recid, update=False, from_oldhepdata=False):
+def process_submission_directory(basepath, submission_file_path, recid, update=False, from_oldhepdata=False, old_submission_schema=False):
     """
     Goes through an entire submission directory and processes the
     files within to create DataSubmissions
@@ -438,7 +438,7 @@ def process_submission_directory(basepath, submission_file_path, recid, update=F
         ]}
         return errors
 
-    submission_file_validator = get_submission_validator()
+    submission_file_validator = get_submission_validator(old_submission_schema)
     is_valid_submission_file = submission_file_validator.validate(
         file_path=submission_file_path,
         data=submission_processed,

--- a/hepdata/modules/records/utils/validators.py
+++ b/hepdata/modules/records/utils/validators.py
@@ -59,12 +59,17 @@ ACCEPTED_REMOTE_SCHEMAS = [
 CACHED_DATA_VALIDATOR = None
 
 
-def get_submission_validator():
+def get_submission_validator(old_schema):
     """
     Returns a SubmissionFileValidator object
 
+    :param old_schema: whether the schema version for the submission.yaml is 0.1.0
     :return: SubmissionFileValidator object
     """
+    if old_schema:
+        return SubmissionFileValidator(schema_version='0.1.0')
+    else:
+        return SubmissionFileValidator()
 
     return SubmissionFileValidator()
 

--- a/hepdata/modules/records/utils/validators.py
+++ b/hepdata/modules/records/utils/validators.py
@@ -71,8 +71,6 @@ def get_submission_validator(old_schema):
     else:
         return SubmissionFileValidator()
 
-    return SubmissionFileValidator()
-
 
 def get_data_validator(old_hepdata):
     """

--- a/setup.py
+++ b/setup.py
@@ -142,6 +142,7 @@ setup(
         ],
         'invenio_celery.tasks': [
             'hepdata_records = hepdata.modules.records.migrator.api',
+            'hepdata_importer = hepdata.modules.records.importer.api',
             'hepdata_doi = hepdata.modules.records.utils.doi_minter',
             'hepdata_mail = hepdata.modules.email.utils',
             'hepdata_conversion = hepdata.modules.converter.tasks',

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ tests_require = [
     'pytest-flask>=1.0.0',
     'pytest-mock>=3.1.0',
     'pytest-timeout>=1.4.2',
+    'requests-mock>=1.8.0',
     'selenium>=3.141.0'
 ]
 

--- a/tests/importer_test.py
+++ b/tests/importer_test.py
@@ -24,11 +24,17 @@
 """HEPData importer test cases."""
 import datetime
 import logging
+import os
+from unittest.mock import call
 
 import requests
 import requests_mock
 
-from hepdata.modules.records.importer.api import get_inspire_ids
+from hepdata.modules.records.importer.api import get_inspire_ids, \
+    _import_record, import_records
+from hepdata.modules.records.utils.common import get_record_by_id
+from hepdata.modules.submission.api import get_latest_hepsubmission
+from hepdata.modules.submission.models import HEPSubmission, DataSubmission
 
 
 def test_get_inspire_ids(caplog):
@@ -103,3 +109,104 @@ def test_get_inspire_ids(caplog):
         assert caplog.records[0].levelname == "ERROR"
         assert caplog.records[0].msg == \
             "Unexpected response from https://hepdata.net/search/ids?inspire_ids=true: 3"
+
+
+def test_import_record(app):
+    all_submissions = HEPSubmission.query.all()
+    assert len(all_submissions) == 0
+    data_submissions = DataSubmission.query.all()
+    assert len(data_submissions) == 0
+
+    # Import a record and check it's been added to the db
+    inspire_id = '1824424'
+    result = _import_record(inspire_id)
+    assert result is True
+
+    all_submissions = HEPSubmission.query.all()
+    assert len(all_submissions) == 1
+    hep_submission = all_submissions[0]
+    assert hep_submission.publication_recid == 1
+    assert hep_submission.inspire_id == inspire_id
+    assert hep_submission.overall_status == 'finished'
+    last_updated = hep_submission.last_updated
+
+    record = get_record_by_id(1)
+    assert record['title'] == 'Measurement of the production cross section of 31 GeV/$c$ protons on carbon via beam attenuation in a 90-cm-long target'
+    assert record['inspire_id'] == inspire_id
+    assert record['abstract'].startswith('The production cross section of 30.92 GeV/$c$ protons on carbon is measured by')
+
+    data_submissions = DataSubmission.query.all()
+    assert len(data_submissions) == 2
+
+    # Try the import again - should not update
+    result = _import_record(inspire_id)
+    assert result is False
+
+    # Retry with update_existing=True
+    result = _import_record(inspire_id, update_existing=True)
+    assert result is True
+    updated_submission = get_latest_hepsubmission(publication_recid=1)
+    assert updated_submission.last_updated > last_updated
+
+    # Try an old inspire id which uses the old schema
+    old_inspire_id = '944937'
+    result = _import_record(old_inspire_id)
+    assert result is True
+    all_submissions = HEPSubmission.query.all()
+    assert len(all_submissions) == 2
+    data_submissions = DataSubmission.query.all()
+    assert len(data_submissions) == 3
+    record = get_record_by_id(all_submissions[1].publication_recid)
+    assert record['title'] == 'The Production of Charged Photomesons from Deuterium and Hydrogen. I'
+    assert record['inspire_id'] == old_inspire_id
+    assert record['abstract'].startswith('Hydrogen and deuterium gases have been bombarded in a gas target at a temperature of 77°K')
+
+    # Try an invalid inspire id
+    assert _import_record('thisisinvalid') is False
+
+    # Mock errors with download
+    with requests_mock.Mocker(real_http=True) as mock:
+        # 404
+        mock.get('https://hepdata.net/download/submission/ins{0}/original'.format(inspire_id),
+                 status_code=404)
+        result = _import_record(inspire_id, update_existing=True)
+        assert result is False
+
+        # Text not zip
+        mock.get('https://hepdata.net/download/submission/ins{0}/original'.format(inspire_id),
+                 text='This is not a zip')
+        result = _import_record(inspire_id, update_existing=True)
+        assert result is False
+
+        # SocketError
+        mock.get('https://hepdata.net/download/submission/ins{0}/original'.format(inspire_id),
+                 exc=requests.exceptions.ConnectTimeout("mock error message"))
+        result = _import_record(inspire_id, update_existing=True)
+        assert result is False
+
+        # Send an invalid zip
+        base_dir = os.path.dirname(os.path.realpath(__file__))
+        file_path = os.path.join(base_dir, 'test_data/submission_invalid_symlink.tgz')
+        with open(file_path, 'rb') as f:
+            mock.get('https://hepdata.net/download/submission/ins{0}/original'.format(inspire_id),
+                     headers={'content-type': 'application/zip'}, body=f)
+            result = _import_record(inspire_id, update_existing=True)
+            assert result is False
+
+
+def test_import_records(mocker):
+    # Patch the _import_record function as it's tested elsewhere
+    m = mocker.patch('hepdata.modules.records.importer.api._import_record')
+    import_records(['ins12345', '67890'], synchronous=True)
+    expected_args = [
+        call('12345', base_url='https://hepdata.net', update_existing=False),
+        call('67890', base_url='https://hepdata.net', update_existing=False),
+    ]
+    assert m.call_count == 2
+    assert m.call_args_list == expected_args
+
+    m.reset_mock()
+    import_records(['ins54321'], base_url='https://localhost:5000',
+                   update_existing=True, synchronous=True)
+    m.assert_called_once_with('54321', base_url='https://localhost:5000',
+                              update_existing=True)

--- a/tests/importer_test.py
+++ b/tests/importer_test.py
@@ -1,0 +1,105 @@
+#
+# This file is part of HEPData.
+# Copyright (C) 2021 CERN.
+#
+# HEPData is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# HEPData is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with HEPData; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""HEPData importer test cases."""
+import datetime
+import logging
+
+import requests
+import requests_mock
+
+from hepdata.modules.records.importer.api import get_inspire_ids
+
+
+def test_get_inspire_ids(caplog):
+    caplog.set_level(logging.ERROR)
+    dummy_ids = list(range(5))
+
+    # Use requests_mock to mock the responses from hepdata.net.
+    # Setting complete_qs=True means the mocker will only respond
+    # if the entire URL including query string is correct
+    with requests_mock.Mocker() as mock:
+        # Test basic call just returns the ids directly from the response
+        mock.get('https://hepdata.net/search/ids?inspire_ids=true',
+                 json=dummy_ids, complete_qs=True)
+        ids = get_inspire_ids()
+        assert ids == dummy_ids
+
+        # Test last_updated is passed correctly to URL
+        mock.get('https://hepdata.net/search/ids?inspire_ids=true&last_updated=2019-12-31',
+                 json=dummy_ids, complete_qs=True)
+        ids = get_inspire_ids(last_updated=datetime.date(2019, 12, 31))
+        assert ids == dummy_ids
+
+        # Test limiting number of responses uses sort_by and restricts the results
+        # returned
+        mock.get('https://hepdata.net/search/ids?inspire_ids=true&sort_by=latest',
+                 json=dummy_ids, complete_qs=True)
+        ids = get_inspire_ids(n_latest=2)
+        assert ids == dummy_ids[:2]
+
+        # Test 404 response
+        mock.get('https://hepdata.net/search/ids?inspire_ids=true',
+                 complete_qs=True, status_code=404)
+        ids = get_inspire_ids()
+        assert ids is False
+        assert len(caplog.records) == 2
+        assert all([r.levelname == "ERROR" for r in caplog.records])
+        assert caplog.records[0].msg == \
+            "Unable to retrieve data from https://hepdata.net/search/ids?inspire_ids=true: 404 Not Found"
+        assert caplog.records[1].msg == "Aborting."
+
+        # Test connection error response
+        caplog.clear()
+        mock.get('https://hepdata.net/search/ids?inspire_ids=true',
+                 complete_qs=True, exc=requests.exceptions.ConnectTimeout("mock error message"))
+        ids = get_inspire_ids()
+        assert ids is False
+        assert len(caplog.records) == 3
+        assert all([r.levelname == "ERROR" for r in caplog.records])
+        assert caplog.records[0].msg == \
+            "Unable to retrieve data from https://hepdata.net/search/ids?inspire_ids=true: "
+        assert caplog.records[1].msg == "Socket error: mock error message."
+        assert caplog.records[2].msg == "Aborting."
+
+        # Test bad data response (not json)
+        caplog.clear()
+        mock.get('https://hepdata.net/search/ids?inspire_ids=true',
+                 text="this is not valid json", complete_qs=True)
+        ids = get_inspire_ids()
+        assert ids is False
+        assert len(caplog.records) == 1
+        assert caplog.records[0].levelname == "ERROR"
+        assert caplog.records[0].msg == \
+            "Unexpected response from https://hepdata.net/search/ids?inspire_ids=true: this is not valid json"
+
+        # Test bad data response (not iterable)
+        caplog.clear()
+        mock.get('https://hepdata.net/search/ids?inspire_ids=true',
+                 json=3, complete_qs=True)
+        ids = get_inspire_ids()
+        assert ids is False
+        assert len(caplog.records) == 1
+        assert caplog.records[0].levelname == "ERROR"
+        assert caplog.records[0].msg == \
+            "Unexpected response from https://hepdata.net/search/ids?inspire_ids=true: 3"

--- a/tests/test_data/test_v0_submission/Table1.yaml
+++ b/tests/test_data/test_v0_submission/Table1.yaml
@@ -1,0 +1,18 @@
+dependent_variables:
+- header: {name: POL(NAME=RECOIL)}
+  qualifiers:
+  - {name: RE, value: GAMMA P --> PI0 P}
+  - {name: SQRT(S), units: GeV, value: 1.383-1.481}
+  - {name: THETA, units: deg, value: '90.0'}
+  values:
+  - errors:
+    - {symerror: 0.12}
+    value: -0.3
+  - errors:
+    - {symerror: 0.06}
+    value: -0.59
+independent_variables:
+- header: {name: E, units: MEV}
+  values:
+  - {value: 550.0}
+  - {value: 700.0}

--- a/tests/test_data/test_v0_submission/submission.yaml
+++ b/tests/test_data/test_v0_submission/submission.yaml
@@ -1,0 +1,22 @@
+comment: |
+  THE RECOIL PROTONS WERE SCATTERED IN CARBON AND DETECTED IN A COUNTER TELESCOPE IN COINCIDENCE WITH A GAMMA FROM PI0 DECAY. THE SIGN CONVENTION HAS BEEN CHANGED. NO SYTEMATIC ERRORS ARE GIVEN.
+dateupdated: 01/01/1970 00:00:00
+hepdata_doi: 10.17182/hepdata.21754.v1
+modifications:
+- {action: Encoded, date: 'null', who: PRS}
+record_ids:
+- {id: 944911, type: inspire}
+---
+data_file: Table1.yaml
+description: No description provided.
+keywords:
+- name: reactions
+  values: [GAMMA P --> PI0 P]
+- name: observables
+  values: [POL]
+- name: phrases
+  values: [Exclusive, Polarization, Photoproduction]
+- name: cmenergies
+  values: [1.383-1.481]
+name: Table 1
+table_doi: 10.17182/hepdata.21754.v1/t1


### PR DESCRIPTION
I've created a new `importer` module and cli group. (See comment on #275 for CLI commands.)

In order to import some of the older submissions from hepdata.net I needed to add an option to create a submission validator which uses the v0.1 schema.

Fixes #275 