### PR TITLE
Reset failed submissions and make celery retry tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
         cd -
         cp hepdata/config_local.gh.py hepdata/config_local.py
     - name: Setup Sauce Connect
-      uses: saucelabs/sauce-connect-action@master
+      uses: saucelabs/sauce-connect-action@v1
       with:
         username: ${{ secrets.SAUCE_USERNAME }}
         accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}

--- a/hepdata/config.py
+++ b/hepdata/config.py
@@ -77,7 +77,14 @@ CELERY_BEAT_SCHEDULE = {
     },
 }
 
-CELERY_TASK_ANNOTATIONS = {'*': {'acks_late': True, 'reject_on_worker_lost': True, 'autoretry_for': (Exception,)}}
+CELERY_TASK_ANNOTATIONS = {
+    '*': {
+        'acks_late': True,
+        'reject_on_worker_lost': True,
+        'autoretry_for': (Exception,),
+        'default_retry_delay': 30
+    }
+}
 
 # Cache
 CACHE_KEY_PREFIX = "cache::"

--- a/hepdata/config.py
+++ b/hepdata/config.py
@@ -77,6 +77,15 @@ CELERY_BEAT_SCHEDULE = {
     },
 }
 
+class Annotator:
+    def annotate(self, task):
+        if task.acks_late:
+            # avoid failing tasks when worker gets killed
+            return {"reject_on_worker_lost": True}
+
+
+CELERY_TASK_ANNOTATIONS = [Annotator()]
+
 # Cache
 CACHE_KEY_PREFIX = "cache::"
 CACHE_REDIS_URL = "redis://localhost:6379/0"

--- a/hepdata/config.py
+++ b/hepdata/config.py
@@ -77,14 +77,7 @@ CELERY_BEAT_SCHEDULE = {
     },
 }
 
-class Annotator:
-    def annotate(self, task):
-        if task.acks_late:
-            # avoid failing tasks when worker gets killed
-            return {"reject_on_worker_lost": True}
-
-
-CELERY_TASK_ANNOTATIONS = [Annotator()]
+CELERY_TASK_ANNOTATIONS = {'*': {'acks_late': True, 'reject_on_worker_lost': True, 'autoretry_for': (Exception,)}}
 
 # Cache
 CACHE_KEY_PREFIX = "cache::"

--- a/hepdata/modules/records/api.py
+++ b/hepdata/modules/records/api.py
@@ -383,7 +383,7 @@ def process_payload(recid, file, redirect_url, synchronous=False):
                         " (or a .oldhepdata or single .yaml or .yaml.gz file)."}), 400
 
 
-@shared_task(autoretry_for=(Exception,), retry_kwargs={'max_retries': 3})
+@shared_task
 def process_saved_file(file_path, recid, userid, redirect_url, previous_status):
     try:
         hepsubmission = get_latest_hepsubmission(publication_recid=recid)

--- a/hepdata/modules/records/api.py
+++ b/hepdata/modules/records/api.py
@@ -469,7 +469,7 @@ def process_saved_file(file_path, recid, userid, redirect_url, previous_status):
                 db.session.commit()
 
             except Exception as ex:
-                log.error("Exception while cleaning up: " % ex)
+                log.error("Exception while cleaning up: %s" % ex)
 
         else:
             log.debug("Celery will retry task, attempt %s" % process_saved_file.request.retries)

--- a/hepdata/modules/records/api.py
+++ b/hepdata/modules/records/api.py
@@ -624,6 +624,7 @@ def check_and_convert_from_oldhepdata(input_directory, id, timestamp):
 def move_files(submission_temp_path, submission_path):
     print('Copying files from {} to {}'.format(submission_temp_path + '/.', submission_path))
     try:
+        shutil.rmtree(submission_path, ignore_errors=True)
         shutil.copytree(submission_temp_path, submission_path, symlinks=False)
     except shutil.Error as e:
         errors = []

--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20210224"
+__version__ = "0.9.4dev20210301"

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ Flask-Cors==3.0.2
 Flask-Login==0.3.2
 gevent==1.4.0
 gunicorn==19.5.0
-hepdata-converter-ws-client==0.2.1
+hepdata-converter-ws-client==0.2.2
 hepdata-validator==0.2.3
 idna<2.8,>=2.5             # Indirect ('invenio-search', 'email-validator')
 invenio-access==1.0.2      # Indirect (needed by invenio-admin)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Babel==2.3.4
 beautifulsoup4==4.5.1
 bleach==3.3.0
-celery==4.4.0
+celery==4.4.6
 click==7.1.1
 datacite==1.0.1
 elasticsearch==7.1.0


### PR DESCRIPTION
Celery will now retry failed tasks 3 times before giving up.

If there's an error in `process_failed_submissions` we now reset the submission status to the previous status and send an error email, unless celery is about to retry the task.

I've tested locally by raising an Exception at the start of `process_zip_archive` to cause a submission to fail, then removing that line before the retry.

Fixes #248.
Fixes #266.