### PR TITLE
SauceLabs fixes/logging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
         hepdata webpack build
         cp hepdata/config_local.gh.py hepdata/config_local.py
     - name: Setup Sauce Connect
-      uses: saucelabs/sauce-connect-action@v1
+      uses: alisonrclarke/sauce-connect-action@v1.1
       with:
         username: ${{ secrets.SAUCE_USERNAME }}
         accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
@@ -150,7 +150,7 @@ jobs:
         cd docs && make html SPHINXOPTS="-W"
     - uses: actions/upload-artifact@v2
       with:
-        name: sauce-connect-log
+        name: ${{ env.SAUCE_CONNECT_DIR_IN_HOST }}
         path: /opt/sauce-connect-action/sauce-connect.log
 
   deploy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
         hepdata webpack build
         cp hepdata/config_local.gh.py hepdata/config_local.py
     - name: Setup Sauce Connect
-      uses: alisonrclarke/sauce-connect-action@v1.1
+      uses: saucelabs/sauce-connect-action@main
       with:
         username: ${{ secrets.SAUCE_USERNAME }}
         accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,9 +128,10 @@ jobs:
       with:
         username: ${{ secrets.SAUCE_USERNAME }}
         accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
+        restUrl: https://eu-central-1.saucelabs.com/rest/v1
         tunnelIdentifier: ${{ github.run_id }}
         scVersion: 4.6.5
-        configFile: sc-config.yml
+        verbose: true
     - name: Run tests
       env:
         SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
@@ -150,7 +151,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: sauce-connect-log
-        path: sauce-connect-log.txt
+        path: /opt/sauce-connect-action/sauce-connect.log
 
   deploy:
     needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,9 +128,9 @@ jobs:
       with:
         username: ${{ secrets.SAUCE_USERNAME }}
         accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
-        restUrl: https://eu-central-1.saucelabs.com/rest/v1
         tunnelIdentifier: ${{ github.run_id }}
         scVersion: 4.6.5
+        configFile: sc-config.yml
     - name: Run tests
       env:
         SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
@@ -147,6 +147,10 @@ jobs:
       run: |
         python -m pip install -e .[docs]
         cd docs && make html SPHINXOPTS="-W"
+    - uses: actions/upload-artifact@v2
+      with:
+        name: sauce-connect-log
+        path: sauce-connect-log.txt
 
   deploy:
     needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,7 @@ jobs:
         python -m pip install -e .[docs]
         cd docs && make html SPHINXOPTS="-W"
     - uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
       with:
         name: sauce-connect-log
         path: ${{ env.SAUCE_CONNECT_DIR_IN_HOST }}/sauce-connect.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,8 +150,8 @@ jobs:
         cd docs && make html SPHINXOPTS="-W"
     - uses: actions/upload-artifact@v2
       with:
-        name: ${{ env.SAUCE_CONNECT_DIR_IN_HOST }}
-        path: /opt/sauce-connect-action/sauce-connect.log
+        name: sauce-connect-log
+        path: ${{ env.SAUCE_CONNECT_DIR_IN_HOST }}/sauce-connect.log
 
   deploy:
     needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,7 @@ jobs:
         accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
         restUrl: https://eu-central-1.saucelabs.com/rest/v1
         tunnelIdentifier: ${{ github.run_id }}
+        scVersion: 4.6.5
     - name: Run tests
       env:
         SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}

--- a/sc-config.yml
+++ b/sc-config.yml
@@ -1,0 +1,4 @@
+# Config file for use by SauceLabs Sauce Connect in CI
+logfile: "sauce-connect-log.txt"
+verbose: 1
+rest-url: "https://eu-central-1.saucelabs.com/rest/v1"

--- a/sc-config.yml
+++ b/sc-config.yml
@@ -1,4 +1,0 @@
-# Config file for use by SauceLabs Sauce Connect in CI
-logfile: "sauce-connect-log.txt"
-verbose: 1
-rest-url: "https://eu-central-1.saucelabs.com/rest/v1"


### PR DESCRIPTION
 * Ensure we use the latest version of Sauce Connect (4.6.5)
 * Set Sauce Connect log level to verbose and keep the Sauce Connect log file as an artifact if tests fail, to help with future debugging

Note that PR currently uses the `main` branch of the SauceConnect action rather than v1, because main includes a [change](https://github.com/saucelabs/sauce-connect-action/pull/33) I made to the action to determine where SauceLabs stores its log file. If we merge this PR before a new release of the action is made, we should log an issue to return to a versioned release at a later date.