### PR TITLE
Revise HTML/BibTeX content of Cite widget and other changes

### DIFF
--- a/hepdata/modules/dashboard/templates/hepdata_dashboard/dashboard-submissions.html
+++ b/hepdata/modules/dashboard/templates/hepdata_dashboard/dashboard-submissions.html
@@ -56,12 +56,14 @@
                     <h4><a href="/record/{{ submission.recid }}"
                            target="_blank">{{ submission.title }}</a>
 
-                        {% if submission.requires_inspire_id and submission.submission_status=='todo' %}
-                            <button class="btn btn-primary btn-xs inspire-btn"
-                                    id="inspire-btn-{{ submission.recid }}"
-                                    data-recid="{{ submission.recid }}">
-                                Attach INSPIRE Record
-                            </button>
+                        {% if ctx.user_is_admin or submission.show_coord_view %}
+                          {% if submission.requires_inspire_id and submission.submission_status=='todo' %}
+                              <button class="btn btn-primary btn-xs inspire-btn"
+                                      id="inspire-btn-{{ submission.recid }}"
+                                      data-recid="{{ submission.recid }}">
+                                  Attach INSPIRE Record
+                              </button>
+                          {% endif %}
                         {% endif %}
                     </h4>
                 </div>

--- a/hepdata/modules/records/templates/hepdata_records/components/cite-widget.html
+++ b/hepdata/modules/records/templates/hepdata_records/components/cite-widget.html
@@ -35,12 +35,11 @@
                                     </p>
                                     <div class="well well-small" style="background: white">
                                         {% if ctx.record.collaborations %}
-                                            <p><i>The
-                                                {% for collaboration in ctx.record.collaborations %}
-                                                  {% if loop.index > 1 %}&{% endif %}
-                                                    {{ collaboration }}{% endfor %}
-                                                collaboration{% if ctx.record.collaborations|length > 1 %}s{% endif %}
-                                              ({{ ctx.record.year }})</i>.</p>
+                                              {% for collaboration in ctx.record.collaborations %}
+                                                {% if loop.index > 1 %}&{% endif %}
+                                                  {{ collaboration }}{% endfor %}
+                                              Collaboration{% if ctx.record.collaborations|length > 1 %}s{% endif %}
+                                            ({{ ctx.record.year }}).
                                         {% else %}
                                             {% for author in ctx.record.summary_authors %}
                                                 {{ author.full_name }}
@@ -49,8 +48,31 @@
                                                     {{ ctx.record.year }}){% endif %}
                                             {% endfor %}
                                         {% endif %}
-                                        <p>{{ ctx.record.title }}. HEPData.</p>
+                                        <p>{{ ctx.record.title }}. HEPData (collection).</p>
                                         <p><strong>https://doi.org/{{ ctx.record.hepdata_doi }}</strong></p>
+                                    </div>
+
+                                    <p>or, if you prefer, a specific version of the <img
+                                            src="{{ url_for('static', filename='img/hepdata_logo.svg') }}" height="30">
+                                        record:
+                                    </p>
+                                    <div class="well well-small" style="background: white">
+                                        {% if ctx.record.collaborations %}
+                                              {% for collaboration in ctx.record.collaborations %}
+                                                {% if loop.index > 1 %}&{% endif %}
+                                                  {{ collaboration }}{% endfor %}
+                                              Collaboration{% if ctx.record.collaborations|length > 1 %}s{% endif %}
+                                            ({{ ctx.record.year }}).
+                                        {% else %}
+                                            {% for author in ctx.record.summary_authors %}
+                                                {{ author.full_name }}
+                                                {% if loop.index < ctx.record.summary_authors|length %},
+                                                {% else %} (
+                                                    {{ ctx.record.year }}){% endif %}
+                                            {% endfor %}
+                                        {% endif %}
+                                      <p>{{ ctx.record.title }} (Version {{ ctx.record.version }}). HEPData (collection).</p>
+                                        <p><strong>https://doi.org/{{ ctx.record.hepdata_doi }}.v{{ ctx.record.version }}</strong></p>
                                     </div>
 
                                     <p>
