### PR TITLE
Create JSON-LD directly to avoid datacite rate limits

### DIFF
--- a/hepdata/modules/records/utils/common.py
+++ b/hepdata/modules/records/utils/common.py
@@ -179,13 +179,20 @@ def default_time(obj):
     return obj
 
 
-def truncate_string(string, words):
-    all_words = string.split()
-    truncated_string = ' '.join(all_words[:words])
+def truncate_string(string, max_words=None, max_chars=None):
+    if max_words:
+        all_words = string.split()
+        truncated_string = ' '.join(all_words[:max_words])
 
-    if len(all_words) > words:
-        truncated_string += '...'
-    return truncated_string
+        if len(all_words) > max_words:
+            truncated_string += '...'
+        return truncated_string
+
+    elif max_chars:
+        if len(string) < max_chars:
+            return string
+        else:
+            return string[:(max_chars - 3)] + '...'
 
 
 def get_record_contents(recid, status=None):

--- a/hepdata/modules/records/utils/json_ld.py
+++ b/hepdata/modules/records/utils/json_ld.py
@@ -48,12 +48,12 @@ def get_json_ld(ctx, submission_status, data_submission=None):
             "@type": "Organization",
             "name": "HEPData"
         },
-        "version": "1",
+        "version": ctx['version'],
         "identifier": [
             {
               "@type": "PropertyValue",
               "propertyID": "HEPDataRecord",
-              "value": f"{ctx['site_url']}/record/ins{ctx['record']['inspire_id']}"
+              "value": f"{ctx['site_url']}/record/ins{ctx['record']['inspire_id']}?version={ctx['version']}"
             },
             {
               "@type": "PropertyValue",
@@ -139,7 +139,7 @@ def _add_publication_info(data, ctx):
     data["@type"] = "Dataset"
     data["additionalType"] = "Collection"
     data["@id"] = f"https://doi.org/{ctx['record']['hepdata_doi']}"
-    data["url"] = f"{ctx['site_url']}/record/ins{ctx['record']['inspire_id']}"
+    data["url"] = f"{ctx['site_url']}/record/ins{ctx['record']['inspire_id']}?version={ctx['version']}"
     abstract = ctx['record'].get('data_abstract') or ctx['record'].get('abstract') or "No description available"
     data["description"] = truncate_string(abstract, max_chars=5000)
     data["name"] = truncate_string(ctx['record']['title'], max_chars=5000)
@@ -222,5 +222,5 @@ def _add_is_part_of(data, ctx):
         "@type": "Dataset",
         "name": truncate_string(ctx['record']['title'], max_chars=5000),
         "description": truncate_string(abstract, max_chars=5000),
-        "url": f"{ctx['site_url']}/record/ins{ctx['record']['inspire_id']}"
+        "url": f"{ctx['site_url']}/record/ins{ctx['record']['inspire_id']}?version={ctx['version']}"
     }

--- a/hepdata/modules/records/utils/json_ld.py
+++ b/hepdata/modules/records/utils/json_ld.py
@@ -1,0 +1,226 @@
+# This file is part of HEPData.
+# Copyright (C) 2021 CERN.
+#
+# HEPData is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# HEPData is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with HEPData; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+from hepdata.modules.records.utils.common import truncate_string
+
+
+def get_json_ld(ctx, submission_status, data_submission=None):
+    """Generates JSON-LD metadata as a python dict
+
+    :param type ctx: Context as would be passed to templates for a publication, data record or data resource
+    :param type submission_status: Current status of the record's submission
+    :return: dict containing metadata ready to be converted to JSON.
+    :rtype: dict
+
+    """
+    if not ctx.get('record') or not ctx['record'].get('hepdata_doi') \
+            or submission_status != 'finished':
+        return {
+            'error': 'JSON-LD is unavailable for this record; JSON-LD is only available for finalised records with DOIs.'
+        }
+
+    data = {
+        "@context": "http://schema.org",
+        "inLanguage": "en",
+        "provider": {
+            "@type": "Organization",
+            "name": "HEPData"
+        },
+        "publisher": {
+            "@type": "Organization",
+            "name": "HEPData"
+        },
+        "version": "1",
+        "identifier": [
+            {
+              "@type": "PropertyValue",
+              "propertyID": "HEPDataRecord",
+              "value": f"{ctx['site_url']}/record/ins{ctx['record']['inspire_id']}"
+            },
+            {
+              "@type": "PropertyValue",
+              "propertyID": "HEPDataRecordAlt",
+              "value": f"{ctx['site_url']}/record/{ctx['record']['recid']}"
+            }
+        ],
+        'datePublished': str(ctx['record']['last_updated'].year)
+    }
+
+    if ctx['record'].get('inspire_id') or ctx['record'].get('journal_info') != "No Journal Information":
+        _add_is_based_on(data, ctx)
+
+    _add_authors(data, ctx)
+
+    if ctx['record_type'] == 'publication':
+        _add_publication_info(data, ctx)
+    elif ctx['record_type'] == 'table':
+        _add_table_info(data, ctx, data_submission)
+    elif ctx['record_type'] == 'resource':
+        _add_resource_info(data, ctx)
+
+    return data
+
+
+def _add_is_based_on(data, ctx):
+    is_based_on = []
+
+    if ctx['record'].get('inspire_id'):
+        is_based_on.append(
+            {
+                "@type": "ScholarlyArticle",
+                "identifier": {
+                     "@type": "PropertyValue",
+                     "propertyID": "URL",
+                     "value": f"https://inspirehep.net/literature/{ctx['record']['inspire_id']}"
+                }
+            }
+        )
+
+    if ctx['record'].get('doi'):
+        is_based_on.append({
+           "@id": f"https://doi.org/{ctx['record']['doi']}",
+           "@type": "JournalArticle"
+        })
+
+    data["@reverse"] = {"isBasedOn": is_based_on}
+
+
+def _add_authors(data, ctx):
+    if ctx['record'].get('collaborations'):
+        collaborations = [
+            {
+                "@type": "Organization",
+                "name": f'{c} Collaboration'
+            }
+            for c in ctx['record'].get('collaborations')
+        ]
+        if len(collaborations) == 1:
+            collaborations = collaborations[0]
+
+        data['author'] = collaborations
+        data['creator'] = collaborations
+    else:
+        authors = []
+        for author in ctx['record'].get('summary_authors', []):
+            author_data = {
+                "@type": "Person",
+                "name": author['full_name'],
+            }
+            if author.get('affiliation'):
+                author_data['affiliation'] = {
+                    "@type": "Organisation",
+                    "name": author['affiliation']
+                }
+            authors.append(author_data)
+
+        data['author'] = authors
+        data['creator'] = authors
+
+
+def _add_publication_info(data, ctx):
+    data["@type"] = "Dataset"
+    data["additionalType"] = "Collection"
+    data["@id"] = f"https://doi.org/{ctx['record']['hepdata_doi']}"
+    data["url"] = f"{ctx['site_url']}/record/ins{ctx['record']['inspire_id']}"
+    abstract = ctx['record'].get('data_abstract') or ctx['record'].get('abstract') or "No description available"
+    data["description"] = truncate_string(abstract, max_chars=5000)
+    data["name"] = truncate_string(ctx['record']['title'], max_chars=5000)
+
+    has_part = []
+
+    for table in ctx['data_tables']:
+        has_part.append({
+            "@id": f"https://doi.org/{table['doi']}",
+            "@type": "Dataset",
+            "description": truncate_string(table['description'], max_chars=5000),
+            "name": table['name']
+        })
+
+    data['hasPart'] = has_part
+
+
+def _add_table_info(data, ctx, data_submission):
+    data["@type"] = "Dataset"
+    data["additionalType"] = "Dataset"
+    table_id = ctx['table_id_to_show']
+    table_metadata = None
+    for table in ctx['data_tables']:
+        if table_id == table['id']:
+            table_metadata = table
+            break
+
+    if table_metadata:
+        data["@id"] = f"https://doi.org/{table_metadata['doi']}"
+        data["name"] = table_metadata['name']
+        if table_metadata['description']:
+            data["description"] = truncate_string(table_metadata['description'], max_chars=5000)
+
+    if data_submission:
+        data["keywords"] = ', '.join([k.value for k in data_submission.keywords])
+        data["url"] = f"{ctx['site_url']}/record/{data_submission.associated_recid}"
+
+    data_downloads = []
+    download_types = {
+        'root': 'https://root.cern',
+        'yaml': 'https://yaml.org',
+        'csv': 'text/csv',
+        'yoda': 'https://yoda.hepforge.org'
+    }
+    for download_type, format in download_types.items():
+        data_downloads.append({
+          "@type": "DataDownload",
+          "contentUrl": f"{ctx['site_url']}/download/table/{ctx['table_id_to_show']}/{download_type}",
+          "description": download_type.upper() + " file",
+          "encodingFormat": format
+        })
+
+    data['distribution'] = data_downloads
+
+    _add_is_part_of(data, ctx)
+    data["includedInDataCatalog"] = {
+        "@id": data["isPartOf"]["@id"],
+        "@type": "DataCatalog",
+        "url": data["isPartOf"]["url"]
+    }
+
+
+def _add_resource_info(data, ctx):
+    data["@id"] = f"https://doi.org/{ctx['resource'].doi}"
+    data["@type"] = "CreativeWork"
+    data["additionalType"] = f"{ctx['resource'].file_type} file"
+    data["contentUrl"] = f"{ctx['site_url']}/record/resource/{ctx['resource'].id}?view=true"
+    description = ctx['resource'].file_description or "No file description available"
+    data["description"] = truncate_string(description, max_chars=5000)
+    name = f'"{ctx["resource_filename"]}" of "{ctx["record"]["title"]}"'
+    data["name"] = truncate_string(name, max_chars=5000)
+    data["url"] = f"{ctx['site_url']}/record/resource/{ctx['resource'].id}?landing_page=true"
+    _add_is_part_of(data, ctx)
+
+
+def _add_is_part_of(data, ctx):
+    abstract = ctx['record'].get('data_abstract') or ctx['record'].get('abstract') or "No description available"
+    data["isPartOf"] = {
+        "@id": f"https://doi.org/{ctx['record'].get('hepdata_doi')}",
+        "@type": "Dataset",
+        "name": truncate_string(ctx['record']['title'], max_chars=5000),
+        "description": truncate_string(abstract, max_chars=5000),
+        "url": f"{ctx['site_url']}/record/ins{ctx['record']['inspire_id']}"
+    }

--- a/hepdata/modules/records/utils/json_ld.py
+++ b/hepdata/modules/records/utils/json_ld.py
@@ -126,7 +126,7 @@ def _add_authors(data, ctx):
             }
             if author.get('affiliation'):
                 author_data['affiliation'] = {
-                    "@type": "Organisation",
+                    "@type": "Organization",
                     "name": author['affiliation']
                 }
             authors.append(author_data)

