### PR TITLE
Flush before querying db to try to avoid OperationalErrors

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -36,7 +36,7 @@ import flask
 from flask_security.utils import hash_password
 import pytest
 from invenio_accounts.models import User, Role
-from invenio_db.shared import metadata, SQLAlchemy as InvenioSQLAlchemy
+from invenio_db import db
 from invenio_search import current_search_client as es
 from selenium import webdriver
 from selenium.webdriver.common.by import By
@@ -51,19 +51,6 @@ from hepdata.ext.elasticsearch.api import reindex_all
 from hepdata.factory import create_app
 from hepdata.modules.records.importer.api import import_records
 from tests.conftest import get_identifiers, import_default_data
-
-
-# Override Invenio-DB's SQLAlchemy object to set pool_pre_ping to True to avoid
-# issues with dropped connection pools
-class SQLAlchemy(InvenioSQLAlchemy):
-    def apply_pool_defaults(self, app, options):
-        # See https://github.com/pallets/flask-sqlalchemy/issues/589#issuecomment-361075700
-        # Will need updating if we move to flask-sqlalchemy >= 2.5
-        super().apply_pool_defaults(app, options)
-        options["pool_pre_ping"] = True
-
-
-db = SQLAlchemy(metadata=metadata)
 
 
 @pytest.fixture(scope='session')
@@ -97,7 +84,6 @@ def app(request):
     with app.app_context():
         if not database_exists(str(db.engine.url)):
             create_database(str(db.engine.url))
-
         db.create_all()
 
     with app.app_context():

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -36,7 +36,7 @@ import flask
 from flask_security.utils import hash_password
 import pytest
 from invenio_accounts.models import User, Role
-from invenio_db import db
+from invenio_db.shared import metadata, SQLAlchemy as InvenioSQLAlchemy
 from invenio_search import current_search_client as es
 from selenium import webdriver
 from selenium.webdriver.common.by import By
@@ -51,6 +51,19 @@ from hepdata.ext.elasticsearch.api import reindex_all
 from hepdata.factory import create_app
 from hepdata.modules.records.importer.api import import_records
 from tests.conftest import get_identifiers, import_default_data
+
+
+# Override Invenio-DB's SQLAlchemy object to set pool_pre_ping to True to avoid
+# issues with dropped connection pools
+class SQLAlchemy(InvenioSQLAlchemy):
+    def apply_pool_defaults(self, app, options):
+        # See https://github.com/pallets/flask-sqlalchemy/issues/589#issuecomment-361075700
+        # Will need updating if we move to flask-sqlalchemy >= 2.5
+        super().apply_pool_defaults(app, options)
+        options["pool_pre_ping"] = True
+
+
+db = SQLAlchemy(metadata=metadata)
 
 
 @pytest.fixture(scope='session')
@@ -84,6 +97,7 @@ def app(request):
     with app.app_context():
         if not database_exists(str(db.engine.url)):
             create_database(str(db.engine.url))
+
         db.create_all()
 
     with app.app_context():

--- a/tests/e2e/test_dashboard.py
+++ b/tests/e2e/test_dashboard.py
@@ -150,6 +150,7 @@ def test_dashboard(live_server, logged_in_browser):
         delete_widget.find_element_by_css_selector('#delete-success p').text
 
     # Should now be 25 submissions not 26
+    db.session.flush()
     submissions = HEPSubmission.query \
         .filter_by(overall_status='todo').all()
     assert len(submissions) == 25


### PR DESCRIPTION
 * Hopefully fixes #484 

The db errors are intermittent so it's hard to know for sure whether this fix has worked or whether it's a coincidence that the last 2 CI runs have passed. I think the `flush` makes sense though, to make sure the db session is up-to-date with the changes made by the web requests before querying.