### PR TITLE
Fix issues with latest indexing changes

### DIFF
--- a/hepdata/ext/elasticsearch/api.py
+++ b/hepdata/ext/elasticsearch/api.py
@@ -260,7 +260,7 @@ def reindex_batch(hepsubmission_record_ids, index):
 
 
 @default_index
-def cleanup_index_all(index=None, batch=5, synchronous=True):
+def cleanup_index_all(index=None, batch=5, synchronous=False):
     # Find entries in elasticsearch which are from previous versions of submissions and remove
     # Get all finished HEPSubmission ids with version numbers less than the max
     # finished version by doing a left outer join of hepsubmission with itself
@@ -279,8 +279,8 @@ def cleanup_index_all(index=None, batch=5, synchronous=True):
     ids = [x[0] for x in res]
 
     count = 0
-    while count <= len(ids):
-        batch_ids = ids[count:min(count + batch, len(ids) + 1)]
+    while count < len(ids):
+        batch_ids = ids[count:min(count + batch, len(ids))]
         if synchronous:
             cleanup_index_batch(batch_ids, index)
         else:
@@ -311,9 +311,10 @@ def cleanup_index_batch(hepsubmission_record_ids, index):
     res = qry.all()
 
     ids = [x[0] for x in res]
-    log.info(f'Deleting entries from index with ids {ids}')
-    s = RecordsSearch(index=index).filter('terms', _id=ids)
-    s.delete()
+    if ids:
+        log.info(f'Deleting entries from index with ids {ids}')
+        s = RecordsSearch(index=index).filter('terms', _id=ids)
+        s.delete()
 
 
 @default_index

--- a/hepdata/ext/elasticsearch/api.py
+++ b/hepdata/ext/elasticsearch/api.py
@@ -413,8 +413,9 @@ def push_data_keywords(pub_ids=None, index=None):
 
         # Get keywords for all data tables
         for data_table in tables.hits:
-            for k, v in data_table.data_keywords.to_dict().items():
-                all_keywords[k].extend(v)
+            if hasattr(data_table, 'data_keywords'):
+                for k, v in data_table.data_keywords.to_dict().items():
+                    all_keywords[k].extend(v)
 
         # Remove duplicates
         for k, v in all_keywords.items():

--- a/hepdata/ext/elasticsearch/document_enhancers.py
+++ b/hepdata/ext/elasticsearch/document_enhancers.py
@@ -30,6 +30,7 @@ from dateutil.parser import parse
 from flask import current_app
 
 from hepdata.config import CFG_PUB_TYPE, CFG_DATA_TYPE
+from hepdata.ext.elasticsearch.config.record_mapping import mapping as es_mapping
 from hepdata.modules.permissions.models import SubmissionParticipant
 from hepdata.modules.submission.api import get_latest_hepsubmission
 
@@ -104,10 +105,12 @@ def add_analyses(doc):
 
 
 def add_data_keywords(doc):
-    # Aggregate
+    # Aggregate and filter out invalid keywords
+    valid_keywords = list(es_mapping['data_keywords']['properties'].keys())
     agg_keywords = defaultdict(list)
     for kw in doc["keywords"]:
-        agg_keywords[kw['name']].append(kw['value'])
+        if kw['name'] in valid_keywords:
+            agg_keywords[kw['name']].append(kw['value'])
 
     # Remove duplicates
     for k, v in agg_keywords.items():

--- a/hepdata/modules/search/config.py
+++ b/hepdata/modules/search/config.py
@@ -20,7 +20,7 @@
 ELASTICSEARCH_MAX_RESULT_WINDOW = 10000  # default Elasticsearch value
 LIMIT_MAX_RESULTS_PER_PAGE = 100  # maximum value of 'size' parameter
 
