### PR TITLE
Switch to new CERN SSO

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -158,9 +158,11 @@ you should use the `QA version of the portal <https://application-portal-qa.web.
 in setting that up - but see below for partial instructions.)
 
 1. (QA only) Set up the CERN proxy following their `instructions <https://security.web.cern.ch/recommendations/en/ssh_browsing.shtml>`_.
+
 2. Sign in to the `CERN Application Portal <https://application-portal.web.cern.ch>`_ (or the `CERN QA Application Portal <https://application-portal-qa.web.cern.ch>`_).
+
 3. Click "Add an Application" and fill in the form:
-    - Application Identifier: hepdata-local
+    - Application Identifier: hepdata-local (example, must be globally unique)
     - Name: HEPData local installation
     - Home Page: https://hepdata.local (this doesn't affect the workings of the SSO but localhost is not allowed)
     - Description: Local installation of HEPData
@@ -170,7 +172,8 @@ in setting that up - but see below for partial instructions.)
     - Select "OpenID Connect (OIDC)"
     - Redirect URI: https://localhost:5000/oauth/authorized/cern_openid/
     - Leave other boxes unchecked, submit and confirm.
-5. You will be shown the Client ID and Client Secret. Copy these into `config_local.py`:
+
+5. You will be shown the Client ID and Client Secret. Copy these into ``config_local.py``:
 
    .. code-block:: python
 
@@ -180,15 +183,16 @@ in setting that up - but see below for partial instructions.)
        )
 
 6. Go to "Roles". Add a new Role:
-   - Role Identifier: cern_user
-   - Role Name: CERN user
-   - Description: CERN user
-   - Check "This role is required to access my application"
-   - Check "This role applies to all authenticated users"
-   - Leave the minimum level of assurance as it is.
+    - Role Identifier: cern_user
+    - Role Name: CERN user
+    - Description: CERN user
+    - Check "This role is required to access my application"
+    - Check "This role applies to all authenticated users"
+    - Leave the minimum level of assurance as it is.
 
 7. If there is a default role, edit it and uncheck both "This role is required to access my application" and "This role applies to all authenticated users".
-8. (QA only) Add the following settings to `config_local.py`:
+
+8. (QA only) Add the following settings to ``config_local.py``:
 
     .. code-block:: python
 
@@ -207,4 +211,5 @@ in setting that up - but see below for partial instructions.)
       (hepdata)$ hepdata run --debugger --reload --cert=adhoc
 
 10. Go to https://localhost:5000. You will see a warning that the connection is not private but choose "Advanced" and "Proceed to localhost (unsafe)" (or the equivalent in your browser).
