### PR TITLE
Correct download links if processed_name passed in URL instead of original table name

### DIFF
--- a/hepdata/config_local.gh.py
+++ b/hepdata/config_local.gh.py
@@ -1,2 +1,3 @@
 TESTING = True
 APP_ENABLE_SECURE_HEADERS = False
+SITE_URL = "http://localhost:5000"

--- a/hepdata/ext/elasticsearch/api.py
+++ b/hepdata/ext/elasticsearch/api.py
@@ -142,7 +142,7 @@ def search(query,
     if query:
         data_search = data_search.query(QueryString(query=query))
 
-    data_search = data_search[0:size*50]
+    data_search = data_search[0:size*100]
     data_result = data_search.execute().to_dict()
 
     merged_results = merge_results(pub_result, data_result)

--- a/hepdata/ext/elasticsearch/document_enhancers.py
+++ b/hepdata/ext/elasticsearch/document_enhancers.py
@@ -61,8 +61,6 @@ def add_data_table_urls(doc):
     for format in FORMATS:
 
         _cleaned_table_name = doc['title'].replace('%', '%25').replace('\\', '%5C')
-        if re.match('^Table \d+$', _cleaned_table_name):
-            _cleaned_table_name = _cleaned_table_name.replace('Table ', 'Table')
 
         doc['access_urls']['links'][format] = '{0}/download/table/ins{1}/{2}/{3}'.format(
             current_app.config.get('SITE_URL', 'https://www.hepdata.net'),

--- a/hepdata/modules/converter/views.py
+++ b/hepdata/modules/converter/views.py
@@ -383,10 +383,13 @@ def download_data_table_by_inspire_id(*args, **kwargs):
             ).one()
         except NoResultFound:
             if ' ' not in table_name:
-                # Allow space in table_name to be omitted from URL.
-                table_name = table_name.replace('Table', 'Table ')
+                # Allow spaces in table_name to be omitted from URL.
                 try:
-                    datasubmission = DataSubmission.query.filter_by(publication_inspire_id=inspire_id, version=version, name=table_name).one()
+                    datasubmission = DataSubmission.query.filter(
+                        DataSubmission.publication_inspire_id == inspire_id,
+                        DataSubmission.version == version,
+                        func.replace(DataSubmission.name, ' ', '') == table_name
+                    ).one()
                 except NoResultFound:
                     pass
 
@@ -447,10 +450,13 @@ def download_data_table_by_recid(*args, **kwargs):
             ).one()
         except NoResultFound:
             if ' ' not in table_name:
-                # Allow space in table_name to be omitted from URL.
-                table_name = table_name.replace('Table', 'Table ')
+                # Allow spaces in table_name to be omitted from URL.
                 try:
-                    datasubmission = DataSubmission.query.filter_by(publication_recid=recid, version=version,name=table_name).one()
+                    datasubmission = DataSubmission.query.filter(
+                        DataSubmission.publication_recid == recid,
+                        DataSubmission.version == version,
+                        func.replace(DataSubmission.name, ' ', '') == table_name
+                    ).one()
                 except NoResultFound:
                     pass
 

--- a/hepdata/modules/converter/views.py
+++ b/hepdata/modules/converter/views.py
@@ -434,23 +434,15 @@ def download_data_table_by_recid(*args, **kwargs):
         datasubmission = DataSubmission.query.filter_by(publication_recid=recid, version=version, name=table_name).one()
     except NoResultFound:
         try:
-            # Try again with '$' signs removed from table name.
-            datasubmission = DataSubmission.query.filter(
-                DataSubmission.publication_recid == recid,
-                DataSubmission.version == version,
-                func.replace(DataSubmission.name, '$', '') == table_name
-            ).one()
-        except NoResultFound:
             if ' ' not in table_name:
                 # Allow spaces in table_name to be omitted from URL.
