### PR TITLE
Check file size less than UPLOAD_MAX_SIZE

### DIFF
--- a/hepdata/config.py
+++ b/hepdata/config.py
@@ -155,6 +155,7 @@ SEARCH_ELASTIC_HOSTS = [
 SEARCH_AUTOINDEX = []
 
 UPLOAD_MAX_SIZE = 52000000  # Upload limit in bytes
+MAX_CONTENT_LENGTH = UPLOAD_MAX_SIZE  # Flask: don’t read more than this many bytes from the incoming request data
 CONVERT_MAX_SIZE = sys.maxsize  # Limit on payload sent to converter (checked at submission)
 CLIENT_TIMEOUT = 298  # Client-side timeout in s (should be slightly smaller than server timeout)
 

--- a/hepdata/modules/records/api.py
+++ b/hepdata/modules/records/api.py
@@ -370,6 +370,13 @@ def process_payload(recid, file, redirect_url, synchronous=False):
 
     if file and (allowed_file(file.filename)):
         file_path = save_zip_file(file, recid)
+        file_size = os.path.getsize(file_path)
+        UPLOAD_MAX_SIZE = current_app.config.get('UPLOAD_MAX_SIZE', 52000000)
+        if file_size > UPLOAD_MAX_SIZE:
+            return jsonify({"message":
+                "{} too large ({} bytes > {} bytes)".format(
+                    file.filename, file_size, UPLOAD_MAX_SIZE)}), 413
+
         hepsubmission = get_latest_hepsubmission(publication_recid=recid)
 
         if hepsubmission.overall_status == 'finished':

--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20210309"
+__version__ = "0.9.4dev20210420"


### PR DESCRIPTION
I've [increased](https://github.com/HEPData/hepdata-cli/commit/e5462ac96212e534f7c4807d80a28fcb1187efd9) the `DEFAULT_TIMEOUT` for the `hepdata-cli` package to allow for the increased request timeout in the Kubernetes settings from 1 minute to 5 minutes.  I've also [added](https://github.com/HEPData/hepdata-cli/commit/fc29cb597570ac5734e4794f012ac8a4b2a45858) a check to the `hepdata-cli` code that the uploaded file size does not exceed `UPLOAD_MAX_SIZE`.  However, this limit could easily be modified in client-side code, so the check should also be made in the server-side code.  Currently, we only make the `UPLOAD_MAX_SIZE` check for web uploads and not for CLI uploads.  This PR modifies `process_payload` to make the check for both.  Alternatively, the Flask [MAX_CONTENT_LENGTH](https://flask.palletsprojects.com/en/1.1.x/patterns/fileuploads/#improving-uploads) could be set, but this did not return an informative error message when I tried it.  I've written a new test `test_upload_max_size` in `tests/records_test.py`.  