@@ -77,12 +99,11 @@
                                     {% for table in ctx.data_tables %}
                                         <div class="well well-small table-cite-html" id="table_cite_html_{{ loop.index }}"{% if loop.index > 1 %} style="display:none"{% endif %}>
                                             {% if ctx.record.collaborations %}
-                                                <p><i>The
-                                                    {% for collaboration in ctx.record.collaborations %}
-                                                        {% if loop.index > 1 %}&{% endif %}
-                                                        {{ collaboration }}{% endfor %}
-                                                    collaboration{% if ctx.record.collaborations|length > 1 %}s{% endif %}
-                                                  ({{ ctx.record.year }})</i>.</p>
+                                                  {% for collaboration in ctx.record.collaborations %}
+                                                      {% if loop.index > 1 %}&{% endif %}
+                                                      {{ collaboration }}{% endfor %}
+                                                  Collaboration{% if ctx.record.collaborations|length > 1 %}s{% endif %}
+                                                ({{ ctx.record.year }}).
                                             {% else %}
                                                 {% for author in ctx.record.authors %}
                                                     {{ author.full_name }}
@@ -91,7 +112,7 @@
                                                     {% endif %}
                                                 {% endfor %}
                                             {% endif %}
-                                            <p>"{{ table.name }}" of "{{ ctx.record.title }}". HEPData.</p>
+                                            <p>&ldquo;{{ table.name }}&rdquo; of &ldquo;{{ ctx.record.title }}&rdquo; (Version {{ ctx.record.version }}). HEPData (dataset).</p>
                                             <p><strong>https://doi.org/{{ table.doi }}</strong></p>
                                         </div>
                                     {% endfor %}
@@ -111,12 +132,11 @@
                                       {% for resource in ctx.resources_with_doi %}
                                         <div class="well well-small resource-cite-html" id="resource_cite_html_{{ loop.index }}"{% if loop.index > 1 %} style="display:none"{% endif %}>
                                             {% if ctx.record.collaborations %}
-                                                <p><i>The
-                                                    {% for collaboration in ctx.record.collaborations %}
-                                                        {% if loop.index > 1 %}&{% endif %}
-                                                        {{ collaboration }}{% endfor %}
-                                                    collaboration{% if ctx.record.collaborations|length > 1 %}s{% endif %}
-                                                  ({{ ctx.record.year }})</i>.</p>
+                                                  {% for collaboration in ctx.record.collaborations %}
+                                                      {% if loop.index > 1 %}&{% endif %}
+                                                      {{ collaboration }}{% endfor %}
+                                                  Collaboration{% if ctx.record.collaborations|length > 1 %}s{% endif %}
+                                                ({{ ctx.record.year }}).
                                             {% else %}
                                                 {% for author in ctx.record.authors %}
                                                     {{ author.full_name }}
@@ -125,7 +145,7 @@
                                                     {% endif %}
                                                 {% endfor %}
                                             {% endif %}
-                                            <p>"{{ resource.filename }}" of "{{ ctx.record.title }}". HEPData.</p>
+                                            <p>&ldquo;{{ resource.filename }}&rdquo; of &ldquo;{{ ctx.record.title }}&rdquo; (Version {{ ctx.record.version }}). HEPData (other).</p>
                                             <p><strong>https://doi.org/{{ resource.doi }}</strong></p>
                                         </div>
                                       {% endfor %}
@@ -149,20 +169,38 @@
                                             <i class="fa fa-copy" alt="Copy to clipboard"></i>
                                         </button>
                                     </p>
-                                    <!--<div class="well well-small" style="background: white">-->
                                         {% set title = '"{' + ctx.record.title + '}"' %}
