### PR TITLE
Add configurable banners to all pages

### DIFF
--- a/hepdata/config.py
+++ b/hepdata/config.py
@@ -361,6 +361,10 @@ APP_DEFAULT_SECURE_HEADERS = {
     'session_cookie_http_only': False
 }
 
+# Set this to an HTML string if you want to put a temporary banner at the top of all pages.
+# It will be placed inside a <p> tag. Tags and attributes not in ALLOWED_HTML_TAGS and ALLOWED_HTML_ATTRS will be escaped
+BANNER_MSG = None
+
 # Import local config file if it is present.
 try:
     from hepdata.config_local import *

--- a/hepdata/modules/dashboard/templates/hepdata_dashboard/dashboard.html
+++ b/hepdata/modules/dashboard/templates/hepdata_dashboard/dashboard.html
@@ -12,7 +12,7 @@
 
     {% set delete_redirect_url = '/dashboard' %}
 
-    <div class="hep-content" style="padding-top: 65px; height: 100%">
+    <div class="hep-content" style="height: 100%">
 
         <div class="dashboard-header">
 

--- a/hepdata/modules/records/templates/hepdata_records/components/record-breadcrumbs.html
+++ b/hepdata/modules/records/templates/hepdata_records/components/record-breadcrumbs.html
@@ -1,4 +1,4 @@
-<div class="hep_breadcrumbs row">
+<div class="hep_breadcrumbs">
     <div class="col-md-12 no-padding">
         <ul>
             <a href="/search">

--- a/hepdata/modules/records/templates/hepdata_records/publication_processing.html
+++ b/hepdata/modules/records/templates/hepdata_records/publication_processing.html
@@ -19,7 +19,7 @@
 
 {% block page_body %}
 
-    <div class="hep-content" style="padding: 80px 30px 15px 30px">
+    <div class="hep-content" style="padding: 15px 30px 15px 30px">
 
       {%- if messages %}
           {%- for category, message in messages %}

--- a/hepdata/modules/records/templates/hepdata_records/publication_record.html
+++ b/hepdata/modules/records/templates/hepdata_records/publication_record.html
@@ -44,17 +44,19 @@
 
 {% block page_description %}{{ ctx.record.title }}{% endblock %}
 
+{%- block additional_header_bars %}
+    {% include 'hepdata_records/components/record-breadcrumbs.html' %}
+{%- endblock additional_header_bars %}
+
 {% block page_body %}
     <div>
         <div class="container-fluid">
-
-            {% include 'hepdata_records/components/record-breadcrumbs.html' %}
 
             <div class="clearfix"></div>
 
             <!--top level publication information-->
 
-            <div class="row" style="padding-top: 120px;">
+            <div class="row" style="padding-top: 10px;">
 
                 {%- if messages %}
                     {%- for category, message in messages %}

--- a/hepdata/modules/records/templates/hepdata_records/sandbox.html
+++ b/hepdata/modules/records/templates/hepdata_records/sandbox.html
@@ -23,41 +23,44 @@
 {%- extends "hepdata_theme/page.html" %}
 
 {%- block additional_assets %}
-    {{ webpack['hepdata-record.css'] }}    
+    {{ webpack['hepdata-record.css'] }}
     {{ webpack['toastr.css'] }}
 {%- endblock additional_assets %}
 
 {%- set messages = get_flashed_messages(with_categories=true) -%}
 
+{%- block additional_header_bars %}
+<div class="hep_breadcrumbs">
+    <div class="col-md-12 no-padding">
+        <ul>
+            <a href="/record/sandbox">
+                <li class="active"><span class="fa fa-cube"></span> HEPData Sandbox
+                </li>
+            </a>
+
+            {% if ctx.data_tables|length != 0 %}
+                <li class="pull-right" style="padding:6px;">
+
+                    <a href="?format=json" id="jsonLabel" type="button"
+                       class="btn btn-sm btn-default"
+                       aria-haspopup="true" aria-expanded="false">
+                        JSON
+                    </a>
+
+                </li>
+            {% endif %}
+        </ul>
+    </div>
+</div>
+{%- endblock additional_header_bars %}
+
 {% block page_body %}
 
     <div class="container-fluid">
-        <div class="hep_breadcrumbs row">
-            <div class="col-md-12 no-padding">
-                <ul>
-                    <a href="/record/sandbox">
-                        <li class="active"><span class="fa fa-cube"></span> HEPData Sandbox
-                        </li>
-                    </a>
-
-                    {% if ctx.data_tables|length != 0 %}
-                        <li class="pull-right" style="padding:6px;">
-
-                            <a href="?format=json" id="jsonLabel" type="button"
-                               class="btn btn-sm btn-default"
-                               aria-haspopup="true" aria-expanded="false">
-                                JSON
-                            </a>
-
-                        </li>
-                    {% endif %}
-                </ul>
-            </div>
-        </div>
 
         <div class="clearfix"></div>
 
