### PR TITLE
Fix reusing downloaded files when importing records for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
         SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
         SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
       run: |
-        if [[ -z ${{ secrets.SAUCE_USERNAME }} || -z ${{ secrets.SAUCE_ACCESS_KEY}} ]]; then py.test -s tests -k 'not tests/e2e'; else py.test -s tests; fi
+        if [[ -z ${{ secrets.SAUCE_USERNAME }} || -z ${{ secrets.SAUCE_ACCESS_KEY}} ]]; then py.test -vv tests -k 'not tests/e2e'; else py.test -vv tests; fi
     - name: Run coveralls
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
         SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
         SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
       run: |
-        if [[ -z ${{ secrets.SAUCE_USERNAME }} || -z ${{ secrets.SAUCE_ACCESS_KEY}} ]]; then py.test -vv tests -k 'not tests/e2e'; else py.test -vv tests; fi
+        if [[ -z ${{ secrets.SAUCE_USERNAME }} || -z ${{ secrets.SAUCE_ACCESS_KEY}} ]]; then py.test -s tests -k 'not tests/e2e'; else py.test -s tests; fi
     - name: Run coveralls
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,6 +114,7 @@ def import_default_data(app, identifiers):
         # sample files multiple times during testing
         def _test_download_file(base_url, inspire_id):
             filename = 'HEPData-ins{0}-v1-original.zip'.format(inspire_id)
+            print(f'Looking for file {filename} in {app.config["CFG_TMPDIR"]}')
             expected_file_name = os.path.join(app.config["CFG_TMPDIR"], filename)
             if os.path.exists(expected_file_name):
                 print("Using existing file at %s" % expected_file_name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,7 +113,7 @@ def import_default_data(app, identifiers):
         # Mock out the _download_file method in importer to avoid downloading the
         # sample files multiple times during testing
         def _test_download_file(base_url, inspire_id):
-            filename = 'HEPData-ins{0}-v1-original.zip'.format(inspire_id)
+            filename = 'HEPData-ins{0}-v1.zip'.format(inspire_id)
             print(f'Looking for file {filename} in {app.config["CFG_TMPDIR"]}')
             expected_file_name = os.path.join(app.config["CFG_TMPDIR"], filename)
             if os.path.exists(expected_file_name):


### PR DESCRIPTION
`conftest.py` mocks the `_download_file` method when importing files, to reuse the previously downloaded file. The filename for download had changed after that was first implemented but `conftest.py` was not modified so the tests were downloading fresh files every time. This PR fixes the filename.

This should hopefully reduce intermittent file download issues when running tests.

[This test run](https://github.com/HEPData/hepdata/actions/runs/924333694) shows that tests are now reusing the previous files.