### PR TITLE
Limit max results per page to 100

### DIFF
--- a/hepdata/ext/elasticsearch/api.py
+++ b/hepdata/ext/elasticsearch/api.py
@@ -39,6 +39,7 @@ from invenio_db import db
 import logging
 
 from invenio_search import current_search_client as es, RecordsSearch
+from hepdata.modules.search.config import ELASTICSEARCH_MAX_RESULT_WINDOW, LIMIT_MAX_RESULTS_PER_PAGE
 
 
 __all__ = ['search', 'index_record_ids', 'index_record_dict', 'fetch_record',
@@ -142,7 +143,8 @@ def search(query,
     if query:
         data_search = data_search.query(QueryString(query=query))
 
-    data_search = data_search[0:size*100]
+    data_search_size = size * ELASTICSEARCH_MAX_RESULT_WINDOW // LIMIT_MAX_RESULTS_PER_PAGE
+    data_search = data_search[0:data_search_size]
     data_result = data_search.execute().to_dict()
 
     merged_results = merge_results(pub_result, data_result)

--- a/hepdata/modules/search/config.py
+++ b/hepdata/modules/search/config.py
@@ -17,6 +17,9 @@
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 #
 
+ELASTICSEARCH_MAX_RESULT_WINDOW = 10000  # default Elasticsearch value
+LIMIT_MAX_RESULTS_PER_PAGE = 100  # maximum value of 'size' parameter
+
 HEPDATA_CFG_MAX_RESULTS_PER_PAGE = 25
 HEPDATA_CFG_FACETS = ['author',
                       'collaboration',

--- a/hepdata/modules/search/views.py
+++ b/hepdata/modules/search/views.py
@@ -120,7 +120,7 @@ def check_date(args):
 
 def check_cmenergies(args):
     """
-    Get the cmenergues query parameter from the URL and convert to floats
+    Get the cmenergies query parameter from the URL and convert to floats
     """
     cmenergies = args.get('cmenergies', None)
     if cmenergies:

--- a/hepdata/modules/search/views.py
+++ b/hepdata/modules/search/views.py
@@ -30,6 +30,7 @@ from hepdata.modules.records.api import get_all_ids as db_get_all_ids
 from hepdata.utils.session import get_session_item, set_session_item
 from hepdata.utils.url import modify_query
 from .config import HEPDATA_CFG_MAX_RESULTS_PER_PAGE, HEPDATA_CFG_FACETS
+from .config import LIMIT_MAX_RESULTS_PER_PAGE
 
 blueprint = Blueprint('es_search',
                       __name__,
@@ -77,8 +78,10 @@ def check_max_results(args):
     except ValueError:
         max_results = HEPDATA_CFG_MAX_RESULTS_PER_PAGE
 
-    if max_results < 1 or max_results > 200:
-        max_results = 200 if max_results > 200 else HEPDATA_CFG_MAX_RESULTS_PER_PAGE
+    if max_results < 1:
+        max_results = HEPDATA_CFG_MAX_RESULTS_PER_PAGE
+    elif max_results > LIMIT_MAX_RESULTS_PER_PAGE:
+        max_results = LIMIT_MAX_RESULTS_PER_PAGE
 
     args['size'] = max_results
 

--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20210429"
+__version__ = "0.9.4dev20210504"


### PR DESCRIPTION
Introduce new `ELASTICSEARCH_MAX_RESULT_WINDOW` (= 10000) and `LIMIT_MAX_RESULTS_PER_PAGE` (= 100) config options and calculate data search size using these two variables.

It would be better to set `ELASTICSEARCH_MAX_RESULT_WINDOW` to the Elasticsearch setting `index.max_result_window`, but I couldn't work out how to do this using [Elasticsearch DSL](https://elasticsearch-dsl.readthedocs.io/en/latest/), so I've simply hard-coded the default value of `index.max_result_window`.

Fixes #339.