-        <div class="row" style="padding-top: 120px;">
+        <div class="row" style="padding-top: 10px;">
 
           {%- if messages %}
               {%- for category, message in messages %}

--- a/hepdata/modules/search/templates/hepdata_search/search_results.html
+++ b/hepdata/modules/search/templates/hepdata_search/search_results.html
@@ -15,51 +15,53 @@
 
 {%- endblock additional_assets %}
 
+{%- block additional_header_bars %}
+<div class="search-header">
+
+    <form class="search-form"
+          action="/search">
+        <div class="search-box">
+            <input type="text"
+                   name="q"
+                   placeholder="Search HEPData"
+                   value="{% if ctx %}{{ ctx.q }}{% endif %}">
+
+            {% for type, value in ctx.filters.items() %}
+                <a href={{ ctx.modify_query('.search',
+        **{type: None}) }}>
+                    <div class="btn facet-tag {{ type }}-tag">
+                        <i class="fa fa-times"></i>
+                        {{ value }}
+                    </div>
+                </a>
+            {% endfor %}
+        </div>
+
+        <button type="submit" class="search-submit">Search</button>
+
+        {% if ctx.q %}
+            <a href="/search" class="btn btn-link hidden-sm hidden-xs">Reset search</a>
+        {% endif %}
+        <a class="btn btn-link hidden-sm hidden-xs" data-toggle="modal"
+           data-target="#searchHelpWidget">Advanced</a>
+
+    </form>
+
+    <div class="pull-right">
+      <a href="{{ ctx.modify_query('.search', format='json') }}"
+         id="jsonLabel" type="button"
+         class="btn btn-sm btn-default"
+         aria-haspopup="true" aria-expanded="false"
+         title="Get search results in JSON format">
+          JSON
+      </a>
+    </div>
+</div>
+
+{%- endblock additional_header_bars %}
 
 {% block page_body %}
     <div class="hep-content">
-
-        <div class="search-header">
-
-            <form class="search-form"
-                  action="/search">
-                <div class="search-box">
-                    <input type="text"
-                           name="q"
-                           placeholder="Search HEPData"
-                           value="{% if ctx %}{{ ctx.q }}{% endif %}">
-
-                    {% for type, value in ctx.filters.items() %}
-                        <a href={{ ctx.modify_query('.search',
-                **{type: None}) }}>
-                            <div class="btn facet-tag {{ type }}-tag">
-                                <i class="fa fa-times"></i>
-                                {{ value }}
-                            </div>
-                        </a>
-                    {% endfor %}
-                </div>
-
-                <button type="submit" class="search-submit">Search</button>
-
-                {% if ctx.q %}
-                    <a href="/search" class="btn btn-link hidden-sm hidden-xs">Reset search</a>
-                {% endif %}
-                <a class="btn btn-link hidden-sm hidden-xs" data-toggle="modal"
-                   data-target="#searchHelpWidget">Advanced</a>
-
-            </form>
-
-            <div class="pull-right">
-              <a href="{{ ctx.modify_query('.search', format='json') }}"
-                 id="jsonLabel" type="button"
-                 class="btn btn-sm btn-default"
-                 aria-haspopup="true" aria-expanded="false"
-                 title="Get search results in JSON format">
-                  JSON
-              </a>
-            </div>
-        </div>
 
         <div class="search-results container-fluid">
             {% if not no_results %}

--- a/hepdata/modules/submission/templates/hepdata_submission/submit.html
+++ b/hepdata/modules/submission/templates/hepdata_submission/submit.html
@@ -38,22 +38,22 @@
 
 {%- endblock additional_assets %}
 
+{% block additional_header_bars %}
+
+<div class="hep_breadcrumbs">
+    <ul>
+        <li class="active"><span class="fa fa-upload"></span>
+            HEPData Submission
+        </li>
+
+        <li class="pull-right">
+        </li>
+    </ul>
+</div>
+
+{% endblock additional_header_bars %}
 
 {% block page_body %}
-
-    <div class="hep_breadcrumbs">
-        <ul>
-            <li class="active"><span class="fa fa-upload"></span>
-                HEPData Submission
-            </li>
-
-            <li class="pull-right">
-            </li>
-        </ul>
-    </div>
-
-    <div class="clearfix"></div>
-
 
     <div class="paper-submission-area">
 

