### PR TITLE
Use postgres 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         py.test -vv tests/*_test.py
     - name: Setup Sauce Connect
       uses: saucelabs/sauce-connect-action@main
-      if: startsWith(matrix.postgres-version, '9.6')
+      if: startsWith(matrix.postgres-version, '12')
       with:
         username: ${{ secrets.SAUCE_USERNAME }}
         accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
@@ -143,7 +143,7 @@ jobs:
         scVersion: 4.7.0
         verbose: true
     - name: Run end-to-end tests
-      if: startsWith(matrix.postgres-version, '9.6')
+      if: startsWith(matrix.postgres-version, '12')
       env:
         SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
         SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
@@ -151,7 +151,7 @@ jobs:
       run: |
         if [[ -n ${{ secrets.SAUCE_USERNAME }} && -n ${{ secrets.SAUCE_ACCESS_KEY}} ]]; then py.test -vv tests/e2e; fi
     - name: Run coveralls
-      if: startsWith(matrix.postgres-version, '9.6')
+      if: startsWith(matrix.postgres-version, '12')
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         COVERALLS_SERVICE_NAME: github

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -30,7 +30,7 @@ Prerequisites
 =============
 
 HEPData uses several services, which you will need to install before running HEPData:
- * `PostgreSQL <http://www.postgresql.org/>`_ (version 9.6) database server
+ * `PostgreSQL <http://www.postgresql.org/>`_ (version 12) database server
  * `Redis <http://redis.io/>`_ for caching
  * `Elasticsearch <https://www.elastic.co/products/elasticsearch>`_ (version 7.1, not later versions) for indexing and information retrieval. See below for further instructions.
  * `Node.js <https://nodejs.org>`_ JavaScript run-time environment and its package manager `npm <https://www.npmjs.com/>`_. (If you're using a Debian-based OS, please follow the `official installation instructions <https://github.com/nodesource/distributions/blob/master/README.md#debinstall>`_ to install NodeJS (which will also install npm), to avoid issues with ``node-sass``.)
@@ -163,9 +163,9 @@ Inspect the ``hepdata`` database from the command line as the ``hepdata`` user:
    hepdata=> \q
 
 If you're having problems with access permissions to the database, a simple solution is to edit the
-PostgreSQL Client Authentication Configuration File (e.g. ``/var/lib/pgsql/9.6/data/pg_hba.conf``) to
+PostgreSQL Client Authentication Configuration File (e.g. ``/var/lib/pgsql/12/data/pg_hba.conf``) to
 ``trust`` local and IPv4/IPv6 connections (instead of ``peer`` or ``ident``), then restart the PostgreSQL
-server (e.g. ``sudo systemctl restart postgresql-9.6``).
+server (e.g. ``sudo systemctl restart postgresql-12``).
 
 Run a local development server
 ------------------------------

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -17,7 +17,7 @@ built using `Flask <https://flask.palletsprojects.com/en/1.1.x/>`_.
 
 HEPData requires:
 
- * `PostgreSQL <http://www.postgresql.org/>`_ (version 9.6) databases
+ * `PostgreSQL <http://www.postgresql.org/>`_ (version 12) databases
  * `Redis <http://redis.io/>`_ for caching
  * `Celery <https://docs.celeryproject.org/en/stable/index.html>`_ for managing asynchronous tasks
  * `Elasticsearch <https://www.elastic.co/products/elasticsearch>`_ for indexing and searching data


### PR DESCRIPTION
Addresses #401 by using postgresql 12 by default in CI, and updating installation instructions.

(There's still work to do to migrate as detailed in #401 but I think the code itself should be fine with v12.)