### PR TITLE
Relax check on converter payload size and replace zipdir with make_archive

### DIFF
--- a/hepdata/config.py
+++ b/hepdata/config.py
@@ -24,6 +24,7 @@
 
 import copy
 import os
+import sys
 import tempfile
 from celery.schedules import crontab
 from datetime import timedelta
@@ -152,8 +153,9 @@ SEARCH_ELASTIC_HOSTS = [
 
 SEARCH_AUTOINDEX = []
 
-UPLOAD_MAX_SIZE = 52000000 # Upload limit in bytes
-NGINX_TIMEOUT = 298 # Client-side timeout in s (should be slightly smaller than server timeout)
+UPLOAD_MAX_SIZE = 52000000  # Upload limit in bytes
+CONVERT_MAX_SIZE = sys.maxsize  # Limit on payload sent to converter (checked at submission)
+CLIENT_TIMEOUT = 298  # Client-side timeout in s (should be slightly smaller than server timeout)
 
 CFG_PUB_TYPE = 'publication'
 CFG_DATA_TYPE = 'datatable'
@@ -162,7 +164,7 @@ CFG_DATA_KEYWORDS = ['observables', 'reactions', 'cmenergies', 'phrases']
 
 CFG_CONVERTER_URL = 'https://converter.hepdata.net'
 CFG_SUPPORTED_FORMATS = ['yaml', 'root', 'csv', 'yoda', 'original']
-CFG_CONVERTER_TIMEOUT = NGINX_TIMEOUT # timeout in seconds
+CFG_CONVERTER_TIMEOUT = CLIENT_TIMEOUT # timeout in seconds
 
 CFG_TMPDIR = tempfile.gettempdir()
 CFG_DATADIR = tempfile.gettempdir()

--- a/hepdata/modules/records/api.py
+++ b/hepdata/modules/records/api.py
@@ -26,7 +26,6 @@
 import os
 from collections import OrderedDict
 from functools import wraps
-import subprocess
 
 import time
 from celery import shared_task

--- a/hepdata/modules/records/utils/common.py
+++ b/hepdata/modules/records/utils/common.py
@@ -140,21 +140,6 @@ def decode_string(string, type="utf-8"):
         return string
 
 
-def zipdir(path, ziph):
-    """
-    From `Stack Overflow
-    <http://stackoverflow.com/questions/1855095/how-to-create-a-zip-archive-of-a-directory?answertab=active#tab-top>`_.
-
-    :param path:
-    :param ziph:
-    :return:
-    """
-    # ziph is zipfile handle
-    for root, dirs, files in os.walk(path):
-        for file in files:
-            ziph.write(os.path.join(root, file))
-
-
 def get_license(license_obj):
     dict = {}
     for field in ["name", "url", "description"]:

--- a/hepdata/modules/records/utils/submission.py
+++ b/hepdata/modules/records/utils/submission.py
@@ -585,11 +585,11 @@ def process_submission_directory(basepath, submission_file_path, recid,
                     'rivet_analysis_name': f'ATLAS_2020_I{dummy_inspire_id}'
                 }
                 data_size = get_data_size(input_directory, options)
-                if data_size > current_app.config['UPLOAD_MAX_SIZE']:
+                if data_size > current_app.config['CONVERT_MAX_SIZE']:
                     errors["Archive"] = [{
                         "level": "error",
                         "message": "Archive is too big for conversion to other formats. (%s bytes would be sent to converter; maximum size is %s.)"
-                                   % (data_size, current_app.config['UPLOAD_MAX_SIZE'])
+                                   % (data_size, current_app.config['CONVERT_MAX_SIZE'])
                     }]
 
             if len(errors) == 0:

--- a/hepdata/modules/records/utils/submission.py
+++ b/hepdata/modules/records/utils/submission.py
@@ -24,9 +24,9 @@
 
 import json
 import logging
-import zipfile
 from datetime import datetime
 from dateutil.parser import parse
+import shutil
 
 from elasticsearch import NotFoundError, ConnectionTimeout
 from flask import current_app
@@ -44,9 +44,9 @@ from hepdata.modules.permissions.models import SubmissionParticipant
 from hepdata.modules.records.utils.workflow import create_record
 from hepdata.modules.submission.api import get_latest_hepsubmission
 from hepdata.modules.submission.models import DataSubmission, DataReview, \
-    DataResource, License, Keyword, HEPSubmission, RecordVersionCommitMessage
+    DataResource, Keyword, HEPSubmission, RecordVersionCommitMessage
 from hepdata.modules.records.utils.common import \
-    get_license, infer_file_type, encode_string, zipdir, get_record_by_id, contains_accepted_url
+    get_license, infer_file_type, get_record_by_id, contains_accepted_url
 from hepdata.modules.records.utils.common import get_or_create
 from hepdata.modules.records.utils.data_files import get_data_path_for_record, \
     cleanup_old_files, delete_all_files, delete_packaged_file, \
@@ -634,15 +634,11 @@ def package_submission(basepath, recid, hep_submission_obj):
     if os.path.exists(zip_location):
         os.remove(zip_location)
 
-    zipf = zipfile.ZipFile(zip_location, 'w')
-    os.chdir(basepath)
     try:
-        zipdir(".", zipf)
+        shutil.make_archive(os.path.splitext(zip_location)[0], 'zip', basepath)
         return {}
     except Exception as e:
         return {zip_location: [{"level": "error", "message": str(e)}]}
-    finally:
-        zipf.close()
 
 
 def process_validation_errors_for_display(errors):

--- a/hepdata/modules/records/utils/yaml_utils.py
+++ b/hepdata/modules/records/utils/yaml_utils.py
@@ -26,7 +26,6 @@
 
 import os
 
-from hepdata.modules.records.utils.common import zipdir
 from hepdata.modules.records.utils.data_processing_utils import str_presenter
 import shutil
 import yaml
@@ -48,13 +47,10 @@ def write_submission_yaml_block(document, submission_yaml,
     submission_yaml.write("\n")
 
 
-def split_files(file_location, output_location,
-                archive_location=None):
+def split_files(file_location, output_location):
     """
     :param file_location: input yaml file location
     :param output_location: output directory path
-    :param archive_location: if present will create a zipped
-           representation of the split files
     """
     last_updated = datetime.utcnow()
     try:
@@ -102,18 +98,6 @@ def split_files(file_location, output_location,
                                                 submission_yaml,
                                                 type="record")
 
-        if archive_location:
-            if os.path.exists(archive_location):
-                os.remove(archive_location)
-
-            zipf = zipfile.ZipFile(archive_location, 'w')
-            os.chdir(output_location)
-            try:
-                zipdir(".", zipf)
-            except Exception as e:
-                return e, last_updated
-            finally:
-                zipf.close()
     except yaml.scanner.ScannerError as se:
         return se, last_updated
     except yaml.parser.ParserError as pe:

--- a/hepdata/resilient_requests.py
+++ b/hepdata/resilient_requests.py
@@ -6,9 +6,9 @@ import requests
 
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
-from hepdata.config import NGINX_TIMEOUT
+from hepdata.config import CLIENT_TIMEOUT
 
-DEFAULT_TIMEOUT = NGINX_TIMEOUT  # seconds
+DEFAULT_TIMEOUT = CLIENT_TIMEOUT  # seconds
 TOTAL_RETRIES = 8
 
 

--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20210301"
+__version__ = "0.9.4dev20210309"

--- a/tests/records_test.py
+++ b/tests/records_test.py
@@ -52,6 +52,7 @@ from hepdata.modules.submission.api import get_latest_hepsubmission
 from tests.conftest import TEST_EMAIL
 from hepdata.modules.records.utils.records_update_utils import get_inspire_records_updated_since, get_inspire_records_updated_on, update_record_info
 from hepdata.modules.inspire_api.views import get_inspire_record_information
+from hepdata.config import CFG_TMPDIR
 
 
 def test_record_creation(app):
@@ -357,7 +358,7 @@ def test_process_zip_archive_invalid(app):
     # Test uploading a zip containing broken symlinks
     base_dir = os.path.dirname(os.path.realpath(__file__))
     file_path = os.path.join(base_dir, 'test_data/submission_invalid_symlink.tgz')
-    tmp_path = tempfile.mkdtemp()
+    tmp_path = tempfile.mkdtemp(dir=CFG_TMPDIR)
     shutil.copy2(file_path, tmp_path)
     tmp_file_path = os.path.join(tmp_path, 'submission_invalid_symlink.tgz')
     errors = process_zip_archive(tmp_file_path, 1)
@@ -373,7 +374,7 @@ def test_process_zip_archive_invalid(app):
 
     # Test uploading an invalid tarfile (real example: user ran 'tar -czvf' then 'gzip')
     file_path = os.path.join(base_dir, 'test_data/submission_invalid_tarfile.tgz.gz')
-    tmp_path = tempfile.mkdtemp()
+    tmp_path = tempfile.mkdtemp(dir=CFG_TMPDIR)
     shutil.copy2(file_path, tmp_path)
     tmp_file_path = os.path.join(tmp_path, 'submission_invalid_tarfile.tgz.gz')
     errors = process_zip_archive(tmp_file_path, 1)
@@ -386,7 +387,7 @@ def test_process_zip_archive_invalid(app):
 
 
 def test_move_files_invalid_path():
-    errors = move_files('this_is_not_a_real_path', tempfile.mkdtemp())
+    errors = move_files('this_is_not_a_real_path', tempfile.mkdtemp(dir=CFG_TMPDIR))
     assert("Exceptions when copying files" in errors)
     assert(len(errors["Exceptions when copying files"]) == 1)
     assert(errors["Exceptions when copying files"][0].get("level") == "error")
@@ -423,7 +424,7 @@ def test_update_record_info(app):
         # Process the files to create DataSubmission tables in the DB.
         base_dir = os.path.dirname(os.path.realpath(__file__))
         directory = os.path.join(base_dir, 'test_data/test_submission')
-        tmp_path = os.path.join(tempfile.mkdtemp(), 'test_submission')
+        tmp_path = os.path.join(tempfile.mkdtemp(dir=CFG_TMPDIR), 'test_submission')
         shutil.copytree(directory, tmp_path)
         process_submission_directory(tmp_path, os.path.join(tmp_path, 'submission.yaml'),
                                      submission.publication_recid)

--- a/tests/submission_test.py
+++ b/tests/submission_test.py
@@ -268,7 +268,7 @@ def test_submission_too_big(app, mocker):
 
     # Patch the app config to reduce the max upload size
     mocker.patch.dict('flask.current_app.config',
-                      {'UPLOAD_MAX_SIZE': 1000})
+                      {'CONVERT_MAX_SIZE': 1000})
 
     test_directory = os.path.join(base_dir, 'test_data/test_submission')
     errors = process_submission_directory(


### PR DESCRIPTION
This PR follows on from issue #304 addressed by PR #313.  The [Kubernetes configuration](https://github.com/inspirehep/kubernetes) for the CERN deployment is moving from the [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/) to the [HAProxy Ingress Controller](https://www.haproxy.com/documentation/kubernetes/latest/).  The latter does not have an equivalent of the NGINX `client-max-body-size=50m` restriction, therefore we do not need to make the check on converter payload size.  We can keep the code making the check in case it's needed in future, but I've introduced a new config variable `CONVERT_MAX_SIZE` set to `sys.maxsize` so that the check is effectively relaxed.  I think we should keep `UPLOAD_MAX_SIZE` at 50 MB even although it's no longer a server restriction.  We don't want to allow arbitrary-size uploads, but `UPLOAD_MAX_SIZE` can be slightly increased if needed in future.  I've renamed `NGINX_TIMEOUT ` as `CLIENT_TIMEOUT` given that the Kubernetes cluster is no longer using NGINX.

I've also removed the `zipdir` function and replaced it with the Python [shutil.make_archive](https://docs.python.org/3/library/shutil.html#shutil.make_archive) function which compresses by default unlike [zipfile.ZipFile](https://docs.python.org/3/library/zipfile.html#zipfile.ZipFile).  This helps avoid the situation described in issue #304 where a 49 MB compressed tar file could be uploaded, but the stored zip file was 52 MB, meaning it could not be downloaded and directly re-uploaded.  The `zipdir` function was also used in `split_files` if the optional `archive_location` argument was specified.  However, `split_files` is only called once in the code *without* the `archive_location` argument.  I've therefore removed the `archive_location` argument from `split_files`.  The use of `make_archive` removes the need for `os.chdir` and therefore I think this PR also closes #319.

Finally, I've specified `dir=CFG_TMPDIR` as an argument of `tempfile.mkdtemp` in `tests/records_test.py` (see a previous [review comment](https://github.com/HEPData/hepdata/pull/313#discussion_r581820073)).