-                                    <textarea readonly id="record_bibtex">@misc {
-    {{ ctx.record.inspire_id }},
+                                        {%  if ctx.record.hepdata_doi %}
+                                          {% set key = ctx.record.hepdata_doi.split('/', 1)[1] %}
+                                        {% endif %}
+                                        {% if ctx.record.collaborations %}
+                                          {% set author = "{" + "Collaboration} and {".join(ctx.record.collaborations) + " Collaboration}" %}
+                                        {% elif ctx.record.summary_authors %}
+                                          {% set author = ctx.record.summary_authors[0].full_name + " and others" %}
+                                        {% endif %}
+                                    <textarea readonly id="record_bibtex">@misc{{ "{" }}{{ key }},
+    author = "{{ author }}",
     title = {{ title }},
-    abstract = "{{ ctx.record.data_abstract }}",
-    doi = "{{ ctx.record.hepdata_doi }}",
-    url = "https://doi.org/{{ ctx.record.hepdata_doi }}",
-    year = "{{ ctx.record.year }}",
-    type = "Data Collection",
-    {% if ctx.record.collaborations %}collaboration = "{% for collaboration in ctx.record.collaborations %}{% if loop.index > 1 %}, {% endif %}{{ collaboration }}{% endfor %}",{% endif %}
-    {% if ctx.record.summary_authors %}authors = "{{ ctx.record.summary_authors[0].full_name }} and others"{% endif %}
+    howpublished = "{HEPData (collection)}",
+    year = {{ ctx.record.year }},
+    note = "\url{https://doi.org/{{ ctx.record.hepdata_doi }}}"
 }</textarea>
-                                    <!--</div>-->
+
+                                    <p>or, if you prefer, a specific version of the <img
+                                                src="{{ url_for('static', filename='img/hepdata_logo.svg') }}" height="30">
+                                            record:
+                                        <button class="btn btn-primary btn-sm cite-copy-btn pull-right" data-clipboard-target="#versioned_record_bibtex">
+                                            <i class="fa fa-copy" alt="Copy to clipboard"></i>
+                                        </button>
+                                        </p>
+                                    {% set title = '"{' + ctx.record.title + ' (Version ' + ctx.record.version|string + ')}"' %}
+                                    <textarea readonly id="versioned_record_bibtex">@misc{{ "{" }}{{ key }}.v{{ ctx.record.version }},
+    author = "{{ author }}",
+    title = {{ title }},
+    howpublished = "{HEPData (collection)}",
+    year = {{ ctx.record.year }},
+    note = "\url{https://doi.org/{{ ctx.record.hepdata_doi }}.v{{ ctx.record.version }}}"
+}</textarea>
 
                                     <p>
                                       You can also cite the {{ ctx.data_tables|length }} data
@@ -188,17 +226,16 @@
                                     </p>
 
                                     {% for table in ctx.data_tables %}
-                                      {% set title = '"{\'' +  table.name + '\' of \'' + ctx.record.title + '\'}"' %}
-                                    <textarea class="table-bibtex" id="table_bibtex_{{ loop.index }}" readonly{% if loop.index > 1 %} style="display:none"{% endif %}>@misc {
-    {{ ctx.record.inspire_id }}/t{{ loop.index }},
+                                      {% set title = '"{``' +  table.name + '\'\' of ``' + ctx.record.title + '\'\' (Version ' + ctx.record.version|string + ')}"' %}
+                                      {% if table.doi %}
+                                          {% set key = table.doi.split('/', 1)[1] %}
+                                      {% endif %}
+                                    <textarea class="table-bibtex" id="table_bibtex_{{ loop.index }}" readonly{% if loop.index > 1 %} style="display:none"{% endif %}>@misc{{ "{" }}{{ key }},
+    author = "{{ author }}",
     title = {{ title }},
-    abstract = "{{ table.description }}",
-    doi = "{{ table.doi }}",
-    url = "https://doi.org/{{ table.doi }}",
-    year = "{{ ctx.record.year }}",
-    type = "Data Set",
-    {% if ctx.record.collaborations %}collaboration = "{% for collaboration in ctx.record.collaborations %}{% if loop.index > 1 %}, {% endif %}{{ collaboration }}{% endfor %}",{% endif %}
-    {% if ctx.record.summary_authors %}authors = "{{ ctx.record.summary_authors[0].full_name }} and others"{% endif %}
+    howpublished = "{HEPData (dataset)}",
+    year = {{ ctx.record.year }},
+    note = "\url{https://doi.org/{{ table.doi }}}"
 }</textarea>
                                     {% endfor %}
 