-HEPDATA_CFG_MAX_RESULTS_PER_PAGE = 25
+HEPDATA_CFG_DEFAULT_RESULTS_PER_PAGE = 10
 HEPDATA_CFG_FACETS = ['author',
                       'collaboration',
                       'date',

--- a/hepdata/modules/search/views.py
+++ b/hepdata/modules/search/views.py
@@ -29,7 +29,7 @@ from hepdata.modules.records.utils.common import decode_string
 from hepdata.modules.records.api import get_all_ids as db_get_all_ids
 from hepdata.utils.session import get_session_item, set_session_item
 from hepdata.utils.url import modify_query
-from .config import HEPDATA_CFG_MAX_RESULTS_PER_PAGE, HEPDATA_CFG_FACETS
+from .config import HEPDATA_CFG_DEFAULT_RESULTS_PER_PAGE, HEPDATA_CFG_FACETS
 from .config import LIMIT_MAX_RESULTS_PER_PAGE
 
 blueprint = Blueprint('es_search',
@@ -72,14 +72,14 @@ def check_max_results(args):
     Get the size query parameter from the URL and if it doesn't exist
     assign a default value.
     """
-    max_results = args.get('size', HEPDATA_CFG_MAX_RESULTS_PER_PAGE)
+    max_results = args.get('size', HEPDATA_CFG_DEFAULT_RESULTS_PER_PAGE)
     try:
         max_results = int(max_results)
     except ValueError:
-        max_results = HEPDATA_CFG_MAX_RESULTS_PER_PAGE
+        max_results = HEPDATA_CFG_DEFAULT_RESULTS_PER_PAGE
 
     if max_results < 1:
-        max_results = HEPDATA_CFG_MAX_RESULTS_PER_PAGE
+        max_results = HEPDATA_CFG_DEFAULT_RESULTS_PER_PAGE
     elif max_results > LIMIT_MAX_RESULTS_PER_PAGE:
         max_results = LIMIT_MAX_RESULTS_PER_PAGE
 

--- a/tests/search_test.py
+++ b/tests/search_test.py
@@ -36,7 +36,7 @@ from hepdata.modules.submission.models import HEPSubmission, DataSubmission
 from invenio_search import current_search_client as es
 
 from hepdata.modules.search.config import LIMIT_MAX_RESULTS_PER_PAGE, \
-    HEPDATA_CFG_MAX_RESULTS_PER_PAGE
+    HEPDATA_CFG_DEFAULT_RESULTS_PER_PAGE
 from hepdata.modules.search.views import check_max_results
 
 def test_query_builder_add_aggregations():
@@ -629,12 +629,12 @@ def test_get_all_ids(app, load_default_data, identifiers):
 
 @pytest.mark.parametrize("input_size, output_size",
     [
-        (None, HEPDATA_CFG_MAX_RESULTS_PER_PAGE),
-        (0, HEPDATA_CFG_MAX_RESULTS_PER_PAGE),
-        (HEPDATA_CFG_MAX_RESULTS_PER_PAGE, HEPDATA_CFG_MAX_RESULTS_PER_PAGE),
+        (None, HEPDATA_CFG_DEFAULT_RESULTS_PER_PAGE),
+        (0, HEPDATA_CFG_DEFAULT_RESULTS_PER_PAGE),
+        (HEPDATA_CFG_DEFAULT_RESULTS_PER_PAGE, HEPDATA_CFG_DEFAULT_RESULTS_PER_PAGE),
         (LIMIT_MAX_RESULTS_PER_PAGE, LIMIT_MAX_RESULTS_PER_PAGE),
         (LIMIT_MAX_RESULTS_PER_PAGE + 1, LIMIT_MAX_RESULTS_PER_PAGE),
-        ('all', HEPDATA_CFG_MAX_RESULTS_PER_PAGE)
+        ('all', HEPDATA_CFG_DEFAULT_RESULTS_PER_PAGE)
     ]
 )
 def test_check_max_results(input_size, output_size):


### PR DESCRIPTION
Fix issues with cleanup-index, and checking that data_keywords exists before using it.

I'd suggest running cleanup-index before running the reindexing.