### PR TITLE
Fix line break issues in emails

### DIFF
--- a/hepdata/modules/theme/templates/hepdata_theme/email/coordinator_request.html
+++ b/hepdata/modules/theme/templates/hepdata_theme/email/coordinator_request.html
@@ -14,9 +14,7 @@ New Coordinator Request
         <p>
             <b>A message has been supplied:</b>
         </p>
-        <div style="padding-left: 20px; white-space: pre-wrap;">
-            <p>{{ message }}</p>
-        </div>
+        <pre style="padding-left:20px;font-family:'Lato',sans-serif;">{{ message }}</pre>
     {% endif %}
 
     <p>

--- a/hepdata/modules/theme/templates/hepdata_theme/email/invite.html
+++ b/hepdata/modules/theme/templates/hepdata_theme/email/invite.html
@@ -49,9 +49,7 @@
         <p>
             <b>A message has been supplied by the Coordinator ({{ coordinator_email }}). </b>
         </p>
-        <div style="padding-left: 20px; white-space: pre-wrap;">
-            <p>{{ message }}</p>
-        </div>
+        <pre style="padding-left:20px;font-family:'Lato',sans-serif;">{{ message }}</pre>
     {% endif %}
 
     <p>

--- a/hepdata/modules/theme/templates/hepdata_theme/email/passed_review.html
+++ b/hepdata/modules/theme/templates/hepdata_theme/email/passed_review.html
@@ -15,7 +15,7 @@ Record {{ article }} ready to be finalised
 
     {% if message %}
         <p style="font-weight: bolder">Message:</p>
-        <p style="padding-left: 20px; font-weight: lighter; white-space: pre-wrap;">{{ message }}</p>
+        <pre style="padding-left:20px;font-family:'Lato',sans-serif;font-weight:lighter;">{{ message }}</pre>
     {% endif %}
 
     <p>The submission is now ready to be finalised{% if collaboration %} for {{ collaboration }}{% endif %}, which can be done from your <a href="{{ dashboard_link }}">HEPData dashboard</a>.</p>

--- a/hepdata/modules/theme/templates/hepdata_theme/email/question.html
+++ b/hepdata/modules/theme/templates/hepdata_theme/email/question.html
@@ -11,7 +11,7 @@
     in HEPData.</p>
 
     <p style="font-weight: bolder">Message:</p>
-    <p style="padding-left: 20px; font-weight: lighter; white-space: pre-wrap;">{{ message }}</p>
+    <pre style="padding-left:20px;font-family:'Lato',sans-serif;font-weight:lighter;">{{ message }}</pre>
 
     <br/>
     <hr>

--- a/hepdata/modules/theme/templates/hepdata_theme/email/review-message.html
+++ b/hepdata/modules/theme/templates/hepdata_theme/email/review-message.html
@@ -11,7 +11,7 @@ New Review Message for Record {{ article }}
         from {{ actor }}.</p>
 
     <p style="font-weight: bolder">Message:</p>
-    <p style="padding-left: 20px; font-weight: lighter; white-space: pre-wrap;">{{ table_message }}</p>
+    <pre style="padding-left:20px;font-family:'Lato',sans-serif;font-weight:lighter;">{{ table_message }}</pre>
 
     <p>You can view the table <a href="{{ table_link }}" style="color: #9b59b6">here</a>.
     </p>

--- a/hepdata/modules/theme/templates/hepdata_theme/email/submission_status.html
+++ b/hepdata/modules/theme/templates/hepdata_theme/email/submission_status.html
@@ -36,7 +36,7 @@
 
     {% if message %}
         <p style="font-weight: bolder">Message:</p>
-        <p style="padding-left: 20px; font-weight: lighter; white-space: pre-wrap;">{{ message }}</p>
+        <pre style="font-family:'Lato',sans-serif;font-weight:lighter;">{{ message }}</pre>
     {% endif %}
 
     {% if show_detail %}
@@ -66,9 +66,7 @@
               {% for message_data in table.messages %}
                 <div style="font-size:90%">
                   <p style="font-weight:bold;margin:5px">{{ message_data.user }} said on {{ message_data.date }}:</p>
-                  <p style="margin:5px 5px 10px 15px;">
-                    {{ message_data.message }}
-                  </p>
+                  <pre style="font-family:'Lato',sans-serif;margin:5px 5px 10px 15px;">{{ message_data.message }}</pre>
                 </div>
               {% endfor %}
             </td>

--- a/hepdata/modules/theme/templates/hepdata_theme/email/upload_errors.html
+++ b/hepdata/modules/theme/templates/hepdata_theme/email/upload_errors.html
@@ -40,7 +40,7 @@
             {% for error in file_errors %}
                 <div style="background-color:#ECF0F1;min-height:40px;margin:3px;border-radius:0 4px 4px 0;display:flex;">
                     <div style="background-color:#C03A2B;padding:10px;width:10%;border-radius:4px 0 0 4px;color: #fff;float:left!important;">{{ error.level }}</div>
-                    <div style="padding:10px;width:75%;text-align:left;color: #3B5169;float:right!important;white-space:pre-wrap;">{{ error.message|safe }}</div>
+                    <pre style="font-family:'Lato',sans-serif;font-weight:lighter;padding:10px;margin:0;width:75%;text-align:left;color: #3B5169;float:right!important;">{{ error.message|safe }}</pre>
                     <div style="clear:both;"></div>
                 </div>
             {% endfor %}


### PR DESCRIPTION
Using actual `<pre>` tags rather than styling with `whitespace:pre-wrap` should stop MS from removing line breaks.

Fixes #405

Note that I haven't tested emails going from HEPData to an O365 account; I've just tested from a mail client that whitespace in `pre` tags doesn't get removed.