### PR TITLE
Allow unquoted searches

### DIFF
--- a/hepdata/ext/elasticsearch/api.py
+++ b/hepdata/ext/elasticsearch/api.py
@@ -159,6 +159,7 @@ def search(query,
             reason = e.info['error']['root_cause'][0]['reason']
         # Otherwise we hide the details from the user
         else:
+            log.error(f'An unexpected error occurred when searching: {e}')
             reason = f'An unexpected error occurred: {e.error}'
         return { 'error': reason }
 

--- a/hepdata/ext/elasticsearch/api.py
+++ b/hepdata/ext/elasticsearch/api.py
@@ -308,6 +308,8 @@ def push_data_keywords(pub_ids=None, index=None):
                    query={'match': {'recid': pub_id}}) \
             .filter("term", doc_type=CFG_DATA_TYPE) \
             .source(includes=['keywords'])
+
+        search = search[0:LIMIT_MAX_RESULTS_PER_PAGE]
         tables = search.execute()
 
         keywords = [d.keywords for d in tables.hits]

--- a/hepdata/modules/search/templates/hepdata_search/search_results.html
+++ b/hepdata/modules/search/templates/hepdata_search/search_results.html
@@ -52,13 +52,19 @@
         </div>
 
         <div class="search-results container-fluid">
-            {% include "hepdata_search/display_results_options.html" %}
+            {% if not no_results %}
+              {% include "hepdata_search/display_results_options.html" %}
+            {% endif %}
             <div class="row-fluid">
                 {% if not no_results %}
                     {% include "hepdata_search/facet_column.html" %}
                 {% endif %}
                 <div class="col-md-10" style="padding-bottom: 3em;">
-                    {% if no_results %}
+                    {% if ctx.error %}
+                    <p>Unable to search for <b>{{ctx.q}}</b>: {{ctx.error}}</p>
+                    <p>Please see <a data-toggle="modal"
+                       data-target="#searchHelpWidget">Advanced Search</a> for details of correct search syntax.<p>
+                    {% elif no_results %}
                     <p>No results found. Please edit your search and try again.</p>
                     {% endif %}
                     {% if ctx.pages and not no_results %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,3 +46,4 @@ SQLAlchemy-Utils==0.35.0
 timestring==1.6.4
 twitter==1.15.0
 unicodeit==0.7.0
+Werkzeug==1.0.1

--- a/tests/e2e/test_search.py
+++ b/tests/e2e/test_search.py
@@ -67,7 +67,7 @@ def test_search_from_home(live_server, env_browser, search_tests):
         {'class_prefix': 'collaboration', 'exp_filter_count': 2, 'exp_first_result_count': 1},
         {'class_prefix': 'subject_areas', 'exp_filter_count': 1, 'exp_first_result_count': 2},
         {'class_prefix': 'phrases', 'exp_filter_count': 10, 'exp_first_result_count': 1},
-        {'class_prefix': 'reactions', 'exp_filter_count': 9, 'exp_first_result_count': 1},
+        {'class_prefix': 'reactions', 'exp_filter_count': 10, 'exp_first_result_count': 1},
         {'class_prefix': 'observables', 'exp_filter_count': 3, 'exp_first_result_count': 1},
         {'class_prefix': 'cmenergies', 'exp_filter_count': 10, 'exp_first_result_count': None}
     ]

--- a/tests/search_test.py
+++ b/tests/search_test.py
@@ -196,6 +196,14 @@ def test_search(app, load_default_data, identifiers):
     for author in expected:
         assert(author in results)
 
+    # Test a search query that ES can't parse
+    results = es_api.search('/', index=index)
+    assert results == {'error': 'Failed to parse query [/]'}
+
+    # Test a search query to an invalid index
+    results = es_api.search('hello', index='thisisnotanindex')
+    assert results == {'error': 'An unexpected error occurred: index_not_found_exception'}
+
 
 def test_merge_results():
     pub_result = {

--- a/tests/search_test.py
+++ b/tests/search_test.py
@@ -140,6 +140,18 @@ def test_query_parser():
     assert (parsed_query_string3 == "data_keywords.observables:ASYM "
                                     "AND unknown_field:hello")
 
+    _test_query4 = 'reactions:P P --> LQ LQ X AND doi:10.1007/s100520000432'
+    parsed_query_string4 = HEPDataQueryParser.parse_query(_test_query4)
+
+    assert (parsed_query_string4 == 'data_keywords.reactions:"P P --> LQ LQ X"'
+                                    ' AND doi:"10.1007/s100520000432"')
+
+    _test_query5 = 'P P --> LQ LQ X'
+    parsed_query_string5 = HEPDataQueryParser.parse_query(_test_query5)
+
+    assert (parsed_query_string5 == '"P P --> LQ LQ X"')
+
+
 
 def test_search(app, load_default_data, identifiers):
     """

--- a/tests/search_test.py
+++ b/tests/search_test.py
@@ -396,8 +396,8 @@ def test_reindex_all(app, load_default_data, identifiers):
     es.indices.delete(index=index)
 
     # Check we can't search
-    with pytest.raises(NotFoundError, match=r"no such index "):
-        es_api.search('', index=index)
+    results = es_api.search('', index=index)
+    assert results == {'error': 'An unexpected error occurred: index_not_found_exception'}
 
     # Reindex, recreating the index
     es_api.reindex_all(index=index, recreate=True, synchronous=True)


### PR DESCRIPTION
Catches query syntax errors from Elasticsearch, and attempts to add quotes to queries that look like a reaction or a DOI.

Fixes #102 