### PR TITLE
Visual updates to banner text

### DIFF
--- a/hepdata/modules/theme/assets/scss/body.scss
+++ b/hepdata/modules/theme/assets/scss/body.scss
@@ -248,7 +248,7 @@ code {
   z-index: 10;
 
   .banner {
-    background-color: $purple;
+    background-color: $purple-light;
     padding: 15px;
     text-align: center;
 
@@ -256,6 +256,11 @@ code {
       font-size: larger;
       margin: 0;
       color: white;
+
+      a {
+        color: white;
+        text-decoration: underline;
+      }
     }
   }
 }

--- a/hepdata/modules/theme/templates/hepdata_theme/footer.html
+++ b/hepdata/modules/theme/templates/hepdata_theme/footer.html
@@ -53,7 +53,9 @@
                     Durham</a>.
             </p>
             {% block version %}
+            {% if ctx and ctx.version %}
                 <p class="sw-version">HEPData version: {{ ctx.version }}</p>
+            {% endif %}
             {% endblock %}
         </div>
     </div>

--- a/hepdata/modules/theme/templates/hepdata_theme/general_footer.html
+++ b/hepdata/modules/theme/templates/hepdata_theme/general_footer.html
@@ -1,4 +1,0 @@
-{% extends "hepdata_theme/footer.html" %}
-
-{% block version %}
-{% endblock %}

--- a/hepdata/modules/theme/templates/hepdata_theme/page.html
+++ b/hepdata/modules/theme/templates/hepdata_theme/page.html
@@ -93,7 +93,7 @@
 
 
 {%- block page_footer %}
-    {% include "hepdata_theme/general_footer.html" %}
+    {% include "hepdata_theme/footer.html" %}
 {%- endblock page_footer %}
 
 {%- block javascript %}


### PR DESCRIPTION
* Fixes #496 

- [x] Fix - The "HEPData version" text is missing from the footer even when there is no text in the banner header.
- [x] Fix - HTML links entered via <a> tags can be difficult to see (e.g. purple text on a purple background). It would be better if a style was automatically used for text in <a> tags so that it is visible on all web pages.