### PR TITLE
Detect and highlight HistFactory (pyhf) files in submissions

### DIFF
--- a/fixes/add_histfactory_analyses.py
+++ b/fixes/add_histfactory_analyses.py
@@ -1,0 +1,64 @@
+import click
+import logging
+
+from celery import shared_task
+from flask import current_app
+from flask.cli import with_appcontext
+from invenio_db import db
+
+from hepdata.celery import dynamic_tasks
+from hepdata.config import HISTFACTORY_FILE_TYPE
+from hepdata.cli import fix
+from hepdata.ext.elasticsearch.api import reindex_batch
+from hepdata.modules.records.utils.common import is_histfactory
+from hepdata.modules.submission.api import get_latest_hepsubmission
+from hepdata.modules.submission.models import HEPSubmission
+
+logging.basicConfig()
+log = logging.getLogger(__name__)
+
+@fix.command()
+@with_appcontext
+@click.option('--batch-size', '-b', type=int, default=20,
+              help='Number of hepsubmission entries to check at a time.')
+@click.option('--synchronous', '-s', type=bool, default=False)
+def add_histfactory_analyses(batch_size, synchronous=False):
+    all_ids = db.session.query(HEPSubmission.id).order_by(HEPSubmission.id).all()
+
+    count = 0
+    total = len(all_ids)
+    while count <= total:
+        batch_ids = [i[0] for i in all_ids[count:min(count + batch_size, total)]]
+        if synchronous:
+            _add_histfactory_analyses_batch(batch_ids)
+        else:
+            log.info('Sending batch of IDs {0} to {1} to celery'.format(batch_ids[0], batch_ids[-1]))
+            dynamic_tasks.delay('_add_histfactory_analyses_batch', 'add_histfactory_analyses', batch_ids)
+        count += batch_size
+
+
+@shared_task
+def _add_histfactory_analyses_batch(ids):
+    log.info(f"Checking for HistFactory resources in submission ids {ids}")
+    recids_to_reindex = []
+    for id in ids:
+        hepsubmission = HEPSubmission.query.get(id)
+
+        if hepsubmission:
+            for resource in hepsubmission.resources:
+                if resource.file_type != HISTFACTORY_FILE_TYPE and \
+                    is_histfactory(resource.file_location, resource.file_description):
+                        log.info(f"Found histfactory for resource {resource.file_location}")
+                        # Update resource to have type histfactory
+                        resource.file_type = HISTFACTORY_FILE_TYPE
+                        db.session.add(resource)
+                        db.session.commit()
+
+                        # Check if latest submission - reindex if so
+                        latest_submission = get_latest_hepsubmission(publication_recid=hepsubmission.publication_recid)
+                        if latest_submission.version == hepsubmission.version:
+                            recids_to_reindex.append(hepsubmission.id)
+
+    if recids_to_reindex:
+        log.info(f"Reindexing records: {recids_to_reindex}")
+        reindex_batch(recids_to_reindex, current_app.config['ELASTICSEARCH_INDEX'])

--- a/fixes/add_histfactory_analyses.py
+++ b/fixes/add_histfactory_analyses.py
@@ -27,7 +27,7 @@ def add_histfactory_analyses(batch_size, synchronous=False):
 
     count = 0
     total = len(all_ids)
-    while count <= total:
+    while count < total:
         batch_ids = [i[0] for i in all_ids[count:min(count + batch_size, total)]]
         if synchronous:
             _add_histfactory_analyses_batch(batch_ids)
@@ -54,9 +54,9 @@ def _add_histfactory_analyses_batch(ids):
                         db.session.add(resource)
                         db.session.commit()
 
-                        # Check if latest submission - reindex if so
-                        latest_submission = get_latest_hepsubmission(publication_recid=hepsubmission.publication_recid)
-                        if latest_submission.version == hepsubmission.version:
+                        # Check if this is the latest finished submission - reindex if so
+                        latest_submission = get_latest_hepsubmission(publication_recid=hepsubmission.publication_recid, overall_status='finished')
+                        if latest_submission and latest_submission.version == hepsubmission.version:
                             recids_to_reindex.append(hepsubmission.id)
 
     if recids_to_reindex:

--- a/hepdata/config.py
+++ b/hepdata/config.py
@@ -319,6 +319,8 @@ ANALYSES_ENDPOINTS = {
     #'madanalysis': {},
 }
 
+HISTFACTORY_FILE_TYPE = 'HistFactory'
+
 ADMIN_EMAIL = 'info@hepdata.net'
 SUBMISSION_FILE_NAME_PATTERN = 'HEPData-{}-v{}-yaml.zip'
 