@@ -218,17 +255,16 @@
                                       </p>
 
                                       {% for resource in ctx.resources_with_doi %}
-                                        {% set title = '"{\'' +  resource.filename + '\' of \'' + ctx.record.title + '\'}"' %}
-                                        <textarea class="resource-bibtex" id="resource_bibtex_{{ loop.index }}" readonly{% if loop.index > 1 %} style="display:none"{% endif %}>@misc {
-    {{ ctx.record.inspire_id }}/r{{ loop.index }},
+                                        {% set title = '"{``' +  resource.filename + '\'\' of ``' + ctx.record.title + '\'\' (Version ' + ctx.record.version|string + ')}"' %}
+                                        {% if resource.doi %}
+                                          {% set key = resource.doi.split('/', 1)[1] %}
+                                        {% endif %}
+                                        <textarea class="resource-bibtex" id="resource_bibtex_{{ loop.index }}" readonly{% if loop.index > 1 %} style="display:none"{% endif %}>@misc{{ "{" }}{{ key }},
+    author = "{{ author }}",
     title = {{ title }},
-    abstract = "{{ resource.description }}",
-    doi = "{{ resource.doi }}",
-    url = "https://doi.org/{{ resource.doi }}",
-    year = "{{ ctx.record.year }}",
-    type = "Data Set",
-    {% if ctx.record.collaborations %}collaboration = "{% for collaboration in ctx.record.collaborations %}{% if loop.index > 1 %}, {% endif %}{{ collaboration }}{% endfor %}",{% endif %}
-    {% if ctx.record.summary_authors %}authors = "{{ ctx.record.summary_authors[0].full_name }} and others"{% endif %}
+    howpublished = "{HEPData (other)}",
+    year = {{ ctx.record.year }},
+    note = "\url{https://doi.org/{{ resource.doi }}}"
 }</textarea>
                                       {% endfor %}
 

--- a/hepdata/modules/records/templates/hepdata_records/components/cite/publication.html
+++ b/hepdata/modules/records/templates/hepdata_records/components/cite/publication.html
@@ -1,10 +1,9 @@
 {% if ctx.record.collaborations %}
-    <p><i>The
-        {% for collaboration in ctx.record.collaborations %}
-          {% if loop.index > 1 %}&{% endif %}
-            {{ collaboration }}{% endfor %}
-        collaboration{% if ctx.record.collaborations|length > 1 %}s{% endif %}
-      ({{ ctx.record.year }})</i>.</p>
+      {% for collaboration in ctx.record.collaborations %}
+        {% if loop.index > 1 %}&{% endif %}
+          {{ collaboration }}{% endfor %}
+      Collaboration{% if ctx.record.collaborations|length > 1 %}s{% endif %}
+    ({{ ctx.record.year }}).
 {% else %}
     {% for author in ctx.record.authors %}
         {{ author.full_name }}{% if loop.index < ctx.record.authors|length %},
@@ -13,9 +12,11 @@
     {% endfor %}
 {% endif %}
 <p>{{ ctx.record.title }}. {{ ctx.record.journal_info|trim }}.</p>
-<p><strong>https://doi.org/{{ ctx.record.doi }}</strong></p>
+{% if ctx.record.doi %}
+  <p><strong>https://doi.org/{{ ctx.record.doi }}</strong></p>
+{% endif %}
 
 <a href="https://inspirehep.net/literature/{{ ctx.record.inspire_id }}" class="btn btn-default btn-sm" target="_new">View