--- a/tests/e2e/test_general.py
+++ b/tests/e2e/test_general.py
@@ -242,7 +242,7 @@ def test_accept_headers(app, live_server, e2e_identifiers):
     json_ld = response.json()
     # Check some fields to make sure it's json for right record
     assert json_ld['@id'] == 'https://doi.org/10.17182/hepdata.1'
-    assert json_ld['url'] == 'http://localhost:5000/record/ins1283842'
+    assert json_ld['url'] == 'http://localhost:5000/record/ins1283842?version=1'
     assert json_ld['@type'] == 'Dataset'
 
     # Main submission page (using rec id, and testing 'application/vnd.hepdata.ld+json')

--- a/tests/e2e/test_general.py
+++ b/tests/e2e/test_general.py
@@ -231,12 +231,6 @@ def test_general_pages(live_server, env_browser):
 
 def test_accept_headers(app, live_server, e2e_identifiers):
     """Test records pages respond to Accept headers"""
-    dummy_json = {
-        '@context': 'http://schema.org',
-        '@type': 'Thing',
-        'name': 'Test Metadata'
-    }
-
     # Main submission page (using inspire_id)
     record_url = flask.url_for(
         'hepdata_records.get_metadata_by_alternative_id',
@@ -246,12 +240,10 @@ def test_accept_headers(app, live_server, e2e_identifiers):
     response = requests.get(record_url, headers={'Accept': 'application/ld+json'})
     assert response.status_code == 200
     json_ld = response.json()
-    # json_ld should be a superset of dummy_json
-    assert dummy_json.items() <= json_ld.items()
-    # Should also contain a description
-    assert json_ld.get('description').startswith(
-        'Fermilab-Tevatron.  We present measurements of the forward-backward asymmetry, ASYMFB(LEPTON) in the angular distribution of leptons'
-    )
+    # Check some fields to make sure it's json for right record
+    assert json_ld['@id'] == 'https://doi.org/10.17182/hepdata.1'
+    assert json_ld['url'] == 'http://localhost:5000/record/ins1283842'
+    assert json_ld['@type'] == 'Dataset'
 
     # Main submission page (using rec id, and testing 'application/vnd.hepdata.ld+json')
     record_url = flask.url_for(
@@ -274,10 +266,11 @@ def test_accept_headers(app, live_server, e2e_identifiers):
     response = requests.get(record_url, headers={'Accept': 'application/ld+json'})
     assert response.status_code == 200
     json_ld3 = response.json()
-    # json_ld should be a superset of dummy_json
-    assert dummy_json.items() <= json_ld3.items()
-    # Should also contain data downloads
-    assert json_ld3.get('distribution') == [
+    # Check some fields to make sure it's json for right record
+    assert json_ld3['@id'] == 'https://doi.org/10.17182/hepdata.1.v1/t1'
+    assert json_ld3['url'] == 'http://localhost:5000/record/2'
+    assert json_ld3['@type'] == 'Dataset'
+    assert json_ld3['distribution'] == [
         {'@type': 'DataDownload', 'contentUrl': 'http://localhost:5000/download/table/1/root', 'description': 'ROOT file', 'encodingFormat': 'https://root.cern'},
         {'@type': 'DataDownload', 'contentUrl': 'http://localhost:5000/download/table/1/yaml', 'description': 'YAML file', 'encodingFormat': 'https://yaml.org'},
         {'@type': 'DataDownload', 'contentUrl': 'http://localhost:5000/download/table/1/csv', 'description': 'CSV file', 'encodingFormat': 'text/csv'},
@@ -294,10 +287,11 @@ def test_accept_headers(app, live_server, e2e_identifiers):
     response = requests.get(resource_url, headers={'Accept': 'application/ld+json'})
     assert response.status_code == 200
     json_ld4 = response.json()
-    # json_ld should be a superset of dummy_json
-    assert dummy_json.items() <= json_ld4.items()
-    # Should also have content url
-    assert json_ld4.get('contentUrl') == 'http://localhost:5555/record/resource/55?view=true'
+    # Check some fields to make sure it's json for right record
+    assert json_ld4['@id'] == 'https://doi.org/10.17182/hepdata.57.v1/r1'
+    assert json_ld4['url'] == 'http://localhost:5000/record/resource/55?landing_page=true'
+    assert json_ld4['@type'] == 'CreativeWork'
+    assert json_ld4['contentUrl'] == 'http://localhost:5000/record/resource/55?view=true'
 
     # JSON-LD for submission without DOI
     submission.doi = ''

--- a/tests/records_test.py
+++ b/tests/records_test.py
@@ -766,7 +766,7 @@ def test_get_json_ld(app, load_default_data, identifiers):
             '@type': 'Organization',
             'name': 'HEPData'
         },
-        'version': '1',
+        'version': 1,
         'identifier': [
             {'@type': 'PropertyValue',
             'propertyID': 'HEPDataRecord',

--- a/tests/records_test.py
+++ b/tests/records_test.py
@@ -961,17 +961,17 @@ def test_get_json_ld(app, load_default_data, identifiers):
     assert publication_data['author'] == [
         {
             "@type": "Person",
-            "affiliation": {"@type": "Organisation", "name": "Columbia U."},
+            "affiliation": {"@type": "Organization", "name": "Columbia U."},
             "name": "Durbin, R."
         },
         {
             "@type": "Person",
-            "affiliation": {"@type": "Organisation", "name": "Columbia U."},
+            "affiliation": {"@type": "Organization", "name": "Columbia U."},
             "name": "Loar, H."
         },
         {
             "@type": "Person",
-            "affiliation": {"@type": "Organisation", "name": "Columbia U."},
+            "affiliation": {"@type": "Organization", "name": "Columbia U."},
             "name": "Steinberger, J."
         }
     ]

--- a/tests/records_test.py
+++ b/tests/records_test.py
@@ -42,12 +42,15 @@ import requests_mock
 from hepdata.modules.permissions.models import SubmissionParticipant
 from hepdata.modules.records.api import process_payload, process_zip_archive, \
     move_files, get_all_ids, has_upload_permissions, \
-    has_coordinator_permissions, create_new_version, get_json_ld, \
-    get_resource_mimetype, create_breadcrumb_text
+    has_coordinator_permissions, create_new_version, \
+    get_resource_mimetype, create_breadcrumb_text, format_submission, \
+    format_resource
+from hepdata.modules.records.importer.api import import_records
 from hepdata.modules.records.utils.submission import get_or_create_hepsubmission, process_submission_directory, do_finalise, unload_submission
 from hepdata.modules.records.utils.common import get_record_by_id, get_record_contents
 from hepdata.modules.records.utils.data_processing_utils import generate_table_structure
 from hepdata.modules.records.utils.data_files import get_data_path_for_record
+from hepdata.modules.records.utils.json_ld import get_json_ld
 from hepdata.modules.records.utils.users import get_coordinators_in_system, has_role
 from hepdata.modules.records.utils.workflow import update_record, create_record
 from hepdata.modules.records.views import set_data_review_status
@@ -730,182 +733,237 @@ def test_get_resource_mimetype(app):
     assert get_resource_mimetype(resource, 'Binary') == 'application/octet-stream'
 
 
-def test_get_json_ld(app):
-    doi = 'my.test.hepdata.doi'
-    dummy_json = {'a': 1, 'b': 2, 'author': 'A. Nonymous'}
-    # Use requests_mock to mock the response from datacite
-    with requests_mock.Mocker() as m:
-        m.get(f'https://api.test.datacite.org/dois/{doi}', json=dummy_json)
-        data = get_json_ld(doi, 'finished')
-        # Only difference from dummy_json is to copy 'author' to 'creator'
-        assert data == {
-            'a': 1,
-            'b': 2,
-            'author': 'A. Nonymous',
-            'creator': 'A. Nonymous'
-        }
+def test_get_json_ld(app, load_default_data, identifiers):
+    recid = 1
+    hepsubmission = get_latest_hepsubmission(publication_recid=recid)
+    record = get_record_by_id(recid)
 
-        m.get(f'https://api.test.datacite.org/dois/{doi}', json=dummy_json)
-        data = get_json_ld(doi, 'finished', content_url='https://my.test.hepdata.url')
-        assert data == {
-            'a': 1,
-            'b': 2,
-            'author': 'A. Nonymous',
-            'creator': 'A. Nonymous',
-            'contentUrl': 'https://my.test.hepdata.url'
-        }
+    # Publication metadata
+    ctx = format_submission(recid, record, 1, 1, hepsubmission)
+    ctx['record_type'] = 'publication'
 
-        m.get(f'https://api.test.datacite.org/dois/{doi}', json=dummy_json)
-        data = get_json_ld(doi, 'finished', download_table_id=12345)
-        site_url = app.config.get('SITE_URL', 'https://www.hepdata.net')
-        assert data == {
-            'a': 1,
-            'b': 2,
-            'author': 'A. Nonymous',
-            'creator': 'A. Nonymous',
-            'distribution': [
+    publication_data = get_json_ld(ctx, 'finished')
+    assert publication_data == {
+        '@context': 'http://schema.org',
+        'inLanguage': 'en',
+        'provider': {
+            '@type': 'Organization',
+            'name': 'HEPData'
+        },
+        'publisher': {
+            '@type': 'Organization',
+            'name': 'HEPData'
+        },
+        'version': '1',
+        'identifier': [
+            {'@type': 'PropertyValue',
+            'propertyID': 'HEPDataRecord',
+            'value': 'http://localhost:5000/record/ins1283842'},
+            {'@type': 'PropertyValue',
+                'propertyID': 'HEPDataRecordAlt',
+                'value': 'http://localhost:5000/record/1'}
+        ],
+        'datePublished': '2014',
+        '@reverse': {
+            'isBasedOn': [
                 {
-                    '@type': 'DataDownload',
-                    'contentUrl': f'{site_url}/download/table/12345/root',
-                    'description': 'ROOT file',
-                    'encodingFormat': 'https://root.cern'
+                    '@type': 'ScholarlyArticle',
+                    'identifier': {
+                        '@type': 'PropertyValue',
+                        'propertyID': 'URL',
+                        'value': 'https://inspirehep.net/literature/1283842'
+                    }
                 },
                 {
-                    '@type': 'DataDownload',
-                    'contentUrl': f'{site_url}/download/table/12345/yaml',
-                    'description': 'YAML file',
-                    'encodingFormat': 'https://yaml.org'
-                },
-                {
-                    '@type': 'DataDownload',
-                    'contentUrl': f'{site_url}/download/table/12345/csv',
-                    'description': 'CSV file',
-                    'encodingFormat': 'text/csv'
-                },
-                {
-                    '@type': 'DataDownload',
-                    'contentUrl': f'{site_url}/download/table/12345/yoda',
-                    'description': 'YODA file',
-                    'encodingFormat': 'https://yoda.hepforge.org'
+                    '@id': 'https://doi.org/10.1103/PhysRevD.90.072001',
+                    '@type': 'JournalArticle'
                 }
             ]
-        }
-
-        # Add isPartOf and includedInDataCatalog; check parent name and
-        # descriptions are added and URLs added
-        dummy_json['isPartOf'] = {
-            '@id': 'https://doi.org/my.parent.doi',
-            'author': 'B. Nonymous'
-        }
-        dummy_json['includedInDataCatalog'] = { '@id': 'my.parent.doi' }
-        m.get(f'https://api.test.datacite.org/dois/{doi}', json=dummy_json)
-        data = get_json_ld(doi, 'finished', parent_name='My HEPData submission',
-                           parent_description="It's amazing")
-        assert data == {
-            'a': 1,
-            'b': 2,
-            'author': 'A. Nonymous',
-            'creator': 'A. Nonymous',
-            'isPartOf': {
-                '@id': 'https://doi.org/my.parent.doi',
-                '@type': 'Dataset',
-                'author': 'B. Nonymous',
-                'creator': 'B. Nonymous',
-                'name': 'My HEPData submission',
-                'description': "It's amazing",
-                'url': 'https://doi.org/my.parent.doi'
-            },
-            'includedInDataCatalog': {
-                '@id': 'my.parent.doi',
-                'url': 'https://doi.org/my.parent.doi'
-            }
-        }
-
-        # Reset dummy_json and add hasPart with data tables
-        del dummy_json['isPartOf']
-        del dummy_json['includedInDataCatalog']
-        dummy_json['hasPart'] = [
-            {'@id': 'https://doi.org/table1.doi'},
-            {'@id': 'https://doi.org/table2.doi'}
-        ]
-        data_tables = [
-            {
-                'doi': 'table1.doi',
-                'name': 'Table 1',
-                'description': 'Description of Table 1'
-            },
-            {
-                'doi': 'table2.doi',
-                'name': 'Table 2',
-                'description': 'Description of Table 2'
-            }
-        ]
-        m.get(f'https://api.test.datacite.org/dois/{doi}', json=dummy_json)
-        data = get_json_ld(doi, 'finished', data_tables=data_tables, data_abstract="Publication description")
-        assert data == {
-            'a': 1,
-            'b': 2,
-            'author': 'A. Nonymous',
-            'creator': 'A. Nonymous',
+        },
+        'author': {'@type': 'Organization', 'name': 'D0 Collaboration'},
+        'creator': {'@type': 'Organization', 'name': 'D0 Collaboration'},
+        '@type': 'Dataset',
+        'additionalType': 'Collection',
+        '@id': 'https://doi.org/10.17182/hepdata.1',
+        'url': 'http://localhost:5000/record/ins1283842',
+        'description': 'Fermilab-Tevatron.  We present measurements of the forward-backward asymmetry, ASYMFB(LEPTON) in the angular distribution of leptons (electrons and muons) from decays of top quarks and antiquarks produced in proton-antiproton collisions. We consider the final state containing a lepton and at least three jets. The entire sample of data collected by the D0 experiment during Run II (2001 - 2011) of the Fermilab Tevatron Collider, corresponding to 9.7 inverse fb of integrated luminosity, is used. We also examine the dependence of ASYMFB(LEPTON) on the transverse momentum, PT(LEPTON), and rapidity, YRAP(LEPTON), of the lepton.',
+        'name': 'Measurement of the forward-backward asymmetry in the distribution of leptons in $t\\bar{t}$ events in the lepton$+$jets channel',
+        'hasPart': [
+            {'@id': 'https://doi.org/10.17182/hepdata.1.v1/t1',
             '@type': 'Dataset',
-            'description': 'Publication description',
-            'hasPart': [
-                {
-                    '@id': 'https://doi.org/table1.doi',
-                    'name': 'Table 1',
-                    'description': 'Description of Table 1'
-                },
-                {
-                    '@id': 'https://doi.org/table2.doi',
-                    'name': 'Table 2',
-                    'description': 'Description of Table 2'
-                }
-            ]
-        }
-
-        # Modify hasPart to only contain a single table
-        dummy_json['hasPart'] = {'@id': 'https://doi.org/table1.doi'}
-        data_tables = [
-            {
-                'doi': 'table1.doi',
-                'name': 'Table 1',
-                'description': 'Description of Table 1'
-            }
-        ]
-        m.get(f'https://api.test.datacite.org/dois/{doi}', json=dummy_json)
-        data = get_json_ld(doi, 'finished', data_tables=data_tables, data_abstract="Publication description")
-        assert data == {
-            'a': 1,
-            'b': 2,
-            'author': 'A. Nonymous',
-            'creator': 'A. Nonymous',
+            'description': 'Observed ASYMFB(LEPTON) as a function of PT(LEPTON) at reconstruction level.',
+            'name': 'Table 1'},
+            {'@id': 'https://doi.org/10.17182/hepdata.1.v1/t2',
             '@type': 'Dataset',
-            'description': 'Publication description',
-            'hasPart': [
-                {
-                    '@id': 'https://doi.org/table1.doi',
-                    'name': 'Table 1',
-                    'description': 'Description of Table 1'
-                }
-            ]
-        }
+            'description': 'Observed production-level ASYMFB(LEPTON) as a function of PT(LEPTON).',
+            'name': 'Table 2'},
+            {'@id': 'https://doi.org/10.17182/hepdata.1.v1/t3',
+            '@type': 'Dataset',
+            'description': 'Observed production-level ASYMFB(LEPTON) as a function of ABS(YRAP(LEPTON)).',
+            'name': 'Table 3'},
+            {'@id': 'https://doi.org/10.17182/hepdata.1.v1/t4',
+            '@type': 'Dataset',
+            'description': 'Observed ASYMFB(LEPTON) at reconstruction level for the "lepton + 3 jets, 1 b-tag" channel.',
+            'name': 'Table 4'},
+            {'@id': 'https://doi.org/10.17182/hepdata.1.v1/t5',
+            '@type': 'Dataset',
+            'description': 'Observed ASYMFB(LEPTON) at reconstruction level for the "lepton + 3 jets, &gt;= 2 b-tags" channel.',
+            'name': 'Table 5'},
+            {'@id': 'https://doi.org/10.17182/hepdata.1.v1/t6',
+            '@type': 'Dataset',
+            'description': 'Observed ASYMFB(LEPTON) at reconstruction level for the "lepton + &gt;= 4 jets, 1 b-tag" channel.',
+            'name': 'Table 6'},
+            {'@id': 'https://doi.org/10.17182/hepdata.1.v1/t7',
+            '@type': 'Dataset',
+            'description': 'Observed ASYMFB(LEPTON) at reconstruction level for the "lepton + &gt;= 4 jets, &gt;= 2 b-tags" channel.',
+            'name': 'Table 7'},
+            {'@id': 'https://doi.org/10.17182/hepdata.1.v1/t8',
+            '@type': 'Dataset',
+            'description': 'Observed ASYMFB(LEPTON) at production level for the "lepton + 3 jets, 1 b-tag" channel.',
+            'name': 'Table 8'},
+            {'@id': 'https://doi.org/10.17182/hepdata.1.v1/t9',
+            '@type': 'Dataset',
+            'description': 'Observed ASYMFB(LEPTON) at production level for the "lepton + 3 jets, &gt;= 2 b-tags" channel.',
+            'name': 'Table 9'},
+            {'@id': 'https://doi.org/10.17182/hepdata.1.v1/t10',
+            '@type': 'Dataset',
+            'description': 'Observed ASYMFB(LEPTON) at production level for the "lepton + &gt;= 4 jets, 1 b-tag" channel.',
+            'name': 'Table 10'},
+            {'@id': 'https://doi.org/10.17182/hepdata.1.v1/t11',
+            '@type': 'Dataset',
+            'description': 'Observed ASYMFB(LEPTON) at production level for the "lepton + &gt;= 4 jets, &gt;= 2 b-tags" channel.',
+            'name': 'Table 11'},
+            {'@id': 'https://doi.org/10.17182/hepdata.1.v1/t12',
+            '@type': 'Dataset',
+            'description': 'The total value of ASYMFB(LEPTON) at reconstruction level measured from the combined channels.',
+            'name': 'Table 12'},
+            {'@id': 'https://doi.org/10.17182/hepdata.1.v1/t13',
+            '@type': 'Dataset',
+            'description': 'The total value of ASYMFB(LEPTON) at production level measured from the combined channels.',
+            'name': 'Table 13'},
+            {'@id': 'https://doi.org/10.17182/hepdata.1.v1/t14',
+            '@type': 'Dataset',
+            'description': 'The total value of ASYMFB(LEPTON) at production level calculated from the measurements using the combined single lepton channels and a...',
+            'name': 'Table 14'}
+        ]}
 
-        # Check a connection error returns JSON with an error
-        m.get(f'https://api.test.datacite.org/dois/{doi}',
-              exc=requests.exceptions.ConnectTimeout)
-        data = get_json_ld(doi, 'finished')
-        assert data == {
-            'error': f'JSON-LD could not be retrieved from https://api.test.datacite.org/dois/{doi}'
-        }
+    table_recid = 2
+    table_record = get_record_contents(table_recid)
+    ctx = format_submission(recid, record,
+                            1, 1, hepsubmission,
+                            data_table=table_record['title'])
+    ctx['record_type'] = 'table'
+    ctx['related_publication_id'] = recid
+    ctx['table_name'] = record['title']
+    ctx['table_id_to_show'] = table_recid
 
-        # Provide invalid json to get an unexpected error
-        dummy_json = {'isPartOf': 3}
-        m.get(f'https://api.test.datacite.org/dois/{doi}', json=dummy_json)
-        data = get_json_ld(doi, 'finished')
-        assert data == {
-            'error': f"An unexpected error occurred when retrieving/formatting JSON-LD for doi {doi}"
-        }
+    # Table metadata
+    data_submission = DataSubmission.query.filter_by(
+        publication_recid=hepsubmission.publication_recid,
+        associated_recid=table_recid).first()
+    table_data = get_json_ld(ctx, 'finished', data_submission)
+    for key in ['@context', 'inLanguage', 'provider', 'publisher', 'version', 'identifier', 'datePublished', '@reverse', 'author', 'creator', '@type']:
+        assert table_data[key] == publication_data[key]
 
+    assert table_data['additionalType'] == 'Dataset'
+    assert table_data["keywords"] == 'PBAR P --> LEPTON JETS X, ASYM, Inclusive, Asymmetry Measurement, Jet Production, 1960.0'
+    assert table_data["url"] == f"http://localhost:5000/record/2"
+    assert table_data['distribution'] == [
+        {
+            '@type': 'DataDownload',
+            'contentUrl': f'http://localhost:5000/download/table/2/root',
+            'description': 'ROOT file',
+            'encodingFormat': 'https://root.cern'
+        },
+        {
+            '@type': 'DataDownload',
+            'contentUrl': f'http://localhost:5000/download/table/2/yaml',
+            'description': 'YAML file',
+            'encodingFormat': 'https://yaml.org'
+        },
+        {
+            '@type': 'DataDownload',
+            'contentUrl': f'http://localhost:5000/download/table/2/csv',
+            'description': 'CSV file',
+            'encodingFormat': 'text/csv'
+        },
+        {
+            '@type': 'DataDownload',
+            'contentUrl': f'http://localhost:5000/download/table/2/yoda',
+            'description': 'YODA file',
+            'encodingFormat': 'https://yoda.hepforge.org'
+        }
+    ]
+    assert table_data['includedInDataCatalog'] == {
+        '@id': 'https://doi.org/10.17182/hepdata.1',
+        '@type': 'DataCatalog',
+        'url': 'http://localhost:5000/record/ins1283842'
+    }
+    assert table_data['isPartOf'] == {
+        '@id': publication_data['@id'],
+        '@type': publication_data['@type'],
+        'description': publication_data['description'],
+        'name': publication_data['name'],
+        'url': publication_data['url']
+    }
+
+    # Resource metadata
+    resource = DataResource(
+        file_location='a/b/myscript.py',
+        file_type='Python',
+        file_description='A script to do some stuff to the data',
+        doi='10.17182/hepdata.1.v1/r1'
+    )
+    hepsubmission.resources.append(resource)
+    db.session.add(hepsubmission)
+    db.session.commit()
+    ctx = format_resource(resource, 'print("Hello world")', f'http://localhost:5000/record/resource/{resource.id}?view=true')
+    resource_data = get_json_ld(ctx, 'finished')
+    for key in ['@context', 'inLanguage', 'provider', 'publisher', 'version', 'identifier', 'datePublished', '@reverse', 'author', 'creator']:
+        print(key, resource_data[key])
+        assert resource_data[key] == publication_data[key]
+
+    assert resource_data['@id'] == 'https://doi.org/10.17182/hepdata.1.v1/r1'
+    assert resource_data['@type'] == "CreativeWork"
+    assert resource_data['additionalType'] == 'Python file'
+    assert resource_data['contentUrl'] == f'http://localhost:5000/record/resource/{resource.id}?view=true'
+    assert resource_data['description'] == resource.file_description
+    assert resource_data['name'] == f'"myscript.py" of "{publication_data["name"]}"'
+    assert resource_data['url'] == f'http://localhost:5000/record/resource/{resource.id}?landing_page=true'
+    assert resource_data['isPartOf'] == table_data['isPartOf']
+
+    # Provide invalid status
+    data = get_json_ld(ctx, 'todo')
+    assert data == {
+        'error': 'JSON-LD is unavailable for this record; JSON-LD is only available for finalised records with DOIs.'
+    }
+
+    # Import a record with no collaboration to check authors work as expected
+    import_records(['ins47326'], synchronous=True)
+    hepsubmission = get_latest_hepsubmission(inspire_id='47326')
+    record = get_record_contents(hepsubmission.publication_recid)
+    ctx = format_submission(recid, record, 1, 1, hepsubmission)
+    ctx['record_type'] = 'publication'
+
+    publication_data = get_json_ld(ctx, 'finished')
+    assert publication_data['author'] == [
+        {
+            "@type": "Person",
+            "affiliation": {"@type": "Organisation", "name": "Columbia U."},
+            "name": "Durbin, R."
+        },
+        {
+            "@type": "Person",
+            "affiliation": {"@type": "Organisation", "name": "Columbia U."},
+            "name": "Loar, H."
+        },
+        {
+            "@type": "Person",
+            "affiliation": {"@type": "Organisation", "name": "Columbia U."},
+            "name": "Steinberger, J."
+        }
+    ]
+    assert publication_data['creator'] == publication_data['author']
 
 
 def test_create_breadcrumb_text():

--- a/tests/records_test.py
+++ b/tests/records_test.py
@@ -758,7 +758,7 @@ def test_get_json_ld(app, load_default_data, identifiers):
         'identifier': [
             {'@type': 'PropertyValue',
             'propertyID': 'HEPDataRecord',
-            'value': 'http://localhost:5000/record/ins1283842'},
+            'value': 'http://localhost:5000/record/ins1283842?version=1'},
             {'@type': 'PropertyValue',
                 'propertyID': 'HEPDataRecordAlt',
                 'value': 'http://localhost:5000/record/1'}
@@ -785,7 +785,7 @@ def test_get_json_ld(app, load_default_data, identifiers):
         '@type': 'Dataset',
         'additionalType': 'Collection',
         '@id': 'https://doi.org/10.17182/hepdata.1',
-        'url': 'http://localhost:5000/record/ins1283842',
+        'url': 'http://localhost:5000/record/ins1283842?version=1',
         'description': 'Fermilab-Tevatron.  We present measurements of the forward-backward asymmetry, ASYMFB(LEPTON) in the angular distribution of leptons (electrons and muons) from decays of top quarks and antiquarks produced in proton-antiproton collisions. We consider the final state containing a lepton and at least three jets. The entire sample of data collected by the D0 experiment during Run II (2001 - 2011) of the Fermilab Tevatron Collider, corresponding to 9.7 inverse fb of integrated luminosity, is used. We also examine the dependence of ASYMFB(LEPTON) on the transverse momentum, PT(LEPTON), and rapidity, YRAP(LEPTON), of the lepton.',
         'name': 'Measurement of the forward-backward asymmetry in the distribution of leptons in $t\\bar{t}$ events in the lepton$+$jets channel',
         'hasPart': [
@@ -897,7 +897,7 @@ def test_get_json_ld(app, load_default_data, identifiers):
     assert table_data['includedInDataCatalog'] == {
         '@id': 'https://doi.org/10.17182/hepdata.1',
         '@type': 'DataCatalog',
-        'url': 'http://localhost:5000/record/ins1283842'
+        'url': 'http://localhost:5000/record/ins1283842?version=1'
     }
     assert table_data['isPartOf'] == {
         '@id': publication_data['@id'],


### PR DESCRIPTION
Replaced function that amended the DataCite JSON-LD with custom JSON-LD generator.

Note that I haven't tested this extensively on different records (though the test coverage of the new module is 100%) so it's worth doing some further checks in case of missing keys in the context dictionary.

 * Fixes #435 