+
 11. Click "Sign in" and "Log in with CERN" and hopefully it will work as expected.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -145,3 +145,66 @@ Run the webpack CLI ``install`` and ``build`` commands separately (rather than u
 
    (hepdata)$ hepdata webpack install --legacy-peer-deps
    (hepdata)$ hepdata webpack build
+
+
+Single Sign On: Local development
+=================================
+
+CERN SSO
+--------
+
+Setting up a local app can be done via the `CERN Application Portal <https://application-portal.web.cern.ch>`_. (Ideally
+you should use the `QA version of the portal <https://application-portal-qa.web.cern.ch>`_ but we have not yet succeeded
+in setting that up - but see below for partial instructions.)
+
+1. (QA only) Set up the CERN proxy following their `instructions <https://security.web.cern.ch/recommendations/en/ssh_browsing.shtml>`_.
+2. Sign in to the `CERN Application Portal <https://application-portal.web.cern.ch>`_ (or the `CERN QA Application Portal <https://application-portal-qa.web.cern.ch>`_).
+3. Click "Add an Application" and fill in the form:
+    - Application Identifier: hepdata-local
+    - Name: HEPData local installation
+    - Home Page: https://hepdata.local (this doesn't affect the workings of the SSO but localhost is not allowed)
+    - Description: Local installation of HEPData
+    - Category: Personal
+
+4. Once your application has been created, edit it and go to "SSO Registration", click the add (+) button, and fill in the form:
+    - Select "OpenID Connect (OIDC)"
+    - Redirect URI: https://localhost:5000/oauth/authorized/cern_openid/
+    - Leave other boxes unchecked, submit and confirm.
+5. You will be shown the Client ID and Client Secret. Copy these into `config_local.py`:
+
+   .. code-block:: python
+
+       CERN_APP_OPENID_CREDENTIALS = dict(
+           consumer_key="hepdata-local",
+           consumer_secret="<your-client-secret>",
+       )
+
+6. Go to "Roles". Add a new Role:
+   - Role Identifier: cern_user
+   - Role Name: CERN user
+   - Description: CERN user
+   - Check "This role is required to access my application"
+   - Check "This role applies to all authenticated users"
+   - Leave the minimum level of assurance as it is.
+
+7. If there is a default role, edit it and uncheck both "This role is required to access my application" and "This role applies to all authenticated users".
+8. (QA only) Add the following settings to `config_local.py`:
+
+    .. code-block:: python
+
+      from .config import CERN_REMOTE_APP
+      CERN_REMOTE_APP['params']['base_url'] = "https://keycloak-qa.cern.ch/auth/realms/cern"
+      CERN_REMOTE_APP['params']['access_token_url'] = "https://keycloak-qa.cern.ch/auth/realms/cern/protocol/openid-connect/token"
+      CERN_REMOTE_APP['params']['authorize_url'] = "https://keycloak-qa.cern.ch/auth/realms/cern/protocol/openid-connect/auth"
+      CERN_REMOTE_APP['logout_url'] = "https://keycloak-qa.cern.ch/auth/realms/cern/protocol/openid-connect/logout"
+      OAUTHCLIENT_CERN_OPENID_USERINFO_URL = "https://keycloak-qa.cern.ch/auth/realms/cern/protocol/openid-connect/userinfo"
+
+9. Run the hepdata app using an adhoc SSL certificate:
+
+   .. code-block:: console
+
+      (hepdata)$ pip install pyopenssl
+      (hepdata)$ hepdata run --debugger --reload --cert=adhoc
+
+10. Go to https://localhost:5000. You will see a warning that the connection is not private but choose "Advanced" and "Proceed to localhost (unsafe)" (or the equivalent in your browser).
+11. Click "Sign in" and "Log in with CERN" and hopefully it will work as expected.

--- a/hepdata/config.py
+++ b/hepdata/config.py
@@ -30,7 +30,7 @@ from celery.schedules import crontab
 from datetime import timedelta
 
 from invenio_oauthclient.contrib.orcid import REMOTE_APP as ORCID_REMOTE_APP
-from invenio_oauthclient.contrib import cern
+from invenio_oauthclient.contrib import cern_openid
 
 
 def _(x):
@@ -265,22 +265,21 @@ ORCID_APP_CREDENTIALS = dict(
     consumer_secret="CHANGE_ME",
 )
 
-CERN_APP_CREDENTIALS = dict(
+CERN_APP_OPENID_CREDENTIALS = dict(
     consumer_key="CHANGE_ME",
     consumer_secret="CHANGE_ME",
 )
 
-CERN_REMOTE_APP = copy.deepcopy(cern.REMOTE_APP)
-CERN_REMOTE_APP["params"].update({
-    'request_token_params': {
-        "scope": "Email Groups",
-    }
-})
+CERN_REMOTE_APP = copy.deepcopy(cern_openid.REMOTE_REST_APP)
 
 #: Definition of OAuth client applications.
+OAUTHCLIENT_REST_REMOTE_APPS = dict(
+   cern_openid=CERN_REMOTE_APP,
+)
+
 OAUTHCLIENT_REMOTE_APPS = dict(
     orcid=ORCID_REMOTE_APP,
-    cern=CERN_REMOTE_APP
+    cern_openid=CERN_REMOTE_APP
 )
 
 ADMIN_APPNAME = "HEPData"

--- a/hepdata/modules/theme/templates/hepdata_theme/security/login_user.html
+++ b/hepdata/modules/theme/templates/hepdata_theme/security/login_user.html
@@ -38,7 +38,7 @@
                 {%- block form_outer %}
                     <div class="social-signup">
                         <a href="{{url_for('invenio_oauthclient.login', remote_app='orcid')}}" class="btn btn-default btn-lg btn-block"><img src="{{ url_for('static', filename='img/orcid.svg')}}" height="18px"> {{_('Log in with ORCID')}}</a>
-                        <a href="{{url_for('invenio_oauthclient.login', remote_app='cern')}}" class="btn btn-default btn-lg btn-block"><img src="{{ url_for('static', filename='img/cern.svg')}}" height="26px"> {{_('Log in with CERN')}}</a>
+                        <a href="{{url_for('invenio_oauthclient.login', remote_app='cern_openid')}}" class="btn btn-default btn-lg btn-block"><img src="{{ url_for('static', filename='img/cern.svg')}}" height="26px"> {{_('Log in with CERN')}}</a>
                         <h3 align="center">&mdash; OR &mdash;</h3>
                     </div>
                     {%- with form = login_user_form %}

--- a/hepdata/modules/theme/templates/hepdata_theme/security/register_user.html
+++ b/hepdata/modules/theme/templates/hepdata_theme/security/register_user.html
@@ -67,7 +67,7 @@
                                style="color: #2c3e50; font-weight: bolder;"><img
                                     src="{{ url_for('static', filename='img/orcid.svg') }}"
                                     height="18px"> {{ _('Sign up with ORCID') }}</a>
-                            <a href="{{ url_for('invenio_oauthclient.login', remote_app='cern') }}"
+                            <a href="{{ url_for('invenio_oauthclient.login', remote_app='cern_openid') }}"
                                class="btn btn-default btn-lg btn-block"
                                style="color: #2c3e50; font-weight: bolder;"><img
                                     src="{{ url_for('static', filename='img/cern.svg') }}"

--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20210521"
+__version__ = "0.9.4dev20210524"

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ invenio-base==1.2.3
 invenio-config==1.0.3
 invenio-db==1.0.9
 invenio-logging[sentry-sdk]==1.3.0
-invenio-oauthclient==1.4.4
+invenio-oauthclient==1.5.0
 invenio-pidstore==1.2.2
 invenio-records==1.4.0
 invenio-search==1.4.1


### PR DESCRIPTION
Instructions for running locally have been added to the development page of the docs.

We will need to set up a new app in the CERN application portal, following the instructions as for running locally but using the relevant names/urls and the "Official" category, and also ensuring the roles are set at the correct permission levels.

The `hepdata-cern-creds` secrets need to be updated with the client ID and secret from the new app.

hepdata.cfg needs a new entry:

```
CERN_APP_OPENID_CREDENTIALS = dict(
    consumer_key=CERN_APP_OPENID_KEY,
    consumer_secret=CERN_APP_OPENID_SECRET
)
```

These should replace the current `CERN_APP_CREDENTIALS` values.

Closes #297.