--- a/hepdata/ext/elasticsearch/api.py
+++ b/hepdata/ext/elasticsearch/api.py
@@ -118,6 +118,7 @@ def search(query,
         fuzzy_query = QueryString(query=query, fuzziness='AUTO')
         search.query = fuzzy_query | \
                        Q('nested', query=fuzzy_query, path='authors') | \
+                       Q('nested', query=fuzzy_query, path='analyses') | \
                        Q('has_child', type="child_datatable", query=fuzzy_query)
 
     search = search.filter("term", doc_type=CFG_PUB_TYPE)

--- a/hepdata/ext/elasticsearch/document_enhancers.py
+++ b/hepdata/ext/elasticsearch/document_enhancers.py
@@ -29,7 +29,7 @@ from collections import defaultdict
 from dateutil.parser import parse
 from flask import current_app
 
-from hepdata.config import CFG_PUB_TYPE, CFG_DATA_TYPE
+from hepdata.config import CFG_PUB_TYPE, CFG_DATA_TYPE, HISTFACTORY_FILE_TYPE, SITE_URL
 from hepdata.ext.elasticsearch.config.record_mapping import mapping as es_mapping
 from hepdata.modules.permissions.models import SubmissionParticipant
 from hepdata.modules.submission.api import get_latest_hepsubmission
@@ -102,6 +102,9 @@ def add_analyses(doc):
         for reference in latest_submission.resources:
             if reference.file_type in current_app.config['ANALYSES_ENDPOINTS']:
                 doc["analyses"].append({'type': reference.file_type, 'analysis': reference.file_location})
+            elif reference.file_type == HISTFACTORY_FILE_TYPE:
+                landing_page_url = f"{SITE_URL}/record/resource/{reference.id}?landing_page=True"
+                doc["analyses"].append({'type': reference.file_type, 'analysis': landing_page_url})
 
 
 def add_data_keywords(doc):

--- a/hepdata/ext/elasticsearch/query_builder.py
+++ b/hepdata/ext/elasticsearch/query_builder.py
@@ -50,7 +50,8 @@ class HEPDataQueryParser(object):
                 "observables": "data_keywords.observables",
                 "cmenergies": "data_keywords.cmenergies",
                 "phrases": "data_keywords.phrases",
-                "reactions": "data_keywords.reactions"
+                "reactions": "data_keywords.reactions",
+                "analysis": "analyses.type"
             }
         }
 

--- a/hepdata/modules/records/templates/hepdata_records/publication_record.html
+++ b/hepdata/modules/records/templates/hepdata_records/publication_record.html
@@ -148,7 +148,7 @@
                             <ul>
                               {% for analysis in ctx.record.analyses %}
                                 <li><div class="analysis"><a href="{{ analysis.analysis }}" target="_blank"><span
-                                  class="fa fa-line-chart"></span> {{ analysis.type }} Analysis</a></div></li>
+                                  class="fa fa-line-chart"></span> {{ analysis.type }}{% if analysis.type != config.HISTFACTORY_FILE_TYPE %} Analysis{% endif %}</a></div></li>
                               {% endfor %}
                             </ul>
                         </div>

--- a/hepdata/modules/records/templates/hepdata_records/related_record.html
+++ b/hepdata/modules/records/templates/hepdata_records/related_record.html
@@ -131,7 +131,7 @@
                         <ul>
                           {% for analysis in ctx.record.analyses %}
                             <li><div class="analysis"><a href="{{ analysis.analysis }}" target="_blank"><span
-                              class="fa fa-line-chart"></span> {{ analysis.type }} Analysis</a></div></li>
+                              class="fa fa-line-chart"></span> {{ analysis.type }}{% if analysis.type != config.HISTFACTORY_FILE_TYPE %} Analysis{% endif %}</a></div></li>
                           {% endfor %}
                         </ul>
                     </div>

