### PR TITLE
Fix celery issues

### DIFF
--- a/hepdata/config.py
+++ b/hepdata/config.py
@@ -67,6 +67,7 @@ CELERY_TASK_ROUTES = {
     'hepdata.modules.records.api.process_saved_file': {'queue': 'priority'},
     'hepdata.modules.records.utils.doi_minter.create_container_doi': {'queue': 'datacite'},
     'hepdata.modules.records.utils.doi_minter.create_data_doi': {'queue': 'datacite'},
+    'hepdata.modules.records.utils.doi_minter.create_resource_doi': {'queue': 'datacite'},
 }
 
 CELERY_BEAT_SCHEDULE = {
@@ -93,12 +94,14 @@ CELERY_TASK_ANNOTATIONS = {
         'default_retry_delay': 30
     },
     'hepdata.modules.records.utils.doi_minter.create_container_doi': {
-        'rate_limit': f"{100 / DATACITE_QUEUE_WORKERS}/m"
+        'rate_limit': f"{50 / DATACITE_QUEUE_WORKERS}/m"
     },
     'hepdata.modules.records.utils.doi_minter.create_data_doi': {
         'rate_limit': f"{500 / DATACITE_QUEUE_WORKERS}/m"
     },
-
+    'hepdata.modules.records.utils.doi_minter.create_resource_doi': {
+        'rate_limit': f"{50 / DATACITE_QUEUE_WORKERS}/m"
+    },
 }
 
 # Cache

--- a/hepdata/modules/records/utils/doi_minter.py
+++ b/hepdata/modules/records/utils/doi_minter.py
@@ -62,7 +62,7 @@ def generate_doi_for_table(doi):
     ).first()
 
     if hep_submission:
-        create_data_doi(hep_submission.id, data_submission.id, site_url)
+        create_data_doi.delay(hep_submission.id, data_submission.id, site_url)
     else:
         print('Finished submission with INSPIRE ID {} and version {} not found in database'.format(
             data_submission.publication_inspire_id, data_submission.version)


### PR DESCRIPTION
 * Ensure `create_resource_doi` runs on the `datacite` queue so that it is rate limited.
 * Fix issue where `generate_doi_for_table` wasn't queueing `create_table_doi`

Note that `CELERY_TASK_ANNOTATIONS` in the Kubernetes config will also need updating as per the changes in `config.py`:

```
CELERY_TASK_ANNOTATIONS = {
    '*': {
        'acks_late': True,
        'reject_on_worker_lost': True,
        'autoretry_for': (Exception,),
        'default_retry_delay': 30
    },
    'hepdata.modules.records.utils.doi_minter.create_container_doi': {
        'rate_limit': f"{50 / DATACITE_QUEUE_WORKERS}/m"
    },
    'hepdata.modules.records.utils.doi_minter.create_data_doi': {
        'rate_limit': f"{500 / DATACITE_QUEUE_WORKERS}/m"
    },
    'hepdata.modules.records.utils.doi_minter.create_resource_doi': {
        'rate_limit': f"{50 / DATACITE_QUEUE_WORKERS}/m"
    },
}
```