### PR TITLE
Improve Rivet analysis name guess and Sandbox "Additional Resources" button

### DIFF
--- a/hepdata/modules/records/templates/hepdata_records/sandbox.html
+++ b/hepdata/modules/records/templates/hepdata_records/sandbox.html
@@ -189,7 +189,7 @@
                             <ul>
                                 {% if ctx.additional_resources %}
                                     <li>
-                                        <button id="show_resources" class="btn btn-sm btn-primary"
+                                        <button id="show_all_resources" class="btn btn-sm btn-primary"
                                                 data-recid="{{ ctx.recid }}">Additional Resources
                                         </button>
                                     </li>


### PR DESCRIPTION
* Improve guess of Rivet analysis name in YODA conversion so it works for unfinished records (closes #347).
* Create new function `guess_rivet_analysis_name` to avoid duplicated code in `download_submission` and `download_datatable` converter functions.
* Highlight "Common Resources" in resources widget instead of the selected table when clicking the "Additional Resources" button on Sandbox records (closes #360).