--- a/hepdata/modules/records/utils/common.py
+++ b/hepdata/modules/records/utils/common.py
@@ -73,7 +73,7 @@ URL_PATTERNS = [
 ALLOWED_EXTENSIONS = ('.zip', '.tar', '.tar.gz', '.tgz', '.oldhepdata', '.yaml', '.yaml.gz')
 
 HISTFACTORY_EXTENSIONS = ALLOWED_EXTENSIONS[:4]
-HISTFACTORY_TERMS = ("histfactory json", "pyhf", "likelihoods")
+HISTFACTORY_TERMS = ("histfactory", "pyhf", "likelihoods")
 
 
 def contains_accepted_url(file):

--- a/hepdata/modules/records/utils/common.py
+++ b/hepdata/modules/records/utils/common.py
@@ -28,7 +28,7 @@ from invenio_records.api import Record
 import os
 from sqlalchemy.orm.exc import NoResultFound
 
-from hepdata.config import CFG_PUB_TYPE
+from hepdata.config import CFG_PUB_TYPE, HISTFACTORY_FILE_TYPE
 from hepdata.ext.elasticsearch.api import get_record
 from hepdata.modules.submission.models import HEPSubmission, License
 
@@ -72,7 +72,6 @@ URL_PATTERNS = [
 
 ALLOWED_EXTENSIONS = ('.zip', '.tar', '.tar.gz', '.tgz', '.oldhepdata', '.yaml', '.yaml.gz')
 
-HISTFACTORY_FILE_TYPE = 'HistFactory'
 HISTFACTORY_EXTENSIONS = ALLOWED_EXTENSIONS[:4]
 HISTFACTORY_TERMS = ("histfactory json", "pyhf", "likelihoods")
 

--- a/hepdata/modules/records/utils/common.py
+++ b/hepdata/modules/records/utils/common.py
@@ -72,6 +72,10 @@ URL_PATTERNS = [
 
 ALLOWED_EXTENSIONS = ('.zip', '.tar', '.tar.gz', '.tgz', '.oldhepdata', '.yaml', '.yaml.gz')
 
+HISTFACTORY_FILE_TYPE = 'HistFactory'
+HISTFACTORY_EXTENSIONS = ALLOWED_EXTENSIONS[:4]
+HISTFACTORY_TERMS = ("histfactory json", "pyhf", "likelihoods")
+
 
 def contains_accepted_url(file):
     for pattern in URL_PATTERNS:
@@ -91,12 +95,27 @@ def is_image(filename):
     return False
 
 
-def infer_file_type(file):
+def is_histfactory(filename, description, type=None):
+    if type and type.lower() == HISTFACTORY_FILE_TYPE.lower():
+        return True
+
+    if filename.endswith(HISTFACTORY_EXTENSIONS):
+        description_lc = description.lower()
+        for term in HISTFACTORY_TERMS:
+            if term in description_lc:
+                return True
+
+    return False
+
+
+def infer_file_type(file, description, type=None):
     if "." in file:
         result, pattern = contains_accepted_url(file)
         if result:
             return pattern
         else:
+            if is_histfactory(file, description, type):
+                return HISTFACTORY_FILE_TYPE
             extension = file.rsplit(".", 1)[1]
             if extension in FILE_TYPES:
                 return FILE_TYPES[extension]

--- a/hepdata/modules/records/utils/submission.py
+++ b/hepdata/modules/records/utils/submission.py
@@ -317,7 +317,7 @@ def parse_additional_resources(basepath, recid, yaml_document):
     for reference in yaml_document['additional_resources']:
         resource_location = reference['location']
 
-        file_type = infer_file_type(reference['location'], reference['description'], reference.get('file_type'))
+        file_type = infer_file_type(reference['location'], reference['description'], reference.get('type'))
         contains_pattern, pattern = contains_accepted_url(reference['location'])
         if ('http' in resource_location.lower() and 'hepdata' not in resource_location) or contains_pattern:
             if pattern:

--- a/hepdata/modules/records/utils/submission.py
+++ b/hepdata/modules/records/utils/submission.py
@@ -317,7 +317,7 @@ def parse_additional_resources(basepath, recid, yaml_document):
     for reference in yaml_document['additional_resources']:
         resource_location = reference['location']
 
-        file_type = infer_file_type(reference["location"])
+        file_type = infer_file_type(reference['location'], reference['description'], reference.get('file_type'))
         contains_pattern, pattern = contains_accepted_url(reference['location'])
         if ('http' in resource_location.lower() and 'hepdata' not in resource_location) or contains_pattern:
             if pattern:

--- a/hepdata/modules/search/templates/hepdata_search/modals/search_help.html
+++ b/hepdata/modules/search/templates/hepdata_search/modals/search_help.html
@@ -172,6 +172,26 @@
                                 </li>
                             </ul>
                         </li>
+                        <br/>
+                        <li>Find all papers which include specific types of <strong>analysis</strong>.
+                            <ul>
+                                <li>
+                                    <a href='/search?q=analysis:rivet'
+                                       target="_new">analysis:rivet</a>
+                                     <span class="text-muted">
+                                         (RIVET analysis)
+                                     </span>
+                                </li>
+                                <li>
+                                    <a href='/search?q=analysis:HistFactory'
+                                       target="_new">analysis:HistFactory</a>
+                                    <span class="text-muted">
+                                       (likelihoods in HistFactory format)
+                                    </span>
+                                </li>
+                            </ul>
+                        </li>
+
                     </ul>
                 </div>
 

--- a/hepdata/modules/search/templates/hepdata_search/search_results.html
+++ b/hepdata/modules/search/templates/hepdata_search/search_results.html
@@ -98,8 +98,9 @@
                                         {% for analysis in record.analyses %}
                                             <div class="analysis">
                                                 <a href="{{ analysis.analysis }}" target="_blank"><span
-                                                        class="fa fa-line-chart"></span> {{ analysis.type }}
-                                                    Analysis</a>
+                                                        class="fa fa-line-chart"></span>
+                                                    {{ analysis.type }}{% if analysis.type != config.HISTFACTORY_FILE_TYPE %}Analysis{% endif %}
+                                                  </a>
                                             </div>
                                         {% endfor %}
 

--- a/tests/records_test.py
+++ b/tests/records_test.py
@@ -47,8 +47,7 @@ from hepdata.modules.records.api import process_payload, process_zip_archive, \
     format_resource
 from hepdata.modules.records.importer.api import import_records
 from hepdata.modules.records.utils.submission import get_or_create_hepsubmission, process_submission_directory, do_finalise, unload_submission
-from hepdata.modules.records.utils.common import get_record_by_id, \
-    get_record_contents, is_histfactory, infer_file_type
+from hepdata.modules.records.utils.common import get_record_by_id, get_record_contents
 from hepdata.modules.records.utils.data_processing_utils import generate_table_structure
 from hepdata.modules.records.utils.data_files import get_data_path_for_record
 from hepdata.modules.records.utils.json_ld import get_json_ld
@@ -1014,32 +1013,3 @@ def test_create_breadcrumb_text():
     assert ctx == {
         'breadcrumb_text': 'Suzy Sheep et al.'
     }
-
-@pytest.mark.parametrize("filename,description,type,expected",
-    [
-        ("pyhf.tar.gz", "PyHF", None, True),
-        ("pyhf.tgz", "File containing likelihoods", None, True),
-        ("pyhf.zip", "HistFactory JSON file", None, True),
-        ("test.zip", "Some sort of file", "HistFactory", True),
-        ("test.zip", "Some sort of file", "histfactory", True),
-        ("pyhf.tar.gz", "A file", None, False),
-        ("pyhf.json", "HistFactory JSON file", None, False),
-        ("test.zip", "Some sort of file", "json", False),
-    ]
-)
-def test_is_histfactory(filename, description, type, expected):
-    assert is_histfactory(filename, description, type) == expected
-
-
-@pytest.mark.parametrize("filename,description,type,expected",
-    [
-        ("somesortofresource", "", None, "resource"),
-        ("https://github.com/HEPData/hepdata", "", None, "github"),
-        ("/a/b/c.sh", "", None, "Bash Shell"),
-        ("a/b/c.d", "", None, "d"),
-        ("pyhf.tgz", "File containing likelihoods", None, "HistFactory"),
-        ("test.zip", "Some sort of file", "HistFactory", "HistFactory")
-    ]
-)
-def test_infer_file_type(filename, description, type, expected):
-    assert infer_file_type(filename, description, type) == expected

--- a/tests/search_test.py
+++ b/tests/search_test.py
@@ -166,6 +166,11 @@ def test_query_parser():
 
     assert (parsed_query_string5 == '"P P --> LQ LQ X"')
 
+    _test_query6 = 'analysis:rivet'
+    parsed_query_string6 = HEPDataQueryParser.parse_query(_test_query6)
+
+    assert (parsed_query_string6 == 'analyses.type:rivet')
+
 
 
 def test_search(app, load_default_data, identifiers):


### PR DESCRIPTION
See notes on #163 for details.

To detect histfactory files on existing submissions, a CLI script from `fixes` can be run to check all submissions for associated HistFactory files; if found it updates their file types and reindexes them. The script checks in batches of 20 submissions, sending jobs to celery.

```bash
$ hepdata fix add-histfactory-analyses
```

Further options:

```
$ hepdata fix add-histfactory-analyses --help
Usage: hepdata fix add-histfactory-analyses [OPTIONS]

Options:
  -b, --batch-size INTEGER   Number of hepsubmission entries to check at a
                             time.

  -s, --synchronous BOOLEAN
  --help                     Show this message and exit.
```