### PR TITLE
Add a nightly build on default branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ on:
     branches: [ master ]
   release:
     types: [ published ]
+  schedule:
+    - cron:  '35 2 * * *'
+
 
 concurrency:
   group: ${{github.event_name}}-${{ github.head_ref || github.ref }}


### PR DESCRIPTION
Should build at 02:35 every day (avoiding on the hour/half hour potentially busy times).

(Can't test that it works until this is merged!)

Fixes #355 