### PR TITLE
Fix data recids

### DIFF
--- a/fixes/data_submission_recids.py
+++ b/fixes/data_submission_recids.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of HEPData.
+# Copyright (C) 2022 CERN.
+#
+# HEPData is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# HEPData is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with HEPData; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+from datetime import datetime
+import logging
+
+from flask import current_app
+from flask.cli import with_appcontext
+from invenio_db import db
+from sqlalchemy import func
+
+from hepdata.cli import fix
+from hepdata.ext.elasticsearch.api import index_record_ids, push_data_keywords
+from hepdata.modules.records.utils.common import get_record_by_id
+from hepdata.modules.records.utils.doi_minter import generate_dois_for_submission
+from hepdata.modules.records.utils.submission import finalise_datasubmission
+from hepdata.modules.submission.models import HEPSubmission, DataSubmission
+
+logging.basicConfig()
+log = logging.getLogger('data_submission_recids')
+log.setLevel('INFO')
+
+
+@fix.command()
+@with_appcontext
+def fix_data_submission_recids():
+    """Update associated_recids for data submissions with version > 1"""
+    submissions_to_update = HEPSubmission.query \
+        .filter(HEPSubmission.version > 1) \
+        .filter(HEPSubmission.overall_status == 'finished') \
+        .order_by(HEPSubmission.publication_recid, HEPSubmission.version).all()
+
+    log.info(f"Updating data submissions for {len(submissions_to_update)} publications with version > 1")
+
+    for i, hep_submission in enumerate(submissions_to_update):
+        # We have ordered the results so if this is the last entry in
+        # submissions_to_update, or the next entry has a different
+        # publication_recid, then this must be the latest version
+        is_latest = (i + 1 == len(submissions_to_update)) or \
+            submissions_to_update[i+1].publication_recid != hep_submission.publication_recid
+        _create_new_data_records(hep_submission, is_latest)
+
+    log.info("Checking for any more duplicate associated rec_ids...")
+    duplicates = DataSubmission.query.with_entities(
+        DataSubmission.associated_recid,
+        func.count(DataSubmission.associated_recid)) \
+        .filter(DataSubmission.associated_recid.isnot(None)) \
+        .group_by(DataSubmission.associated_recid) \
+        .having(func.count(DataSubmission.associated_recid) > 1).all()
+
+    if duplicates:
+        log.warning("There are still some records with duplicate associated_recids:")
+        for d in duplicates:
+            log.warning(f"    associated_recid: {d[0]}, count {d[1]}")
+    else:
+        log.info('No duplicates found 👍')
+
+
+def _create_new_data_records(hep_submission, is_latest=True):
+    log.info("Checking records for publication rec_id "
+             f"{hep_submission.publication_recid}, "
+             f"version {hep_submission.version} "
+             f"(inspire id {hep_submission.inspire_id})")
+
+    data_submissions = DataSubmission.query.filter_by(
+        publication_recid=hep_submission.publication_recid,
+        version=hep_submission.version
+    )
+    # Get full list of associated recids across all versions so we can check
+    # for duplicates
+    all_versions_associated_recids = [
+        x[0] for x in
+        db.session.query(DataSubmission.associated_recid)
+          .filter_by(publication_recid=hep_submission.publication_recid)
+    ]
+
+    generated_record_ids = []
+    publication_record = get_record_by_id(hep_submission.publication_recid)
+    last_updated = datetime.strftime(
+        hep_submission.last_updated,
+        '%Y-%m-%d %H:%M:%S'
+    )
+
+    for data_submission in data_submissions:
+        # Only re-finalise those data submissions whose associated recid is not unique
+        if all_versions_associated_recids.count(data_submission.associated_recid) > 1:
+            log.info(f"Re-finalising data_submission id {data_submission.id}")
+            finalise_datasubmission(
+                last_updated,
+                {},
+                generated_record_ids,
+                publication_record,
+                hep_submission.publication_recid,
+                data_submission,
+                data_submission.version
+            )
+
+    db.session.commit()
+
+    if generated_record_ids:
+        # Only mint DOIs if not testing.
+        if not current_app.config.get('TESTING', False):
+            generate_dois_for_submission.delay(
+                inspire_id=hep_submission.inspire_id,
+                version=hep_submission.version
+            )
+
+        # Reindex updated data records if this is the latest version
+        if is_latest:
+            index_record_ids(generated_record_ids)
+            push_data_keywords(pub_ids=[hep_submission.publication_recid])

