### PR TITLE
Bump hepdata-validator version to 0.3.2 and update test

### DIFF
--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20211130"
+__version__ = "0.9.4dev20211201"

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ Flask-Login==0.3.2
 gevent==1.4.0
 gunicorn==19.5.0
 hepdata-converter-ws-client==0.2.2
-hepdata-validator==0.3.1
+hepdata-validator==0.3.2
 invenio-access==1.4.2      # Indirect (needed by invenio-admin)
 invenio-accounts==1.4.6
 invenio-admin==1.3.0

--- a/tests/submission_test.py
+++ b/tests/submission_test.py
@@ -274,7 +274,7 @@ def test_old_submission_yaml(app, admin_idx):
     ))
     assert(errors['submission.yaml'][1]['level'] == 'error')
     assert(errors['submission.yaml'][1]['message'].startswith(
-        "Invalid value (in GeV) for cmenergies: '1.383-1.481'"
+        "Invalid value (in GeV) for cmenergies: '1.383-1.481 GeV'"
     ))
 
     # Use old schema - should now work

--- a/tests/test_data/test_v0_submission/submission.yaml
+++ b/tests/test_data/test_v0_submission/submission.yaml
@@ -17,6 +17,6 @@ keywords:
 - name: phrases
   values: [Exclusive, Polarization, Photoproduction]
 - name: cmenergies
-  values: [1.383-1.481]
+  values: [1.383-1.481 GeV]
 name: Table 1
 table_doi: 10.17182/hepdata.21754.v1/t1


### PR DESCRIPTION
This PR updates the `hepdata-validator` version in the `requirements.txt` file to the latest version 0.3.2.  One of the tests `test_old_submission_yaml` broke after the bug HEPData/hepdata-validator#42 was fixed by the PR HEPData/hepdata-validator#41.  I've therefore updated the test data to replace `[1.383-1.481]` (which now passes validation) for the `values` of the `cmenergies` keyword by `[1.383-1.481 GeV]` (which still fails validation).