### PR TITLE
elasticsearch: catch `ValueError` from invalid `sort_by` parameter or some `cmenergies` ranges

### DIFF
--- a/hepdata/ext/elasticsearch/aggregations.py
+++ b/hepdata/ext/elasticsearch/aggregations.py
@@ -161,7 +161,6 @@ def create_dummy_cmenergies_facets(query_filters=None):
                 span = max_limit - min_limit
                 if span > 0:
                     interval = math.ceil(span / 5)
-                    base = 5
 
                     if span > 1000:
                         base = 500
@@ -175,8 +174,12 @@ def create_dummy_cmenergies_facets(query_filters=None):
                         base = 1
 
                     interval = int(base * math.floor(interval / base))
-                    filter_limits = list(range(min_limit, max_limit, interval))
-                    filter_limits.append(max_limit)
+                    if interval:
+                        filter_limits = list(range(min_limit, max_limit, interval))
+                        filter_limits.append(max_limit)
+                    else:
+                        # The min and max both lie between two adjacent elements in filter_limits.
+                        filter_limits = [min_limit, max_limit]
                 else:
                     # If the span is 0, we've only got a single value, so the
                     # aggregations won't make sense - don't show them.

--- a/hepdata/ext/elasticsearch/api.py
+++ b/hepdata/ext/elasticsearch/api.py
@@ -122,7 +122,10 @@ def search(query,
     search = search.filter("term", doc_type=CFG_PUB_TYPE)
     search = QueryBuilder.add_filters(search, filters)
 
-    mapped_sort_field = sort_fields_mapping(sort_field)
+    try:
+        mapped_sort_field = sort_fields_mapping(sort_field)
+    except ValueError as ve:
+        return {'error': str(ve)}
     search = search.sort({mapped_sort_field : {"order" : calculate_sort_order(sort_order, sort_field)}})
     search = add_default_aggregations(search, filters)
 

--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20220531"
+__version__ = "0.9.4dev20220608"

--- a/tests/aggregations_test.py
+++ b/tests/aggregations_test.py
@@ -449,3 +449,27 @@ def test_create_dummy_cmenergies_facets():
     }
     assert(create_dummy_cmenergies_facets([('cmenergies', [1000.0, 1000.0])]) == expected_filtered3)
     assert(create_dummy_cmenergies_facets([('cmenergies', [1000.0])]) == expected_filtered3)
+
+    expected_filtered4 = {
+        'vals': [
+            {'doc_count': None,
+             'key': u'\u221as \u2265 14000.0',
+             'url_params': {'cmenergies': '14000.0,100000.0'}}
+        ],
+        'max_values': 5,
+        'printable_name': 'CM Energies (GeV)',
+        'type': 'cmenergies'
+    }
+    assert(create_dummy_cmenergies_facets([('cmenergies', [14000.0, 100000.0])]) == expected_filtered4)
+
+    expected_filtered5 = {
+        'vals': [
+            {'doc_count': None,
+             'key': u'2760.0 \u2264 \u221as < 5020.0',
+             'url_params': {'cmenergies': '2760.0,5020.0'}}
+        ],
+        'max_values': 5,
+        'printable_name': 'CM Energies (GeV)',
+        'type': 'cmenergies'
+    }
+    assert(create_dummy_cmenergies_facets([('cmenergies', [2760.0, 5020.0])]) == expected_filtered5)

--- a/tests/e2e/test_search.py
+++ b/tests/e2e/test_search.py
@@ -163,6 +163,13 @@ def test_search_from_home(live_server, env_browser, search_tests):
     )
     assert 'Unable to search for /: Failed to parse query [/]' in element.text
 
+    # Test passing an invalid sort_by value as a URL argument to a search query
+    browser.get(flask.url_for('es_search.search', _external=True) + '?q=collisions&sort_by=invalid_field')
+    element = WebDriverWait(browser, 10).until(
+        EC.presence_of_element_located((By.CLASS_NAME, 'search-results'))
+    )
+    assert 'Unable to search for collisions: Sorting on field invalid_field is not supported' in element.text
+
 
 def test_author_search(live_server, env_browser):
     """Test the author search"""


### PR DESCRIPTION
* Fixes #503.
* Fixes #517.