-                try:
-                    datasubmission = DataSubmission.query.filter(
-                        DataSubmission.publication_recid == recid,
-                        DataSubmission.version == version,
-                        func.replace(DataSubmission.name, ' ', '') == table_name
-                    ).one()
-                except NoResultFound:
-                    pass
+                datasubmission = DataSubmission.query.filter(
+                    DataSubmission.publication_recid == recid,
+                    DataSubmission.version == version,
+                    func.replace(DataSubmission.name, ' ', '') == table_name
+                ).one()
+        except NoResultFound:
+            pass
 
     if not datasubmission:
         return display_error(

--- a/hepdata/modules/converter/views.py
+++ b/hepdata/modules/converter/views.py
@@ -433,16 +433,16 @@ def download_data_table_by_recid(*args, **kwargs):
     try:
         datasubmission = DataSubmission.query.filter_by(publication_recid=recid, version=version, name=table_name).one()
     except NoResultFound:
-        try:
-            if ' ' not in table_name:
+        if ' ' not in table_name:
+            try:
                 # Allow spaces in table_name to be omitted from URL.
                 datasubmission = DataSubmission.query.filter(
                     DataSubmission.publication_recid == recid,
                     DataSubmission.version == version,
                     func.replace(DataSubmission.name, ' ', '') == table_name
                 ).one()
-        except NoResultFound:
-            pass
+            except NoResultFound:
+                pass
 
     if not datasubmission:
         return display_error(

--- a/hepdata/modules/converter/views.py
+++ b/hepdata/modules/converter/views.py
@@ -374,24 +374,16 @@ def download_data_table_by_inspire_id(*args, **kwargs):
     try:
         datasubmission = DataSubmission.query.filter_by(publication_inspire_id=inspire_id, version=version, name=table_name).one()
     except NoResultFound:
-        try:
-            # Try again with $ signs removed from table name.
-            datasubmission = DataSubmission.query.filter(
-                DataSubmission.publication_inspire_id == inspire_id,
-                DataSubmission.version == version,
-                func.replace(DataSubmission.name, '$', '') == table_name
-            ).one()
-        except NoResultFound:
-            if ' ' not in table_name:
-                # Allow spaces in table_name to be omitted from URL.
-                try:
-                    datasubmission = DataSubmission.query.filter(
-                        DataSubmission.publication_inspire_id == inspire_id,
-                        DataSubmission.version == version,
-                        func.replace(DataSubmission.name, ' ', '') == table_name
-                    ).one()
-                except NoResultFound:
-                    pass
+        if ' ' not in table_name:
+            # Allow spaces in table_name to be omitted from URL.
+            try:
+                datasubmission = DataSubmission.query.filter(
+                    DataSubmission.publication_inspire_id == inspire_id,
+                    DataSubmission.version == version,
+                    func.replace(DataSubmission.name, ' ', '') == table_name
+                ).one()
+            except NoResultFound:
+                pass
 
     if not datasubmission:
         return display_error(

--- a/hepdata/modules/records/api.py
+++ b/hepdata/modules/records/api.py
@@ -183,11 +183,29 @@ def format_tables(ctx, data_record_query, data_table, recid):
         ctx, data_record_query, first_data_id, data_table)
     assign_or_create_review_status(data_table_metadata, recid, ctx["version"])
     ctx['watched'] = is_current_user_subscribed_to_record(recid)
-    ctx['table_to_show'] = first_data_id
+    ctx['table_id_to_show'] = first_data_id
+    ctx['table_name_to_show'] = ''
+    ctx['data_tables'] = list(data_table_metadata.values())
     if 'table' in request.args:
         if request.args['table']:
-            ctx['table_to_show'] = request.args['table']
-    ctx['data_tables'] = list(data_table_metadata.values())
+            ctx['table_name_to_show'] = request.args['table']
+            # Check for table name in list of data tables.
+            matching_tables = list(filter(
+                lambda data_table: data_table['name'] == ctx['table_name_to_show'],
+                ctx['data_tables']))
+            if not matching_tables:
+                # Check for processed table name in list of data tables.
+                matching_tables = list(filter(
+                    lambda data_table: data_table['processed_name'] == ctx['table_name_to_show'],
+                    ctx['data_tables']))
+            if matching_tables:
+                # Set table ID and name to the first matching table.
+                ctx['table_id_to_show'] = matching_tables[0]['id']
+                ctx['table_name_to_show'] = matching_tables[0]['name']
+            elif ctx['data_tables']:
+                # Otherwise just set the table ID and name to the first table.
+                ctx['table_id_to_show'] = ctx['data_tables'][0]['id']
+                ctx['table_name_to_show'] = ctx['data_tables'][0]['name']
 
 
 def get_commit_message(ctx, recid):

--- a/hepdata/modules/records/api.py
+++ b/hepdata/modules/records/api.py
@@ -183,29 +183,25 @@ def format_tables(ctx, data_record_query, data_table, recid):
         ctx, data_record_query, first_data_id, data_table)
     assign_or_create_review_status(data_table_metadata, recid, ctx["version"])
     ctx['watched'] = is_current_user_subscribed_to_record(recid)
-    ctx['table_id_to_show'] = first_data_id
-    ctx['table_name_to_show'] = ''
     ctx['data_tables'] = list(data_table_metadata.values())
+    ctx['table_id_to_show'] = ctx['data_tables'][0]['id']
+    ctx['table_name_to_show'] = ctx['data_tables'][0]['name']
     if 'table' in request.args:
         if request.args['table']:
-            ctx['table_name_to_show'] = request.args['table']
+            table_from_args = request.args['table']
             # Check for table name in list of data tables.
             matching_tables = list(filter(
-                lambda data_table: data_table['name'] == ctx['table_name_to_show'],
+                lambda data_table: data_table['name'] == table_from_args,
                 ctx['data_tables']))
             if not matching_tables:
                 # Check for processed table name in list of data tables.
                 matching_tables = list(filter(
-                    lambda data_table: data_table['processed_name'] == ctx['table_name_to_show'],
+                    lambda data_table: data_table['processed_name'] == table_from_args,
                     ctx['data_tables']))
             if matching_tables:
                 # Set table ID and name to the first matching table.
                 ctx['table_id_to_show'] = matching_tables[0]['id']
                 ctx['table_name_to_show'] = matching_tables[0]['name']
-            elif ctx['data_tables']:
-                # Otherwise just set the table ID and name to the first table.
-                ctx['table_id_to_show'] = ctx['data_tables'][0]['id']
-                ctx['table_name_to_show'] = ctx['data_tables'][0]['name']
 
 
 def get_commit_message(ctx, recid):

--- a/hepdata/modules/records/assets/js/hepdata_tables.js
+++ b/hepdata/modules/records/assets/js/hepdata_tables.js
@@ -33,9 +33,6 @@ HEPDATA.switch_table = function (listId, table_requested, table_name, status) {
     // Only use jQuery when called from table_details.html where '$' symbols are stripped from table names.
     _name = $('[value="' + table_requested + '"]').text();  //
   }
-  if (_name.match(/^Table \d+$/)) {
-    _name = _name.replace("Table ", "Table");
-  }
 
   var _recid = HEPDATA.current_inspire_id && status == 'finished' ? 'ins' + HEPDATA.current_inspire_id : HEPDATA.current_record_id;
   var direct_link = HEPDATA.site_url + '/record/' + _recid

--- a/hepdata/modules/records/assets/js/hepdata_tables.js
+++ b/hepdata/modules/records/assets/js/hepdata_tables.js
@@ -27,13 +27,7 @@ HEPDATA.switch_table = function (listId, table_requested, table_name, status) {
     {"width": 200, "height": 200}
   );
 
-  // Pass the table name from record-javascript.html or table_list.html before it gets mangled by MathJax.
   var encoded_name = encodeURIComponent(table_name);
-  /*if (!_name) {
-    console.log("No name provided.")
-    // Only use jQuery when called from table_details.html where '$' symbols are stripped from table names.
-    _name = $('[value="' + table_requested + '"]').text();  //
-  }*/
 
   var _recid = HEPDATA.current_inspire_id && status == 'finished' ? 'ins' + HEPDATA.current_inspire_id : HEPDATA.current_record_id;
   var direct_link = HEPDATA.site_url + '/record/' + _recid

--- a/hepdata/modules/records/assets/js/hepdata_tables.js
+++ b/hepdata/modules/records/assets/js/hepdata_tables.js
@@ -28,15 +28,16 @@ HEPDATA.switch_table = function (listId, table_requested, table_name, status) {
   );
 
   // Pass the table name from record-javascript.html or table_list.html before it gets mangled by MathJax.
-  var _name = table_name;
-  if (!_name) {
+  var encoded_name = encodeURIComponent(table_name);
+  /*if (!_name) {
+    console.log("No name provided.")
     // Only use jQuery when called from table_details.html where '$' symbols are stripped from table names.
     _name = $('[value="' + table_requested + '"]').text();  //
-  }
+  }*/
 
   var _recid = HEPDATA.current_inspire_id && status == 'finished' ? 'ins' + HEPDATA.current_inspire_id : HEPDATA.current_record_id;
   var direct_link = HEPDATA.site_url + '/record/' + _recid
-    + '?version=' + HEPDATA.current_table_version + "&table=" + _name.replace(/\+/g, '%2B').replace(/ /g, '%20');
+    + '?version=' + HEPDATA.current_table_version + "&table=" + encoded_name;
 
   $("#direct_data_link").val(direct_link);
   $(".copy-btn").attr('data-clipboard-text', direct_link);
@@ -76,11 +77,11 @@ HEPDATA.switch_table = function (listId, table_requested, table_name, status) {
 
   $(".data_download_link").each(function () {
     var data_format = $(this).text().toLowerCase();
-    var data_url = '/download/table/' + _recid + '/' + _name.replace(/%/g, '%25').replace(/\\/g, '%5C') + '/' + HEPDATA.current_table_version + '/' + data_format;
+    var data_url = '/download/table/' + _recid + '/' + encoded_name + '/' + HEPDATA.current_table_version + '/' + data_format;
     $(this).attr('href', data_url);
   });
 
-  $("#json_link").attr('href', '/download/table/' + _recid + '/' + _name.replace(/%/g, '%25').replace(/\\/g, '%5C') + '/' + HEPDATA.current_table_version + '/json')
+  $("#json_link").attr('href', '/download/table/' + _recid + '/' + encoded_name + '/' + HEPDATA.current_table_version + '/json')
 };
 
 HEPDATA.table_renderer = {

--- a/hepdata/modules/records/templates/hepdata_records/components/record-javascript.html
+++ b/hepdata/modules/records/templates/hepdata_records/components/record-javascript.html
@@ -51,8 +51,10 @@
 
             // If table_to_show is an integer, replace with table name.
             if (table_to_show.match(/^\d+$/)) {
-              {% for table in ctx.data_tables if table_to_show == table.id %}
-                  table_name = table.name;  // avoids using jQuery
+              {% for table in ctx.data_tables %}
+                if (table_to_show == {{ table.id }}) {
+                  table_name = "{{ table.name }}";  // avoids using jQuery
+                }
               {% endfor %}
               if (!table_name) {
                 table_name = $('#' + table_to_show + " h4").text();  // fallback using jQuery
@@ -66,6 +68,13 @@
             if (!table_to_show.match(/^\d+$/)) {
 
               table_name = table_to_show;
+
+              // If table_to_show is the processed table name, replace the table name with the original.
+              {% for table in ctx.data_tables %}
+                if (table_to_show == "{{ table.processed_name }}") {
+                  table_name = "{{ table.name }}";  // original table name including spaces
+                }
+              {% endfor %}
 
               // Remove whitespace from table name and escape special characters.
               table_to_show = table_to_show.replace(/\s/g, "");

--- a/hepdata/modules/records/templates/hepdata_records/components/record-javascript.html
+++ b/hepdata/modules/records/templates/hepdata_records/components/record-javascript.html
@@ -46,64 +46,17 @@
             HEPDATA.site_url = "{{ ctx.site_url }}";
             HEPDATA.current_record_id = {{ctx.recid | safe}};
             HEPDATA.current_table_version = {{ctx.version | safe}};
-            var table_to_show = "{{ctx.table_to_show | replace("\\","\\\\")}}";  // escape backslashes
-            var table_name = undefined;
 
-            // If table_to_show is an integer, replace with table name.
-            if (table_to_show.match(/^\d+$/)) {
-              {% for table in ctx.data_tables %}
-                if (table_to_show == {{ table.id }}) {
-                  table_name = "{{ table.name }}";  // avoids using jQuery
-                }
-              {% endfor %}
-              if (!table_name) {
-                table_name = $('#' + table_to_show + " h4").text();  // fallback using jQuery
-              }
-              if (table_name) {
-                table_to_show = table_name;
-              }
-            }
-
-            // If table_to_show is the table name, replace with table id.
-            if (!table_to_show.match(/^\d+$/)) {
-
-              table_name = table_to_show;
-
-              // If table_to_show is the processed table name, replace the table name with the original.
-              {% for table in ctx.data_tables %}
-                if (table_to_show == "{{ table.processed_name }}") {
-                  table_name = "{{ table.name }}";  // original table name including spaces
-                }
-              {% endfor %}
-
-              // Remove whitespace from table name and escape special characters.
-              table_to_show = table_to_show.replace(/\s/g, "");
-              table_to_show = CSS.escape(table_to_show);
-
-              // Find table_id from table name.
-              var table_id = undefined;
-              if (table_to_show) {
-                table_id = $("." + table_to_show).attr("id");
-              }
-
-              if (table_id == undefined) {
-                // Just return first table.
-                table_to_show = {{ ctx.data_tables[0].id }};
-                table_name = "{{ ctx.data_tables[0].name | replace("\\","\\\\") }}";
-              } else {
-                table_to_show = table_id;
-              }
-
-            }
-
+            var table_id_to_show = {{ ctx.table_id_to_show | safe }};
+            var table_name_to_show = "{{ ctx.table_name_to_show | replace("\\","\\\\") }}";  // escape backslashes
             var status = "{{ ctx.status }}";
 
             // Pass table name before it gets mangled by MathJax if it contains LaTeX encoding.
-            HEPDATA.switch_table('#table-list', table_to_show, table_name, status);
+            HEPDATA.switch_table('#table-list', table_id_to_show, table_name_to_show, status);
 
             if (window.location.href.indexOf("table=") > -1) {
                 $('#table-list').animate({
-                    scrollTop: $("#" + table_to_show).offset().top
+                    scrollTop: $("#" + table_id_to_show).offset().top
                 }, 2000);
             }
         {%else %}

--- a/hepdata/modules/records/templates/hepdata_records/components/table_details.html
+++ b/hepdata/modules/records/templates/hepdata_records/components/table_details.html
@@ -6,11 +6,11 @@
     {% endif %}
 
     <div class="nice-dropdown" id="table-selector">
-        <select style="width: 100%" onchange="HEPDATA.switch_table('#table-list',$(this).val(),'','{{ctx.status}}')">
+        <select style="width: 100%" onchange="HEPDATA.switch_table('#table-list',$(this).val(),$(this).find('option:selected').attr('name'),'{{ctx.status}}')">
             {% for table in ctx.data_tables %}
-                <option value="{{ table.id }}"
+                <option value="{{ table.id }}" name="{{ table.name }}"
                 {% if ctx.table_id_to_show == table.id %}selected{% endif %}
-                >{{ table.name | replace('$','') }}</option>
+                >{{ table.name }}</option>
             {% endfor %}
         </select>
     </div>

--- a/hepdata/modules/records/templates/hepdata_records/components/table_details.html
+++ b/hepdata/modules/records/templates/hepdata_records/components/table_details.html
@@ -8,7 +8,9 @@
     <div class="nice-dropdown" id="table-selector">
         <select style="width: 100%" onchange="HEPDATA.switch_table('#table-list',$(this).val(),'','{{ctx.status}}')">
             {% for table in ctx.data_tables %}
-                <option value="{{ table.id }}">{{ table.name | replace('$','') }}</option>
+                <option value="{{ table.id }}"
+                {% if ctx.table_id_to_show == table.id %}selected{% endif %}
+                >{{ table.name | replace('$','') }}</option>
             {% endfor %}
         </select>
     </div>

--- a/hepdata/modules/records/templates/hepdata_records/data_record.html
+++ b/hepdata/modules/records/templates/hepdata_records/data_record.html
@@ -149,7 +149,7 @@
 
                             {% if ctx.additional_resources %}
                                 <li>
-                                    <button id="show_resources" class="link"
+                                    <button id="show_resources" class="btn btn-primary btn-sm"
                                             data-recid="{{ ctx.record.recid }}">
                                         Resources
                                     </button>

--- a/hepdata/modules/records/templates/hepdata_records/data_record.html
+++ b/hepdata/modules/records/templates/hepdata_records/data_record.html
@@ -30,6 +30,7 @@
 {%- block additional_assets %}
 
     {{ webpack['hepdata-record.css'] }}
+    {{ webpack['toastr.css'] }}
 
 {%- endblock additional_assets %}
 

--- a/hepdata/modules/records/utils/data_processing_utils.py
+++ b/hepdata/modules/records/utils/data_processing_utils.py
@@ -287,8 +287,6 @@ def process_ctx(ctx, light_mode=False):
                     _recid = ctx['recid']
 
                 _cleaned_table_name = data_table['name'].replace('%', '%25').replace('\\', '%5C')
-                if re.match('^Table \d+$', _cleaned_table_name):
-                    _cleaned_table_name = _cleaned_table_name.replace('Table ', 'Table')
 
                 data_table['data'] = {
                     'json': '{0}/download/table/{1}/{2}/json'.format(

--- a/hepdata/modules/records/utils/users.py
+++ b/hepdata/modules/records/utils/users.py
@@ -28,13 +28,12 @@ def get_coordinators_in_system():
     """
     Utility function to get all coordinator users in the database.
 
-    :return: list of coordinator ids, nicknames, and emails.
+    :return: list of coordinator ids and emails.
     """
 
-    coordinators = User.query.filter(User.roles.any(name='coordinator')).all()
+    coordinators = User.query.filter(User.roles.any(name='coordinator')).order_by(User.email).all()
 
-    to_return = [{'id': coordinator.id, 'nickname': coordinator.email,
-                  'email': coordinator.email} for coordinator in coordinators]
+    to_return = [{'id': coordinator.id, 'email': coordinator.email} for coordinator in coordinators]
 
     return to_return
 

--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20210427"
+__version__ = "0.9.4dev20210428"

--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20210420"
+__version__ = "0.9.4dev20210423"

--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20210423"
+__version__ = "0.9.4dev20210427"

--- a/tests/e2e/test_general.py
+++ b/tests/e2e/test_general.py
@@ -32,6 +32,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from functools import reduce
+from tests.conftest import import_default_data
 
 
 def test_home(live_server, env_browser, identifiers):
@@ -89,21 +90,41 @@ def test_home(live_server, env_browser, identifiers):
     # Close download dropdown by clicking again
     browser.find_element_by_id('dLabel').click()
 
+
+def test_tables(app, live_server, env_browser):
+    """E2E test to tables in a record."""
+    browser = env_browser
+
+    # Import record with non-default table names
+    import_default_data(app, [{'hepdata_id': 'ins1206352'}])
+
+    browser.get(flask.url_for('hepdata_theme.index', _external=True))
+    assert (flask.url_for('hepdata_theme.index', _external=True) in
+            browser.current_url)
+
+    latest_item = browser.find_element_by_css_selector('.latest-record .title')
+    actions = ActionChains(browser)
+    actions.move_to_element(latest_item).perform()
+    latest_item.click()
+
+    # Check current table name
+    assert(browser.find_element_by_id('table_name').text == 'Figure 8 panel (a)')
+
     # Check switching tables works as expected
     new_table = browser.find_elements_by_css_selector('#table-list li h4')[2]
-    assert(new_table.text == "Table 3")
+    assert(new_table.text == "Figure 8 panel (c)")
     new_table.click()
-    _check_table_links(browser, "Table 3", "Table3")
+    _check_table_links(browser, "Figure 8 panel (c)", "Figure%208%20panel%20(c)")
 
     # Get link to table from table page
     table_link = browser.find_element_by_css_selector('#data_link_container button') \
         .get_attribute('data-clipboard-text')
-    assert(table_link.endswith('Table3'))
-    _check_table_links(browser, "Table 3", "Table3", url=table_link)
+    assert(table_link.endswith('table=Figure%208%20panel%20(c)'))
+    _check_table_links(browser, "Figure 8 panel (c)", "Figure%208%20panel%20(c)", url=table_link)
 
     # Check a link to an invalid table
-    invalid_table_link = table_link.replace('Table3', 'NotARealTable')
-    _check_table_links(browser, "Table 1", "Table1", url=invalid_table_link)
+    invalid_table_link = table_link.replace('Figure%208%20panel%20(c)', 'NotARealTable')
+    _check_table_links(browser, "Figure 8 panel (a)", "Figure%208%20panel%20(a)", url=invalid_table_link)
 
 
 def _check_table_links(browser, table_full_name, table_short_name, url=None):
@@ -126,7 +147,7 @@ def _check_table_links(browser, table_full_name, table_short_name, url=None):
     response = requests.get(yaml_link)
     assert(response.status_code == 200)
     assert(response.headers['Content-Disposition']
-           == f'attachment; filename=HEPData-ins1283842-v1-{filename_table}.yaml')
+           == f'attachment; filename="HEPData-ins1206352-v1-{filename_table}.yaml"')
 
 
 def test_general_pages(live_server, env_browser):

--- a/tests/e2e/test_general.py
+++ b/tests/e2e/test_general.py
@@ -34,6 +34,10 @@ from selenium.webdriver.support import expected_conditions as EC
 from functools import reduce
 from tests.conftest import import_default_data
 
+from hepdata.ext.elasticsearch.api import reindex_all
+from hepdata.modules.submission.api import get_latest_hepsubmission
+from hepdata.modules.records.utils.submission import unload_submission
+
 
 def test_home(live_server, env_browser, identifiers):
     """E2E home test to check record counts and latest submissions."""
@@ -125,6 +129,11 @@ def test_tables(app, live_server, env_browser):
     # Check a link to an invalid table
     invalid_table_link = table_link.replace('Figure%208%20panel%20(c)', 'NotARealTable')
     _check_table_links(browser, "Figure 8 panel (a)", "Figure%208%20panel%20(a)", url=invalid_table_link)
+
+    # Delete record and reindex so added record doesn't affect other tests
+    submission = get_latest_hepsubmission(inspire_id='1206352')
+    unload_submission(submission.publication_recid)
+    reindex_all(recreate=True)
 
 
 def _check_table_links(browser, table_full_name, table_short_name, url=None):

--- a/tests/e2e/test_general.py
+++ b/tests/e2e/test_general.py
@@ -102,42 +102,44 @@ def test_tables(app, live_server, env_browser):
     # Import record with non-default table names
     import_default_data(app, [{'hepdata_id': 'ins1206352'}])
 
-    browser.get(flask.url_for('hepdata_theme.index', _external=True))
-    assert (flask.url_for('hepdata_theme.index', _external=True) in
-            browser.current_url)
+    try:
+        browser.get(flask.url_for('hepdata_theme.index', _external=True))
+        assert (flask.url_for('hepdata_theme.index', _external=True) in
+                browser.current_url)
 
-    latest_item = browser.find_element_by_css_selector('.latest-record .title')
-    actions = ActionChains(browser)
-    actions.move_to_element(latest_item).perform()
-    latest_item.click()
+        latest_item = browser.find_element_by_css_selector('.latest-record .title')
+        actions = ActionChains(browser)
+        actions.move_to_element(latest_item).perform()
+        latest_item.click()
 
-    # Check current table name
-    assert(browser.find_element_by_id('table_name').text == 'Figure 8 panel (a)')
+        # Check current table name
+        assert(browser.find_element_by_id('table_name').text == 'Figure 8 panel (a)')
 
-    # Check switching tables works as expected
-    new_table = browser.find_elements_by_css_selector('#table-list li h4')[2]
-    assert(new_table.text == "Figure 8 panel (c)")
-    new_table.click()
-    _check_table_links(browser, "Figure 8 panel (c)")
+        # Check switching tables works as expected
+        new_table = browser.find_elements_by_css_selector('#table-list li h4')[2]
+        assert(new_table.text == "Figure 8 panel (c)")
+        new_table.click()
+        _check_table_links(browser, "Figure 8 panel (c)")
 
-    # Get link to table from table page
-    table_link = browser.find_element_by_css_selector('#data_link_container button') \
-        .get_attribute('data-clipboard-text')
-    assert(table_link.endswith('table=Figure%208%20panel%20(c)'))
-    _check_table_links(browser, "Figure 8 panel (c)", url=table_link)
+        # Get link to table from table page
+        table_link = browser.find_element_by_css_selector('#data_link_container button') \
+            .get_attribute('data-clipboard-text')
+        assert(table_link.endswith('table=Figure%208%20panel%20(c)'))
+        _check_table_links(browser, "Figure 8 panel (c)", url=table_link)
 
-    # Check a link to a table name with spaces removed
-    short_table_link = table_link.replace('%20', '')
-    _check_table_links(browser, "Figure 8 panel (c)", url=short_table_link)
+        # Check a link to a table name with spaces removed
+        short_table_link = table_link.replace('%20', '')
+        _check_table_links(browser, "Figure 8 panel (c)", url=short_table_link)
 
-    # Check a link to an invalid table
-    invalid_table_link = table_link.replace('Figure%208%20panel%20(c)', 'NotARealTable')
-    _check_table_links(browser, "Figure 8 panel (a)", url=invalid_table_link)
+        # Check a link to an invalid table
+        invalid_table_link = table_link.replace('Figure%208%20panel%20(c)', 'NotARealTable')
+        _check_table_links(browser, "Figure 8 panel (a)", url=invalid_table_link)
 
-    # Delete record and reindex so added record doesn't affect other tests
-    submission = get_latest_hepsubmission(inspire_id='1206352')
-    unload_submission(submission.publication_recid)
-    reindex_all(recreate=True)
+    finally:
+        # Delete record and reindex so added record doesn't affect other tests
+        submission = get_latest_hepsubmission(inspire_id='1206352')
+        unload_submission(submission.publication_recid)
+        reindex_all(recreate=True)
 
 
 def _check_table_links(browser, table_full_name, url=None):

--- a/tests/e2e/test_general.py
+++ b/tests/e2e/test_general.py
@@ -118,17 +118,21 @@ def test_tables(app, live_server, env_browser):
     new_table = browser.find_elements_by_css_selector('#table-list li h4')[2]
     assert(new_table.text == "Figure 8 panel (c)")
     new_table.click()
-    _check_table_links(browser, "Figure 8 panel (c)", "Figure%208%20panel%20(c)")
+    _check_table_links(browser, "Figure 8 panel (c)")
 
     # Get link to table from table page
     table_link = browser.find_element_by_css_selector('#data_link_container button') \
         .get_attribute('data-clipboard-text')
     assert(table_link.endswith('table=Figure%208%20panel%20(c)'))
-    _check_table_links(browser, "Figure 8 panel (c)", "Figure%208%20panel%20(c)", url=table_link)
+    _check_table_links(browser, "Figure 8 panel (c)", url=table_link)
+
+    # Check a link to a table name with spaces removed
+    short_table_link = table_link.replace('%20', '')
+    _check_table_links(browser, "Figure 8 panel (c)", url=short_table_link)
 
     # Check a link to an invalid table
     invalid_table_link = table_link.replace('Figure%208%20panel%20(c)', 'NotARealTable')
-    _check_table_links(browser, "Figure 8 panel (a)", "Figure%208%20panel%20(a)", url=invalid_table_link)
+    _check_table_links(browser, "Figure 8 panel (a)", url=invalid_table_link)
 
     # Delete record and reindex so added record doesn't affect other tests
     submission = get_latest_hepsubmission(inspire_id='1206352')
@@ -136,7 +140,7 @@ def test_tables(app, live_server, env_browser):
     reindex_all(recreate=True)
 
 
-def _check_table_links(browser, table_full_name, table_short_name, url=None):
+def _check_table_links(browser, table_full_name, url=None):
     if url:
         # Replace port in url (5555 used for unit testing is set in pytest.ini not config
         url = url.replace('5000', '5555')
@@ -150,7 +154,7 @@ def _check_table_links(browser, table_full_name, table_short_name, url=None):
     # Check download YAML link for table
     yaml_link = browser.find_element_by_id('download_yaml_data') \
         .get_attribute('href')
-    assert(yaml_link.endswith(f'/{table_short_name}/1/yaml'))
+    assert(yaml_link.endswith(f'/{table_full_name.replace(" ", "%20")}/1/yaml'))
     # Download yaml using requests and check we get expected filename
     filename_table = table_full_name.replace(' ', '_')
     response = requests.get(yaml_link)

--- a/tests/e2e/test_records.py
+++ b/tests/e2e/test_records.py
@@ -188,7 +188,7 @@ def test_record_update(live_server, logged_in_browser):
     assert 'Submission deleted' in \
         delete_widget.find_element_by_css_selector('#delete-success p').text
 
-    # Should now only be 1 verion of our submission
+    # Should now only be 1 version of our submission
     submissions = HEPSubmission.query \
         .filter_by(inspire_id=inspire_id).all()
     assert len(submissions) == 1


### PR DESCRIPTION
This PR fixes a bug where incorrect download links are shown containing table names without spaces if the `processed_name` (without spaces) is passed as the `table` URL argument instead of the original `name` (with spaces).  Example links can be seen in [Table 1](https://www.hepdata.net/record/ins1750597?version=2&table=Table1) of an ATLAS record.

Fixes #334.