### PR TITLE
Improve user experience if submission archive extraction fails

### DIFF
--- a/hepdata/modules/records/api.py
+++ b/hepdata/modules/records/api.py
@@ -856,7 +856,7 @@ def process_zip_archive(file_path, id, old_schema=False):
                 # Log the exception and raise it so that celery can retry
                 log.exception(f"Unable to extract file {file_path}")
                 message = clean_error_message_for_display(
-                    "Unable to extract file {}. Please check the file is a valid zip or tar archive file and try again.".format(file_path),
+                    "Unable to extract file {}. Please check the file is a valid zip or tar archive file and try again later. Contact info@hepdata.net if problems persist.".format(file_path),
                     file_save_directory
                 )
                 raise ValueError(message) from e

--- a/hepdata/modules/records/api.py
+++ b/hepdata/modules/records/api.py
@@ -853,7 +853,13 @@ def process_zip_archive(file_path, id, old_schema=False):
             try:
                 unzipped_path = extract(file_path, submission_temp_path)
             except Exception as e:
-                unzipped_path = None
+                # Log the exception and raise it so that celery can retry
+                log.exception(f"Unable to extract file {file_path}")
+                message = clean_error_message_for_display(
+                    "Unable to extract file {}. Please check the file is a valid zip or tar archive file and try again.".format(file_path),
+                    file_save_directory
+                )
+                raise ValueError(message) from e
 
             if not unzipped_path:
                 message = clean_error_message_for_display(

--- a/hepdata/modules/records/utils/yaml_utils.py
+++ b/hepdata/modules/records/utils/yaml_utils.py
@@ -79,32 +79,33 @@ def split_files(file_location, output_location):
                     write_submission_yaml_block(
                         document, submission_yaml)
                 else:
-                    file_name = document["name"].replace(' ', '_').replace('/', '-') + ".yaml"
+                    file_name = document.get("name", '').replace(' ', '_').replace('/', '-') + ".yaml"
                     document["data_file"] = file_name
 
                     with open(os.path.join(output_location, file_name),
                               'w') as data_file:
                         Dumper.add_representer(str, str_presenter)
-                        yaml.dump(
-                            {"independent_variables":
+                        yaml.dump({
+                            "independent_variables":
                                 cleanup_data_yaml(
-                                    document["independent_variables"]),
-                                "dependent_variables":
-                                    cleanup_data_yaml(
-                                        document["dependent_variables"])},
+                                    document.get("independent_variables")),
+                            "dependent_variables":
+                                cleanup_data_yaml(
+                                    document.get("dependent_variables"))
+                            },
                             data_file, allow_unicode=True, Dumper=Dumper)
 
                     write_submission_yaml_block(document,
                                                 submission_yaml,
                                                 type="record")
 
-    except yaml.scanner.ScannerError as se:
-        return se, last_updated
-    except yaml.parser.ParserError as pe:
-        return pe, last_updated
+    except (yaml.scanner.ScannerError, yaml.parser.ParserError) as ye:
+        return ye, last_updated
     except Exception as e:
-        log.error('Error parsing %s, %s', file_location, e)
-        return e, last_updated
+        log.exception('Error extracting YAML from %s, %s', file_location, e)
+        message = f"Unable to extract YAML from file {os.path.basename(file_location)}. " \
+            + "Please check the file is valid YAML and try again."
+        raise ValueError(message) from e
     return None, last_updated
 
 

--- a/hepdata/modules/records/utils/yaml_utils.py
+++ b/hepdata/modules/records/utils/yaml_utils.py
@@ -104,7 +104,7 @@ def split_files(file_location, output_location):
     except Exception as e:
         log.exception('Error extracting YAML from %s, %s', file_location, e)
         message = f"Unable to extract YAML from file {os.path.basename(file_location)}. " \
-            + "Please check the file is valid YAML and try again."
+            + "Please check the file is valid YAML and try again later. Contact info@hepdata.net if problems persist."
         raise ValueError(message) from e
     return None, last_updated
 

--- a/hepdata/utils/file_extractor.py
+++ b/hepdata/utils/file_extractor.py
@@ -47,7 +47,7 @@ def extract(file_path, unzipped_path):
         tar.extractall(path=unzipped_path)
         tar.close()
         return unzipped_path
-    elif is_gz_file(file_path):
+    elif is_gz_file(file_path) and file_path.endswith('.yaml.gz'):
         with gzip.GzipFile(file_path, 'rb') as gzip_file:
             with open(unzipped_path, 'wb') as unzipped_file:
                 unzipped_file.write(gzip_file.read())

--- a/tests/records_test.py
+++ b/tests/records_test.py
@@ -507,6 +507,12 @@ def test_process_zip_archive_invalid(app):
     assert ("did not find expected ',' or '}'" in errors["Single YAML file splitter"][0].get("message"))
     shutil.rmtree(tmp_path)
 
+    # Try again, using the path that we've just deleted, to simulate a disk error
+    with pytest.raises(ValueError) as exc_info:
+        process_zip_archive(tmp_file_path, 1)
+
+    assert str(exc_info.value) == 'Unable to extract YAML from file invalid_parser_file.yaml. Please check the file is valid YAML and try again.'
+
 
 def test_move_files_invalid_path():
     errors = move_files('this_is_not_a_real_path', tempfile.mkdtemp(dir=CFG_TMPDIR))

--- a/tests/records_test.py
+++ b/tests/records_test.py
@@ -476,12 +476,10 @@ def test_process_zip_archive_invalid(app):
     tmp_path = tempfile.mkdtemp(dir=CFG_TMPDIR)
     shutil.copy2(file_path, tmp_path)
     tmp_file_path = os.path.join(tmp_path, 'submission_invalid_tarfile.tgz.gz')
-    errors = process_zip_archive(tmp_file_path, 1)
-    assert ("Archive file extractor" in errors)
-    assert (len(errors["Archive file extractor"]) == 1)
-    assert (errors["Archive file extractor"][0].get("level") == "error")
-    assert (errors["Archive file extractor"][0].get("message")
-            == "submission_invalid_tarfile.tgz.gz is not a valid zip or tar archive file.")
+    with pytest.raises(ValueError) as exc_info:
+        process_zip_archive(tmp_file_path, 1)
+
+    assert str(exc_info.value) == 'Unable to extract file submission_invalid_tarfile.tgz.gz. Please check the file is a valid zip or tar archive file and try again.'
     shutil.rmtree(tmp_path)
 
     # Test uploading a file that is not in any of the given formats

--- a/tests/records_test.py
+++ b/tests/records_test.py
@@ -488,7 +488,7 @@ def test_process_zip_archive_invalid(app):
     with pytest.raises(ValueError) as exc_info:
         process_zip_archive(tmp_file_path, 1)
 
-    assert str(exc_info.value) == 'Unable to extract file submission_invalid_tarfile.tgz.gz. Please check the file is a valid zip or tar archive file and try again.'
+    assert str(exc_info.value) == 'Unable to extract file submission_invalid_tarfile.tgz.gz. Please check the file is a valid zip or tar archive file and try again later. Contact info@hepdata.net if problems persist.'
 
     # Test uploading a file that is not in any of the given formats
     file_path = os.path.join(base_dir, 'test_data/notazip.yaml.gz')
@@ -519,7 +519,7 @@ def test_process_zip_archive_invalid(app):
     with pytest.raises(ValueError) as exc_info:
         process_zip_archive(tmp_file_path, 1)
 
-    assert str(exc_info.value) == 'Unable to extract YAML from file invalid_parser_file.yaml. Please check the file is valid YAML and try again.'
+    assert str(exc_info.value) == 'Unable to extract YAML from file invalid_parser_file.yaml. Please check the file is valid YAML and try again later. Contact info@hepdata.net if problems persist.'
 
 
 def test_move_files_invalid_path():

--- a/tests/records_test.py
+++ b/tests/records_test.py
@@ -476,11 +476,19 @@ def test_process_zip_archive_invalid(app):
     tmp_path = tempfile.mkdtemp(dir=CFG_TMPDIR)
     shutil.copy2(file_path, tmp_path)
     tmp_file_path = os.path.join(tmp_path, 'submission_invalid_tarfile.tgz.gz')
+    errors = process_zip_archive(tmp_file_path, 1)
+    assert ("Archive file extractor" in errors)
+    assert (len(errors["Archive file extractor"]) == 1)
+    assert (errors["Archive file extractor"][0].get("level") == "error")
+    assert (errors["Archive file extractor"][0].get("message")
+            == "submission_invalid_tarfile.tgz.gz is not a valid zip or tar archive file.")
+    shutil.rmtree(tmp_path)
+
+    # Try again, using the path that we've just deleted, to simulate a disk error
     with pytest.raises(ValueError) as exc_info:
         process_zip_archive(tmp_file_path, 1)
 
     assert str(exc_info.value) == 'Unable to extract file submission_invalid_tarfile.tgz.gz. Please check the file is a valid zip or tar archive file and try again.'
-    shutil.rmtree(tmp_path)
 
     # Test uploading a file that is not in any of the given formats
     file_path = os.path.join(base_dir, 'test_data/notazip.yaml.gz')


### PR DESCRIPTION
 * Fixes #453 

As discussed, in case of an unexpected error (e.g. a temporary disk error) we raise the error so it's caught by celery and retried.

@GraemeWatt Let me know if you think the error messages are OK.