-    Inspire Record</a>
+    INSPIRE Record</a>
 <a href="https://inspirehep.net/api/literature/{{ ctx.record.inspire_id }}?format=bibtex" class="btn btn-default btn-sm"
-   target="_new">Download BibTeX from Inspire</a>
+   target="_new">Download BibTeX from INSPIRE</a>

--- a/hepdata/modules/records/templates/hepdata_records/formats/datacite/datacite_data_record.xml
+++ b/hepdata/modules/records/templates/hepdata_records/formats/datacite/datacite_data_record.xml
@@ -26,8 +26,7 @@
         <date dateType="Updated">{{ overall_submission.last_updated }}</date>
     </dates>
     <titles>
-        <title>{{ table_name }}</title>
-        <title xml:lang="en-us" titleType="Subtitle">{{ publication_info.title }}</title>
+        <title>"{{ table_name }}" of "{{ publication_info.title }}"</title>
     </titles>
     <publisher>HEPData</publisher>
     <publicationYear>{{ overall_submission.last_updated.year }}</publicationYear>

--- a/hepdata/modules/records/templates/hepdata_records/formats/datacite/datacite_resource.xml
+++ b/hepdata/modules/records/templates/hepdata_records/formats/datacite/datacite_resource.xml
@@ -26,8 +26,7 @@
         <date dateType="Updated">{{ overall_submission.last_updated }}</date>
     </dates>
     <titles>
-        <title>{{ filename }}</title>
-        <title xml:lang="en-us" titleType="Subtitle">{{ publication_info.title }}</title>
+        <title>"{{ filename }}" of "{{ publication_info.title }}"</title>
     </titles>
     <publisher>HEPData</publisher>
     <publicationYear>{{ overall_submission.last_updated.year }}</publicationYear>

--- a/hepdata/modules/records/utils/records_update_utils.py
+++ b/hepdata/modules/records/utils/records_update_utils.py
@@ -49,11 +49,12 @@ def update_record_info(inspire_id, send_email=False):
 
         # Also need to update publication information for data records.
         data_submissions = DataSubmission.query.filter_by(
-            publication_recid=publication_recid, version=hep_submission.version
+            publication_recid=publication_recid,
         ).order_by(DataSubmission.id.asc())
         record_ids = [publication_recid]  # list of record IDs
         for data_submission in data_submissions:
-            record_ids.append(data_submission.associated_recid)
+            if data_submission.associated_recid:
+                record_ids.append(data_submission.associated_recid)
 
         same_information = {}
         for index, recid in enumerate(record_ids):
@@ -85,7 +86,7 @@ def update_record_info(inspire_id, send_email=False):
         log.warning("Failed to retrieve publication information for Inspire record {0}".format(inspire_id))
         return 'Invalid Inspire ID'
 
-    if hep_submission.overall_status == 'finished':
+    if hep_submission.overall_status == 'finished' or hep_submission.version > 1:
         index_record_ids(record_ids)  # index for Elasticsearch
         push_data_keywords(pub_ids=[recid])
         if not TESTING:

--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20210927"
+__version__ = "0.9.4dev20211028"


### PR DESCRIPTION
The main purpose of this PR is to revise the content of the "Cite" widget as follows:

* Give citation information for the versioned DOI of a record.
* Follow DataCite preferred format (e.g. include `resourceTypeGeneral`).
* Use BibTeX keys based on the last part of the DOI after first `/`.
* Only use standard BibTeX fields for `@misc` type (closes #408).

It also combines the title and subtitle in the DataCite XML for data tables and resource files, which should improve the search results shown in both DataCite Search and Google Dataset Search.  Currently the results just show titles like "Table 3" which does not seem useful.  The [Google guidelines](https://developers.google.com/search/docs/advanced/structured-data/dataset#dataset) say "Use unique names for distinct datasets whenever possible".

Although unrelated, the PR also fixes #403 and fixes #406.