--- a/hepdata/modules/theme/assets/scss/body.scss
+++ b/hepdata/modules/theme/assets/scss/body.scss
@@ -249,7 +249,7 @@ code {
 
   .banner {
     background-color: $purple;
-    padding: 20px;
+    padding: 15px;
     text-align: center;
 
     p {

--- a/hepdata/modules/theme/assets/scss/body.scss
+++ b/hepdata/modules/theme/assets/scss/body.scss
@@ -84,8 +84,6 @@
 }
 
 .hep_breadcrumbs {
-  position: fixed;
-  margin-top: 65px;
   height: 42px;
   width: 100%;
   z-index: 999;
@@ -242,4 +240,22 @@ body::-webkit-scrollbar-thumb {
 code {
   color: $navy;
   background-color: $lightgrey;
+}
+
+.sticky-bars {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+
+  .banner {
+    background-color: $purple;
+    padding: 20px;
+    text-align: center;
+
+    p {
+      font-size: larger;
+      margin: 0;
+      color: white;
+    }
+  }
 }

--- a/hepdata/modules/theme/assets/scss/home.scss
+++ b/hepdata/modules/theme/assets/scss/home.scss
@@ -1,3 +1,7 @@
+.home-page .sticky-bars .banner {
+  background-color: $navy-light;
+}
+
 .home-top {
   background: $purple url('../../static/img/home_bg.svg') no-repeat bottom right;
   height: 35vh;
@@ -13,6 +17,9 @@
     font-weight: normal;
   }
 
+  .top-bar {
+    position: static;
+  }
 }
 
 .search-area {

--- a/hepdata/modules/theme/assets/scss/navbar.scss
+++ b/hepdata/modules/theme/assets/scss/navbar.scss
@@ -49,12 +49,12 @@
 
 .top-bar {
   background-color: #ECF0F1;
-  height: 65px !important;
   min-height: 65px;
   border: none;
   color: #fff;
   z-index: 1000;
-  top: 0;
+  margin-bottom: 0;
+  position: relative;
 }
 
 .navbar-brand {

--- a/hepdata/modules/theme/assets/scss/search.scss
+++ b/hepdata/modules/theme/assets/scss/search.scss
@@ -33,10 +33,6 @@ body {
   font-size: 1em;
 }
 
-.hep-content {
-  padding-top: 65px;
-}
-
 .data-more {
   padding-left: 20px;
   padding-top: 5px;
@@ -50,7 +46,7 @@ body {
 }
 
 .search-results {
-  padding-top: 80px;
+  padding-top: 30px;
 }
 
 .record-header {
@@ -72,8 +68,6 @@ body {
   color: white;
   padding: 13px;
   height: 60px;
-  position: fixed;
-  top: 65px;
   width: 100%;
   z-index: 100;
 }

--- a/hepdata/modules/theme/assets/scss/submission.scss
+++ b/hepdata/modules/theme/assets/scss/submission.scss
@@ -3,7 +3,7 @@
 .paper-submission-area {
   width: 400px;
   margin: 0 auto;
-  margin-top: 13em;
+  margin-top: 5em;
   text-align: center;
   overflow-y: hidden;
   min-height: 600px;

--- a/hepdata/modules/theme/assets/scss/type.scss
+++ b/hepdata/modules/theme/assets/scss/type.scss
@@ -26,7 +26,7 @@ body {
 
 body, html{
   width: 100%;
-  height: 100%;
+  min-height: 100%;
 }
 
 .text-white {

--- a/hepdata/modules/theme/templates/hepdata_theme/banner.html
+++ b/hepdata/modules/theme/templates/hepdata_theme/banner.html
@@ -1,0 +1,5 @@
+{% if banner_msg %}
+  <div class="banner">
+    <p>{{ banner_msg | safe }}</p>
+  </div>
+{% endif %}

--- a/hepdata/modules/theme/templates/hepdata_theme/header.html
+++ b/hepdata/modules/theme/templates/hepdata_theme/header.html
@@ -1,4 +1,5 @@
 <nav class="navbar navbar-default navbar-fixed-top top-bar">
+
     <div class="container-fluid">
         <!-- Brand and toggle get grouped for better mobile display -->
         <div class="navbar-header">

--- a/hepdata/modules/theme/templates/hepdata_theme/home.html
+++ b/hepdata/modules/theme/templates/hepdata_theme/home.html
@@ -162,9 +162,10 @@
                 <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
             </div>
 
+            {% include "hepdata_search/modals/search_help.html" %}
+
 {% endblock page_body %}
 
-{% include "hepdata_search/modals/search_help.html" %}
 
 {%- block javascript %}
   {{ webpack['hepdata-home-js.js'] }}

--- a/hepdata/modules/theme/templates/hepdata_theme/home.html
+++ b/hepdata/modules/theme/templates/hepdata_theme/home.html
@@ -35,17 +35,10 @@
 </script>
 {%- endblock json_ld %}
 
-{%- block body %}
+{%- block header_bars %}
+{%- endblock header_bars %}
 
-    {%- block browserupgrade %}
-        <!--[if lt IE 8]>
-            <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
-        <![endif]-->
-    {%- endblock browserupgrade %}
-
-    <div class="site-wrapper">
-
-        {% block page_body %}
+{% block page_body %}
 
             <div class="home-top">
                 <div class="top-bar" id="home_top_bar">
@@ -169,21 +162,14 @@
                 <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
             </div>
 
-            {% include "hepdata_theme/footer.html" %}
+{% endblock page_body %}
 
+{% include "hepdata_search/modals/search_help.html" %}
 
+{%- block javascript %}
+  {{ webpack['hepdata-home-js.js'] }}
+{% endblock %}
 
-            <div class="clearfix"></div>
-
-        {% endblock page_body %}
-
-        {% include "hepdata_search/modals/search_help.html" %}
-
-    </div>
-    {%- block javascript %}
-      {{ webpack['hepdata-home-js.js'] }}
-    {% endblock %}
-    {%- block trackingcode %}
-        {% include "hepdata_theme/trackingcode.html" %}
-    {% endblock %}
-{%- endblock body %}
+{%- block trackingcode %}
+    {% include "hepdata_theme/trackingcode.html" %}
+{% endblock %}

--- a/hepdata/modules/theme/templates/hepdata_theme/page.html
+++ b/hepdata/modules/theme/templates/hepdata_theme/page.html
@@ -80,9 +80,11 @@
 {%- block page_header %}
   <div class="sticky-bars">
 
-    <div class="banner">
-      <p>This is a placeholder banner</p>
-    </div>
+    {% if banner_msg is not none %}
+      <div class="banner">
+        <p>{{ banner_msg | safe }}</p>
+      </div>
+    {% endif %}
 
     {%- block header_bars %}
       {% include "hepdata_theme/header.html" %}

--- a/hepdata/modules/theme/templates/hepdata_theme/page.html
+++ b/hepdata/modules/theme/templates/hepdata_theme/page.html
@@ -78,7 +78,19 @@
 {%- endblock css %}
 
 {%- block page_header %}
-    {% include "hepdata_theme/header.html" %}
+  <div class="sticky-bars">
+
+    <div class="banner">
+      <p>This is a placeholder banner</p>
+    </div>
+
+    {%- block header_bars %}
+      {% include "hepdata_theme/header.html" %}
+      {%- block additional_header_bars %}
+      {%- endblock additional_header_bars %}
+    {%- endblock header_bars %}
+
+  </div>
 {%- endblock page_header %}
 
 

--- a/hepdata/modules/theme/templates/hepdata_theme/page.html
+++ b/hepdata/modules/theme/templates/hepdata_theme/page.html
@@ -80,11 +80,7 @@
 {%- block page_header %}
   <div class="sticky-bars">
 
-    {% if banner_msg is not none %}
-      <div class="banner">
-        <p>{{ banner_msg | safe }}</p>
-      </div>
-    {% endif %}
+    {% include "hepdata_theme/banner.html" %}
 
     {%- block header_bars %}
       {% include "hepdata_theme/header.html" %}

--- a/hepdata/modules/theme/templates/hepdata_theme/page_cover.html
+++ b/hepdata/modules/theme/templates/hepdata_theme/page_cover.html
@@ -46,6 +46,10 @@
         <![endif]-->
     {%- endblock browserupgrade %}
 
+    <div class="sticky-bars">
+      {% include "hepdata_theme/banner.html" %}
+    </div>
+
     <div class="site-wrapper">
         {% block page_header %}
             <div class="container">

--- a/hepdata/modules/theme/templates/hepdata_theme/pages/about.html
+++ b/hepdata/modules/theme/templates/hepdata_theme/pages/about.html
@@ -5,7 +5,7 @@
 
     {{ webpack['hepdata-info.css'] }}
 
-    <div id="about" class="row" style="margin: 0; padding: 9em 10% 1% 5%">
+    <div id="about" class="row" style="margin: 0; padding: 1% 10% 1% 5%">
         <div class="section-header" style="width:135px; padding-bottom: 4em">
             <p>About HEPData</p></div>
 

--- a/hepdata/modules/theme/templates/hepdata_theme/pages/cookies.html
+++ b/hepdata/modules/theme/templates/hepdata_theme/pages/cookies.html
@@ -2,7 +2,7 @@
 
 {% block page_body %}
 
-    <div class="row" style="margin: 0; padding: 9em 10% 1% 5%">
+    <div class="row" style="margin: 0; padding: 1% 10% 1% 5%">
 
         <div class="col-md-12">
              <h2>HEPData Cookie Policy</h2>

--- a/hepdata/modules/theme/templates/hepdata_theme/pages/formats.html
+++ b/hepdata/modules/theme/templates/hepdata_theme/pages/formats.html
@@ -8,7 +8,7 @@
     {% set atlas_search_url = url_for('es_search.search', q='', page=1, collaboration='ATLAS', _external=True) %}
     {% set record_url = url_for('hepdata_records.get_metadata_by_alternative_id', recid='ins1419244', _external=True) %}
 
-    <div class="row" style="margin: 0; padding:9em 10% 2% 5%;">
+    <div class="row" style="margin: 0; padding:2% 10% 2% 5%;">
         <div class="section-header" style="width:185px; padding-bottom: 2em"><p>HEPData Output Formats</p></div>
         <div class="col-md-6">
           <div style="width:330px; margin: 0 auto;">

--- a/hepdata/modules/theme/templates/hepdata_theme/pages/help.html
+++ b/hepdata/modules/theme/templates/hepdata_theme/pages/help.html
@@ -4,7 +4,7 @@
 
     {{ webpack['hepdata-info.css'] }}
 
-    <div id="steps" class="row" style="margin: 0; padding:9em 10% 2% 5%; background-color: #894B9D">
+    <div id="steps" class="row" style="margin: 0; padding:2% 10% 2% 5%; background-color: #894B9D">
         <div class="section-header" style="width:185px; padding-bottom: 2em"><p>Submission Steps</p></div>
 
         <div class="col-md-6">

--- a/hepdata/modules/theme/templates/hepdata_theme/pages/terms.html
+++ b/hepdata/modules/theme/templates/hepdata_theme/pages/terms.html
@@ -5,7 +5,7 @@
 
     {{ webpack['hepdata-info.css'] }}
 
-    <div class="row" style="margin: 0; padding: 6em 10% 1% 5%">
+    <div class="row" style="margin: 0; padding: 1% 10% 1% 5%">
 
         <div class="col-md-12">
             <div align="center">

--- a/hepdata/modules/theme/views.py
+++ b/hepdata/modules/theme/views.py
@@ -31,6 +31,7 @@ from hepdata_validator import LATEST_SCHEMA_VERSION, RAW_SCHEMAS_URL
 
 from hepdata.modules.email.utils import send_flask_message_email
 from hepdata.modules.submission.api import get_latest_hepsubmission
+from hepdata.utils.miscellaneous import sanitize_html
 from hepdata.version import __version__
 
 blueprint = Blueprint(
@@ -57,6 +58,12 @@ def init(state):
     def security_mail_processor():
         site_url = app.config.get('SITE_URL', 'https://www.hepdata.net')
         return dict(site_url=site_url)
+
+    @app.context_processor
+    def set_banner_msg():
+        banner_msg = app.config.get('BANNER_MSG', None)
+        banner_msg = sanitize_html(banner_msg)
+        return dict(banner_msg=banner_msg)
 
 
 @blueprint.route('/')


### PR DESCRIPTION
 * Fixes #322 

Allows addition of a single banner to the top of all pages, configured by putting an HTML string in the `BANNER_MSG` variable in the config file.

Screenshots:
![Screenshot 2022-03-03 at 11 39 26](https://user-images.githubusercontent.com/4507639/156558104-67aebda9-8b54-474b-b3aa-a6003f40c2af.png)
![Screenshot 2022-03-03 at 11 39 49](https://user-images.githubusercontent.com/4507639/156558114-30008d3f-d1eb-4354-9fc5-20a5a51cc163.png)
![Screenshot 2022-03-03 at 11 39 56](https://user-images.githubusercontent.com/4507639/156558119-23b45125-c958-4539-906c-1189867c5d61.png)
![Screenshot 2022-03-03 at 11 40 09](https://user-images.githubusercontent.com/4507639/156558123-e6f42c61-35d3-4dec-82d1-ed9d66e80361.png)

@GraemeWatt are you happy with the styling and colours? (I'm not sure what the best colour is for the home page.)