--- a/fixes/data_submission_recids.py
+++ b/fixes/data_submission_recids.py
@@ -128,5 +128,7 @@ def _create_new_data_records(hep_submission, is_latest=True):
 
         # Reindex updated data records if this is the latest version
         if is_latest:
-            index_record_ids(generated_record_ids)
+            # Check publication is in the index - add it if not
+            log.info(f'Indexing record ids: {[hep_submission.publication_recid] + generated_record_ids}')
+            index_record_ids([hep_submission.publication_recid] + generated_record_ids)
             push_data_keywords(pub_ids=[hep_submission.publication_recid])

--- a/fixes/data_submission_recids.py
+++ b/fixes/data_submission_recids.py
@@ -86,7 +86,8 @@ def _create_new_data_records(hep_submission, is_latest=True):
     data_submissions = DataSubmission.query.filter_by(
         publication_recid=hep_submission.publication_recid,
         version=hep_submission.version
-    )
+    ).order_by(DataSubmission.id.asc())
+
     # Get full list of associated recids across all versions so we can check
     # for duplicates
     all_versions_associated_recids = [

--- a/hepdata/modules/records/utils/submission.py
+++ b/hepdata/modules/records/utils/submission.py
@@ -656,11 +656,24 @@ def do_finalise(recid, publication_record=None, force_finalise=False,
         Creates record SIP for each data record with a link to the associated
         publication.
 
-        :param synchronous: if true then workflow execution and creation is
-               waited on, then everything is indexed in one go.
-               If False, object creation is asynchronous, however reindexing is not
-               performed. This is only really useful for the full migration of
-               content.
+        :param int recid: `publication_recid` of HEPSubmission to finalise
+        :param HEPSubmission publication_record: HEPSubmission object to
+            finalise
+        :param bool force_finalise: Whether to force finalisation. If False,
+            will only finalise if logged-in user is the submission coordinator.
+            Should only be set to True for admin tasks/testing.
+        :param str commit_message: Version information for updated versions of
+            a submission.
+        :param bool send_tweet: Whether to tweet about the new submission.
+        :param bool update: Whether to update the existing data records rather
+            than create new ones (only used for admin/test purposes)
+        :param bool convert: Whether to convert to (and store) other data
+            formats using hepdata_converter
+        :param type send_email: Whether to email the submission participants
+            and coordinator to inform them that the submission is complete
+        :return: JSON string with keys: ``success``, ``recid``, (on success)
+            ``data_count``, ``generated_records``, (on failure) ``errors``.
+        :rtype: str
     """
     print('Finalising record {}'.format(recid))
 

--- a/hepdata/modules/records/utils/submission.py
+++ b/hepdata/modules/records/utils/submission.py
@@ -698,8 +698,9 @@ def do_finalise(recid, publication_record=None, force_finalise=False,
             for record in existing_data_records["hits"]["hits"]:
 
                 if "recid" in record["_source"]:
-                    existing_submissions[record["_source"]["title"]] = \
-                        record["_source"]["recid"]
+                    if update: # Only reuse existing data submissions for update, not for new version
+                        existing_submissions[record["_source"]["title"]] = \
+                            record["_source"]["recid"]
                     delete_item_from_index(record["_id"],
                                            doc_type=CFG_DATA_TYPE, parent=record["_source"]["related_publication"])
 

--- a/hepdata/modules/records/utils/submission.py
+++ b/hepdata/modules/records/utils/submission.py
@@ -685,7 +685,8 @@ def do_finalise(recid, publication_record=None, force_finalise=False,
 
         submissions = DataSubmission.query.filter_by(
             publication_recid=recid,
-            version=hep_submission.version).all()
+            version=hep_submission.version
+        ).order_by(DataSubmission.id.asc()).all()
 
         version = hep_submission.version
 

--- a/hepdata/modules/records/utils/submission.py
+++ b/hepdata/modules/records/utils/submission.py
@@ -669,7 +669,7 @@ def do_finalise(recid, publication_record=None, force_finalise=False,
             than create new ones (only used for admin/test purposes)
         :param bool convert: Whether to convert to (and store) other data
             formats using hepdata_converter
-        :param type send_email: Whether to email the submission participants
+        :param bool send_email: Whether to email the submission participants
             and coordinator to inform them that the submission is complete
         :return: JSON string with keys: ``success``, ``recid``, (on success)
             ``data_count``, ``generated_records``, (on failure) ``errors``.


### PR DESCRIPTION
 * Fixes #470 

Ensures that tables in new versions will have unique `associated_recid` values.

Also provides a CLI command to re-finalise data tables with duplicate `associated_recid` values. To run:

```bash
hepdata fix fix-data-submission-recids
```