### PR TITLE
Fix #519

### DIFF
--- a/scripts/check_datatables.py
+++ b/scripts/check_datatables.py
@@ -123,15 +123,15 @@ def _get_driver(username=None):
         (By.CSS_SELECTOR, ".cc_btn_accept_all")
     ))
     time.sleep(1)
-    cookie_accept_btn = driver.find_element_by_css_selector(".cc_btn_accept_all")
+    cookie_accept_btn = driver.find_element(By.CSS_SELECTOR, ".cc_btn_accept_all")
     cookie_accept_btn.click()
 
     if username and password:
         click.echo("Logging in...")
         driver.get('https://www.hepdata.net/login/')
-        login_form = driver.find_element_by_name('login_user_form')
-        login_form.find_element_by_name('email').send_keys(username)
-        login_form.find_element_by_name('password').send_keys(password)
+        login_form = driver.find_element(By.NAME, 'login_user_form')
+        login_form.find_element(By.NAME, 'email').send_keys(username)
+        login_form.find_element(By.NAME, 'password').send_keys(password)
         login_form.submit()
 
     return driver

--- a/scripts/check_datatables.py
+++ b/scripts/check_datatables.py
@@ -45,7 +45,7 @@ def check_by_page(start_page, end_page, max_tables, username):
     for page in range(int(start_page), int(end_page) + 1):
         click.echo("Checking page %s of search results" % page)
         driver.get('https://www.hepdata.net/search/?page=%s' % page)
-        record_links = driver.find_elements_by_css_selector(
+        record_links = driver.find_elements(By.CSS_SELECTOR,
             '.search-result-item .record-header a'
         )
         urls = []
@@ -83,7 +83,7 @@ def _check_url(url, start_table, end_table, driver):
 
     driver.get(url)
 
-    table_links = driver.find_elements_by_css_selector('#table-list li')
+    table_links = driver.find_elements(By.CSS_SELECTOR, '#table-list li')
     table_links = table_links[start_table-1:end_table]
 
     for i, table_link in enumerate(table_links):
@@ -100,7 +100,7 @@ def _check_url(url, start_table, end_table, driver):
             click.echo("Loaded")
         except TimeoutException:
             click.echo("***** Missing table at %s: *****" % url)
-            for el in driver.find_elements_by_id("hepdata_table_loading_failed"):
+            for el in driver.find_elements(By.ID, "hepdata_table_loading_failed"):
                 click.echo("***** %s *****" % el.text)
 
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ tests_require = [
     'pytest-mock>=3.1.0',
     'pytest-timeout>=1.4.2',
     'requests-mock>=1.8.0',
-    'selenium>=4.0.0,<4.3.0',
+    'selenium>=4.0.0',
     'lxml'
 ]
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -233,7 +233,7 @@ def env_browser(request):
     wait = WebDriverWait(browser, 10)
     wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".cc_btn_accept_all")))
     sleep(1)
-    cookie_accept_btn = browser.find_element_by_css_selector(".cc_btn_accept_all")
+    cookie_accept_btn = browser.find_element(By.CSS_SELECTOR, ".cc_btn_accept_all")
     cookie_accept_btn.click()
 
     # Add finalizer to quit the webdriver instance
@@ -255,9 +255,9 @@ def logged_in_browser(env_browser):
     env_browser.get(flask.url_for('security.login', _external=True))
     e2e_assert_url(env_browser, 'security.login')
 
-    login_form = env_browser.find_element_by_name('login_user_form')
-    login_form.find_element_by_name('email').send_keys('test@hepdata.net')
-    login_form.find_element_by_name('password').send_keys('hello1')
+    login_form = env_browser.find_element(By.NAME, 'login_user_form')
+    login_form.find_element(By.NAME, 'email').send_keys('test@hepdata.net')
+    login_form.find_element(By.NAME, 'password').send_keys('hello1')
     login_form.submit()
 
     # Check we're back at the homepage
@@ -284,7 +284,7 @@ def e2e_assert(driver, assertion, message = None):
             print('Assertion message: ' + message + '\n')
 
         print('Browser body text was:\n')
-        print(driver.find_element_by_tag_name('body').text)
+        print(driver.find_element(By.TAG_NAME, 'body').text)
         print('\n================================================================================')
 
     assert assertion, message

--- a/tests/e2e/test_accounts.py
+++ b/tests/e2e/test_accounts.py
@@ -30,6 +30,7 @@ from invenio_accounts.models import User
 from invenio_db import db
 from itsdangerous import URLSafeTimedSerializer
 from flask_security import utils
+from selenium.webdriver.common.by import By
 
 def test_user_registration_and_login(live_server, env_browser):
     """E2E user registration and login test."""
@@ -39,9 +40,9 @@ def test_user_registration_and_login(live_server, env_browser):
     e2e_assert_url(browser, 'security.register')
 
     # 2. Input user data
-    signup_form = browser.find_element_by_name('register_user_form')
-    input_email = signup_form.find_element_by_name('email')
-    input_password = signup_form.find_element_by_name('password')
+    signup_form = browser.find_element(By.NAME, 'register_user_form')
+    input_email = signup_form.find_element(By.NAME, 'email')
+    input_password = signup_form.find_element(By.NAME, 'password')
     # input w/ name "email"
     # input w/ name "password"
     user_email = 'user@hepdata.net'
@@ -53,7 +54,7 @@ def test_user_registration_and_login(live_server, env_browser):
     signup_form.submit()
 
     # ...and get a message saying to expect an email
-    success_element = browser.find_element_by_css_selector('.alert-success')
+    success_element = browser.find_element(By.CSS_SELECTOR, '.alert-success')
     assert(success_element is not None)
     assert(success_element.text == 'Thank you. Confirmation instructions have been sent to {}.'.format(user_email))
 
@@ -65,15 +66,15 @@ def test_user_registration_and_login(live_server, env_browser):
     browser.get(flask.url_for('security.login', _external=True))
     e2e_assert_url(browser, 'security.login')
 
-    login_form = browser.find_element_by_name('login_user_form')
+    login_form = browser.find_element(By.NAME, 'login_user_form')
     # 5. input registered info
-    login_form.find_element_by_name('email').send_keys(user_email)
-    login_form.find_element_by_name('password').send_keys(user_password)
+    login_form.find_element(By.NAME, 'email').send_keys(user_email)
+    login_form.find_element(By.NAME, 'password').send_keys(user_password)
     # 6. Submit!
     login_form.submit()
 
     # 7. We should not yet be able to log in as we haven't confirmed the email
-    error_element = browser.find_element_by_css_selector('.alert-danger')
+    error_element = browser.find_element(By.CSS_SELECTOR, '.alert-danger')
     assert(error_element is not None)
     assert('Email requires confirmation.' in error_element.text)
 
@@ -84,13 +85,13 @@ def test_user_registration_and_login(live_server, env_browser):
     # 8. Check that the resend confirmation link works
     browser.get(flask.url_for('security.send_confirmation', _external=True))
     e2e_assert_url(browser, 'security.send_confirmation')
-    email_confirm_form = browser.find_element_by_name('send_confirmation_form')
+    email_confirm_form = browser.find_element(By.NAME, 'send_confirmation_form')
     # 8a. input registered info
-    email_confirm_form.find_element_by_name('email').send_keys(user_email)
+    email_confirm_form.find_element(By.NAME, 'email').send_keys(user_email)
     # 8b. Submit!
     email_confirm_form.submit()
 
-    info_element = browser.find_element_by_css_selector('.alert-info')
+    info_element = browser.find_element(By.CSS_SELECTOR, '.alert-info')
     assert(info_element is not None)
     assert('Confirmation instructions have been sent to %s.' % user_email
            in info_element.text)
@@ -108,7 +109,7 @@ def test_user_registration_and_login(live_server, env_browser):
 
     # 9c Check that we're on the dashboard and we've got a success message
     e2e_assert_url(browser, 'hep_dashboard.dashboard')
-    success_element = browser.find_element_by_css_selector('.alert-success')
+    success_element = browser.find_element(By.CSS_SELECTOR, '.alert-success')
     assert(success_element is not None)
     assert('Thank you. Your email has been confirmed.' in success_element.text)
 
@@ -126,10 +127,10 @@ def test_user_registration_and_login(live_server, env_browser):
     browser.get(flask.url_for('security.login', _external=True))
     e2e_assert_url(browser, 'security.login')
 
-    login_form = browser.find_element_by_name('login_user_form')
+    login_form = browser.find_element(By.NAME, 'login_user_form')
     # 11a. input registered info
-    login_form.find_element_by_name('email').send_keys(user_email)
-    login_form.find_element_by_name('password').send_keys(user_password)
+    login_form.find_element(By.NAME, 'email').send_keys(user_email)
+    login_form.find_element(By.NAME, 'password').send_keys(user_password)
     # 11b. Submit!
     # check if authenticated at `flask.url_for('security.change_password')`
     login_form.submit()

--- a/tests/e2e/test_dashboard.py
+++ b/tests/e2e/test_dashboard.py
@@ -79,12 +79,12 @@ def test_dashboard(live_server, logged_in_browser):
     assert len(submissions) == 26
 
     # Click on dashboard link
-    browser.find_element_by_link_text('Dashboard').click()
+    browser.find_element(By.LINK_TEXT, 'Dashboard').click()
     e2e_assert_url(browser, 'hep_dashboard.dashboard')
 
     # Check links in top section work
     # Submissions Overview link
-    browser.find_element_by_link_text('Submissions Overview').click()
+    browser.find_element(By.LINK_TEXT, 'Submissions Overview').click()
     e2e_assert_url(browser, 'hep_dashboard.submissions')
 
     # Wait for graph to load
@@ -97,7 +97,7 @@ def test_dashboard(live_server, logged_in_browser):
     e2e_assert_url(browser, 'hep_dashboard.dashboard')
 
     # Edit Profile link
-    browser.find_element_by_link_text('Edit Profile').click()
+    browser.find_element(By.LINK_TEXT, 'Edit Profile').click()
     e2e_assert_url(browser, 'invenio_userprofiles.profile')
 
     # Go back
@@ -112,7 +112,7 @@ def test_dashboard(live_server, logged_in_browser):
     assert len(submission_items) == 25
 
     # Check pagination works
-    browser.find_element_by_css_selector(".pagination-bar a[href='/dashboard/?page=2']").click()
+    browser.find_element(By.CSS_SELECTOR, ".pagination-bar a[href='/dashboard/?page=2']").click()
     # Wait for loader, then new items appear
     WebDriverWait(browser, 10).until(
         EC.text_to_be_present_in_element(
@@ -125,32 +125,32 @@ def test_dashboard(live_server, logged_in_browser):
     assert len(submission_items) == 1
 
     # Check settings modal appears
-    submission_items[0].find_element_by_class_name('manage-submission-trigger').click()
+    submission_items[0].find_element(By.CLASS_NAME, 'manage-submission-trigger').click()
     manage_widget = WebDriverWait(browser, 10).until(
         EC.visibility_of_element_located((By.ID, 'manageWidget'))
     )
-    assert manage_widget.find_element_by_class_name('modal-title').text == 'Manage Submission'
+    assert manage_widget.find_element(By.CLASS_NAME, 'modal-title').text == 'Manage Submission'
     # Close modal
-    manage_widget.find_element_by_css_selector('.modal-footer .btn-default').click()
+    manage_widget.find_element(By.CSS_SELECTOR, '.modal-footer .btn-default').click()
     WebDriverWait(browser, 10).until(
         EC.invisibility_of_element(manage_widget)
     )
 
     # Click delete button
     # Check settings modal appears
-    submission_items[0].find_element_by_class_name('delete-submission-trigger').click()
+    submission_items[0].find_element(By.CLASS_NAME, 'delete-submission-trigger').click()
     delete_widget = WebDriverWait(browser, 10).until(
         EC.visibility_of_element_located((By.ID, 'deleteWidget'))
     )
-    assert delete_widget.find_element_by_class_name('modal-title').text == 'Delete Submission'
+    assert delete_widget.find_element(By.CLASS_NAME, 'modal-title').text == 'Delete Submission'
     # Confirm deletion
-    delete_widget.find_element_by_class_name('confirm-delete').click()
+    delete_widget.find_element(By.CLASS_NAME, 'confirm-delete').click()
     # Wait for confirmation of deletion
     WebDriverWait(browser, 10).until(
         EC.visibility_of_element_located((By.ID, 'delete-success'))
     )
     assert 'Submission deleted' in \
-        delete_widget.find_element_by_css_selector('#delete-success p').text
+        delete_widget.find_element(By.CSS_SELECTOR, '#delete-success p').text
 
     # Should now be 25 submissions not 26
     db.session.flush()
@@ -177,8 +177,8 @@ def test_dashboard(live_server, logged_in_browser):
     assert len(coordinator_rows) == 5
 
     # Click on uploader pane - should be all 25 items
-    browser.find_element_by_link_text('uploader').click()
-    uploader_pane = browser.find_element_by_id('uploader')
+    browser.find_element(By.LINK_TEXT, 'uploader').click()
+    uploader_pane = browser.find_element(By.ID, 'uploader')
     uploader_rows = uploader_pane.find_elements_by_class_name('row')
     assert len(uploader_rows) == 25
 
@@ -188,13 +188,13 @@ def test_dashboard(live_server, logged_in_browser):
     # Scroll down to find paginator
     ActionChains(browser).move_to_element(uploader_rows[4]).perform()
     # Click on last page
-    uploader_pane.find_element_by_css_selector(".pagination-bar li a[title=last]").click()
+    uploader_pane.find_element(By.CSS_SELECTOR, ".pagination-bar li a[title=last]").click()
     # Now last 5 items should be visible
     assert all(not row.is_displayed() for row in uploader_rows[:20])
     assert all(row.is_displayed() for row in uploader_rows[20:])
 
     # Check CSV download works
-    csv_button = browser.find_element_by_link_text('Download Submissions CSV')
+    csv_button = browser.find_element(By.LINK_TEXT, 'Download Submissions CSV')
     download_url = csv_button.get_attribute("href")
     assert(download_url.endswith("/submissions/csv"))
     # We can't test file downloads via selenium on SauceLabs so we'll just
@@ -214,7 +214,7 @@ def test_dashboard(live_server, logged_in_browser):
     # View the dashboard as the non-admin user
     # First scroll back to the top of the screen
     browser.execute_script("window.scrollTo(0,0);")
-    admin_user_filter = browser.find_element_by_id('admin-user-filter')
+    admin_user_filter = browser.find_element(By.ID, 'admin-user-filter')
     admin_user_filter.send_keys('test')
     suggestions_div = WebDriverWait(browser, 10).until(
         EC.presence_of_element_located((By.CLASS_NAME, 'tt-open'))
@@ -230,7 +230,7 @@ def test_dashboard(live_server, logged_in_browser):
         _external=True, view_as_user=non_admin_user.id)
 
     # Check banner appears at top of page
-    banner = browser.find_element_by_class_name('alert-info')
+    banner = browser.find_element(By.CLASS_NAME, 'alert-info')
     assert banner.text == "You are logged in as test@hepdata.net but are currently viewing the " \
         "dashboard as user test2@hepdata.net. View as test@hepdata.net"
 
@@ -242,5 +242,5 @@ def test_dashboard(live_server, logged_in_browser):
     assert len(submission_items) == 0
 
     # Check permissions widget - should be a message saying no contributions
-    permissions_div = browser.find_element_by_id('permissions')
+    permissions_div = browser.find_element(By.ID, 'permissions')
     assert permissions_div.text.startswith('No contributions to show')

--- a/tests/e2e/test_dashboard.py
+++ b/tests/e2e/test_dashboard.py
@@ -108,7 +108,7 @@ def test_dashboard(live_server, logged_in_browser):
     submissions_list = WebDriverWait(browser, 10).until(
         EC.presence_of_element_located((By.ID, "hep-submissions"))
     )
-    submission_items = submissions_list.find_elements_by_class_name('submission-item')
+    submission_items = submissions_list.find_elements(By.CLASS_NAME, 'submission-item')
     assert len(submission_items) == 25
 
     # Check pagination works
@@ -121,7 +121,7 @@ def test_dashboard(live_server, logged_in_browser):
         )
     )
     # Should just be 1 submission on page 2
-    submission_items = browser.find_elements_by_class_name('submission-item')
+    submission_items = browser.find_elements(By.CLASS_NAME, 'submission-item')
     assert len(submission_items) == 1
 
     # Check settings modal appears
@@ -173,13 +173,13 @@ def test_dashboard(live_server, logged_in_browser):
     coordinator_pane = WebDriverWait(browser, 10).until(
         EC.presence_of_element_located((By.ID, 'coordinator'))
     )
-    coordinator_rows = coordinator_pane.find_elements_by_class_name('row')
+    coordinator_rows = coordinator_pane.find_elements(By.CLASS_NAME, 'row')
     assert len(coordinator_rows) == 5
 
     # Click on uploader pane - should be all 25 items
     browser.find_element(By.LINK_TEXT, 'uploader').click()
     uploader_pane = browser.find_element(By.ID, 'uploader')
-    uploader_rows = uploader_pane.find_elements_by_class_name('row')
+    uploader_rows = uploader_pane.find_elements(By.CLASS_NAME, 'row')
     assert len(uploader_rows) == 25
 
     # Only first 5 should be visible
@@ -219,7 +219,7 @@ def test_dashboard(live_server, logged_in_browser):
     suggestions_div = WebDriverWait(browser, 10).until(
         EC.presence_of_element_located((By.CLASS_NAME, 'tt-open'))
     )
-    suggestions = suggestions_div.find_elements_by_class_name('tt-suggestion')
+    suggestions = suggestions_div.find_elements(By.CLASS_NAME, 'tt-suggestion')
     assert len(suggestions) == 2
     assert suggestions[0].text == 'test@hepdata.net'
     assert suggestions[1].text == 'test2@hepdata.net'
@@ -238,7 +238,7 @@ def test_dashboard(live_server, logged_in_browser):
     submissions_list = WebDriverWait(browser, 10).until(
         EC.presence_of_element_located((By.ID, "hep-submissions"))
     )
-    submission_items = submissions_list.find_elements_by_class_name('submission-item')
+    submission_items = submissions_list.find_elements(By.CLASS_NAME, 'submission-item')
     assert len(submission_items) == 0
 
     # Check permissions widget - should be a message saying no contributions

--- a/tests/e2e/test_general.py
+++ b/tests/e2e/test_general.py
@@ -53,7 +53,7 @@ def test_home(app, live_server, env_browser, e2e_identifiers):
             browser.current_url)
 
     # 2. check number of records and the number of datatables is correct
-    record_stats = browser.find_element_by_css_selector("#record_stats")
+    record_stats = browser.find_element(By.CSS_SELECTOR, "#record_stats")
     exp_data_table_count = sum([i['data_tables'] for i in e2e_identifiers])
     exp_publication_count = len(e2e_identifiers)
     assert (record_stats.text == "Search on {0} publications and {1} data tables."
@@ -74,17 +74,17 @@ def test_home(app, live_server, env_browser, e2e_identifiers):
     assert (flask.url_for('hepdata_records.get_metadata_by_alternative_id', recid=hepdata_id, _external=True) in
             browser.current_url)
 
-    assert (browser.find_element_by_css_selector('.record-title').text is not None)
-    assert (browser.find_element_by_css_selector('.record-journal').text is not None)
-    assert (browser.find_element_by_css_selector('#table-list-section li') is not None)
+    assert (browser.find_element(By.CSS_SELECTOR, '.record-title').text is not None)
+    assert (browser.find_element(By.CSS_SELECTOR, '.record-journal').text is not None)
+    assert (browser.find_element(By.CSS_SELECTOR, '#table-list-section li') is not None)
 
-    table_placeholder = browser.find_element_by_css_selector('#table-filter').get_attribute('placeholder')
+    table_placeholder = browser.find_element(By.CSS_SELECTOR, '#table-filter').get_attribute('placeholder')
     expected_record = [x for x in e2e_identifiers if x['hepdata_id'] == hepdata_id]
     assert (table_placeholder == "Filter {0} data tables".format(expected_record[0]['data_tables']))
 
     # Check file download works
-    browser.find_element_by_id('dLabel').click()
-    download_original_link = browser.find_element_by_id('download_original')
+    browser.find_element(By.ID, 'dLabel').click()
+    download_original_link = browser.find_element(By.ID, 'download_original')
     download_url = download_original_link.get_attribute("href")
     assert(download_url.endswith("/download/submission/ins1283842/1/original"))
     # We can't test file downloads via selenium on SauceLabs so we'll just
@@ -96,7 +96,7 @@ def test_home(app, live_server, env_browser, e2e_identifiers):
     except zipfile.BadZipFile:
         assert False, "File is not a valid zip file"
     # Close download dropdown by clicking again
-    browser.find_element_by_id('dLabel').click()
+    browser.find_element(By.ID, 'dLabel').click()
 
     # Go back to homepage and click on 1st link - should be record with resources
     browser.back()
@@ -108,7 +108,7 @@ def test_home(app, live_server, env_browser, e2e_identifiers):
     assert (flask.url_for('hepdata_records.get_metadata_by_alternative_id', recid='ins1883075', _external=True) in
             browser.current_url)
     # Check Resources button is present
-    resources_btn = browser.find_element_by_id('show_all_resources')
+    resources_btn = browser.find_element(By.ID, 'show_all_resources')
     assert resources_btn is not None
     resources_btn.click()
 
@@ -120,19 +120,19 @@ def test_home(app, live_server, env_browser, e2e_identifiers):
     assert len(submission_resources) == 3
 
     # Find Python file resource
-    python_resources = [e for e in submission_resources if e.find_element_by_tag_name('h4').text == 'Python File']
+    python_resources = [e for e in submission_resources if e.find_element(By.TAG_NAME, 'h4').text == 'Python File']
     assert len(python_resources) == 1
     python_resource = python_resources[0]
-    download_btn = python_resource.find_element_by_css_selector('a.btn-sm')
+    download_btn = python_resource.find_element(By.CSS_SELECTOR, 'a.btn-sm')
     assert download_btn.text == 'Download'
     # Get landing page URL from download link and load
     landing_page_url = download_btn.get_attribute("href").replace('view=true', 'landing_page=true')
     browser.get(landing_page_url)
     # Check landing page has appropriate elements
-    header_h4 = browser.find_element_by_css_selector(".hepdata_table_detail_header h4")
-    assert header_h4.find_element_by_class_name("pull-left").text.strip() == \
+    header_h4 = browser.find_element(By.CSS_SELECTOR, ".hepdata_table_detail_header h4")
+    assert header_h4.find_element(By.CLASS_NAME, "pull-left").text.strip() == \
         "cut_based_id.py"
-    textarea = browser.find_element_by_id("code-contents")
+    textarea = browser.find_element(By.ID, "code-contents")
     assert """import numpy as np
 import math
 import ROOT as rt""" in textarea.text
@@ -150,13 +150,13 @@ def test_tables(app, live_server, env_browser):
         assert (flask.url_for('hepdata_theme.index', _external=True) in
                 browser.current_url)
 
-        latest_item = browser.find_element_by_css_selector('.latest-record .title')
+        latest_item = browser.find_element(By.CSS_SELECTOR, '.latest-record .title')
         actions = ActionChains(browser)
         actions.move_to_element(latest_item).perform()
         latest_item.click()
 
         # Check current table name
-        assert(browser.find_element_by_id('table_name').text == 'Figure 8 panel (a)')
+        assert(browser.find_element(By.ID, 'table_name').text == 'Figure 8 panel (a)')
 
         # Check switching tables works as expected
         new_table = browser.find_elements_by_css_selector('#table-list li h4')[2]
@@ -165,7 +165,7 @@ def test_tables(app, live_server, env_browser):
         _check_table_links(browser, "Figure 8 panel (c)")
 
         # Get link to table from table page
-        table_link = browser.find_element_by_css_selector('#data_link_container button') \
+        table_link = browser.find_element(By.CSS_SELECTOR, '#data_link_container button') \
             .get_attribute('data-clipboard-text')
         assert(table_link.endswith('table=Figure%208%20panel%20(c)'))
         _check_table_links(browser, "Figure 8 panel (c)", url=table_link)
@@ -197,7 +197,7 @@ def _check_table_links(browser, table_full_name, url=None):
         EC.text_to_be_present_in_element((By.ID, 'table_name'), table_full_name)
     )
     # Check download YAML link for table
-    yaml_link = browser.find_element_by_id('download_yaml_data') \
+    yaml_link = browser.find_element(By.ID, 'download_yaml_data') \
         .get_attribute('href')
     assert(yaml_link.endswith(f'/{table_full_name.replace(" ", "%20")}/1/yaml'))
     # Download yaml using requests and check we get expected filename

--- a/tests/e2e/test_general.py
+++ b/tests/e2e/test_general.py
@@ -60,9 +60,9 @@ def test_home(app, live_server, env_browser, e2e_identifiers):
             .format(exp_publication_count, exp_data_table_count))
 
     # 3. check that there are three submissions in the latest submissions section
-    assert len(browser.find_elements_by_css_selector('.latest-record .title')) == 3
+    assert len(browser.find_elements(By.CSS_SELECTOR, '.latest-record .title')) == 3
     # 4. click on the second submission (should be one in e2e_identifiers)
-    second_item = browser.find_elements_by_css_selector('.latest-record .title')[1]
+    second_item = browser.find_elements(By.CSS_SELECTOR, '.latest-record .title')[1]
     actions = ActionChains(browser)
     actions.move_to_element(second_item).perform()
     href = second_item.get_attribute("href")
@@ -100,7 +100,7 @@ def test_home(app, live_server, env_browser, e2e_identifiers):
 
     # Go back to homepage and click on 1st link - should be record with resources
     browser.back()
-    latest_item = browser.find_elements_by_css_selector('.latest-record .title')[0]
+    latest_item = browser.find_elements(By.CSS_SELECTOR, '.latest-record .title')[0]
     actions = ActionChains(browser)
     actions.move_to_element(latest_item).perform()
     latest_item.click()
@@ -116,7 +116,7 @@ def test_home(app, live_server, env_browser, e2e_identifiers):
     WebDriverWait(browser, 10).until(
         EC.visibility_of_element_located((By.ID, 'resource-modal-contents'))
     )
-    submission_resources = browser.find_elements_by_class_name('resource-item-container')
+    submission_resources = browser.find_elements(By.CLASS_NAME, 'resource-item-container')
     assert len(submission_resources) == 3
 
     # Find Python file resource
@@ -159,7 +159,7 @@ def test_tables(app, live_server, env_browser):
         assert(browser.find_element(By.ID, 'table_name').text == 'Figure 8 panel (a)')
 
         # Check switching tables works as expected
-        new_table = browser.find_elements_by_css_selector('#table-list li h4')[2]
+        new_table = browser.find_elements(By.CSS_SELECTOR, '#table-list li h4')[2]
         assert(new_table.text == "Figure 8 panel (c)")
         new_table.click()
         _check_table_links(browser, "Figure 8 panel (c)")

--- a/tests/e2e/test_records.py
+++ b/tests/e2e/test_records.py
@@ -56,24 +56,24 @@ def test_record_update(live_server, logged_in_browser):
         'hepdata_records.get_metadata_by_alternative_id',
         recid=f'ins{inspire_id}', _external=True)
     browser.get(record_url)
-    browser.find_element_by_css_selector(
+    browser.find_element(By.CSS_SELECTOR, 
         "button.btn-danger[data-target='#reviseSubmission']").click()
-    revise_submission_dialog = browser.find_element_by_id('reviseSubmission')
+    revise_submission_dialog = browser.find_element(By.ID, 'reviseSubmission')
     WebDriverWait(browser, 10).until(
         EC.visibility_of(revise_submission_dialog)
     )
 
     # Check for warning about a new version
     assert "This submission is already finished." in \
-        revise_submission_dialog.find_element_by_id('revise-confirm').text
+        revise_submission_dialog.find_element(By.ID, 'revise-confirm').text
 
     # Click "Revise Submission" button and wait for response
-    revise_submission_dialog.find_element_by_css_selector("#revise-confirm button[type='submit']").click()
-    revise_success = browser.find_element_by_id('revise-success')
+    revise_submission_dialog.find_element(By.CSS_SELECTOR, "#revise-confirm button[type='submit']").click()
+    revise_success = browser.find_element(By.ID, 'revise-success')
     WebDriverWait(browser, 10).until(
         EC.visibility_of(revise_success)
     )
-    assert revise_success.find_element_by_tag_name('p').text \
+    assert revise_success.find_element(By.TAG_NAME, 'p').text \
         .startswith("Version 2 created.\nThis window will close in ")
 
     # Refresh record page (to avoid waiting)
@@ -90,16 +90,16 @@ def test_record_update(live_server, logged_in_browser):
     assert submissions[1].overall_status == 'todo'
 
     # Upload a new file
-    upload = browser.find_element_by_id('root_file_upload')
+    upload = browser.find_element(By.ID, 'root_file_upload')
     ActionChains(browser).move_to_element(upload).perform()
     upload.send_keys(os.path.abspath("tests/test_data/TestHEPSubmission.zip"))
-    browser.find_element_by_css_selector('form[name=upload-form] input[type=submit]').click()
+    browser.find_element(By.CSS_SELECTOR, 'form[name=upload-form] input[type=submit]').click()
 
     # Wait for page reload
     WebDriverWait(browser, 15).until(
         EC.staleness_of(upload)
     )
-    alert = browser.find_element_by_class_name('alert-info')
+    alert = browser.find_element(By.CLASS_NAME, 'alert-info')
     assert alert.text == "File saved. You will receive an email when the file has been processed."
 
     # Run common checks
@@ -107,19 +107,19 @@ def test_record_update(live_server, logged_in_browser):
 
     # Add some reviews
     # Check initial status of Table 1 is "ToDo"
-    table1_summary = browser.find_element_by_id('table-list') \
-        .find_element_by_class_name('Table1')
+    table1_summary = browser.find_element(By.ID, 'table-list') \
+        .find_element(By.CLASS_NAME, 'Table1')
     table1_id = table1_summary.get_attribute('id')
-    table1_status = table1_summary.find_element_by_id(f'{table1_id}-status')
+    table1_status = table1_summary.find_element(By.ID, f'{table1_id}-status')
     assert "todo" in table1_status.get_attribute('class')
 
     # Change review status
-    browser.find_element_by_id('reviewer-button').click()
-    reviews_view = browser.find_element_by_class_name('reviews-view')
+    browser.find_element(By.ID, 'reviewer-button').click()
+    reviews_view = browser.find_element(By.CLASS_NAME, 'reviews-view')
     WebDriverWait(browser, 10).until(
         EC.visibility_of(reviews_view)
     )
-    reviews_view.find_element_by_id('attention-option').click()
+    reviews_view.find_element(By.ID, 'attention-option').click()
     if "attention" not in table1_status.get_attribute('class'):
         WebDriverWait(browser, 10).until(
             EC.visibility_of_element_located(
@@ -129,10 +129,10 @@ def test_record_update(live_server, logged_in_browser):
     assert "attention" in table1_status.get_attribute('class')
 
     # Send a message
-    message_box = reviews_view.find_element_by_id('message')
+    message_box = reviews_view.find_element(By.ID, 'message')
     ActionChains(browser).move_to_element(message_box).perform()
     message_box.send_keys("This needs to change!")
-    reviews_view.find_element_by_id('save_no_email').click()
+    reviews_view.find_element(By.ID, 'save_no_email').click()
     # Wait until message appears
     message = WebDriverWait(browser, 10).until(
         EC.visibility_of_element_located(
@@ -140,25 +140,25 @@ def test_record_update(live_server, logged_in_browser):
         )
     )
     assert "This needs to change!" in message.text
-    assert "test@hepdata.net" in message.find_element_by_class_name('reviewer').text
+    assert "test@hepdata.net" in message.find_element(By.CLASS_NAME, 'reviewer').text
     # Close review pane
-    browser.find_element_by_id('reviewer-button').click()
+    browser.find_element(By.ID, 'reviewer-button').click()
 
     # Switch to Table 2 and change review status
-    table2_summary = browser.find_element_by_id('table-list') \
-        .find_element_by_class_name('Table2')
+    table2_summary = browser.find_element(By.ID, 'table-list') \
+        .find_element(By.CLASS_NAME, 'Table2')
     table2_summary.click()
     table2_id = table2_summary.get_attribute('id')
-    table2_status = table2_summary.find_element_by_id(f'{table2_id}-status')
+    table2_status = table2_summary.find_element(By.ID, f'{table2_id}-status')
     assert "todo" in table2_status.get_attribute('class')
 
     # Change review status
-    browser.find_element_by_id('reviewer-button').click()
-    reviews_view = browser.find_element_by_class_name('reviews-view')
+    browser.find_element(By.ID, 'reviewer-button').click()
+    reviews_view = browser.find_element(By.CLASS_NAME, 'reviews-view')
     WebDriverWait(browser, 10).until(
         EC.visibility_of(reviews_view)
     )
-    reviews_view.find_element_by_id('passed-option').click()
+    reviews_view.find_element(By.ID, 'passed-option').click()
     if "passed" not in table2_status.get_attribute('class'):
         WebDriverWait(browser, 10).until(
             EC.visibility_of_element_located(
@@ -168,52 +168,52 @@ def test_record_update(live_server, logged_in_browser):
     assert "passed" in table2_status.get_attribute('class')
 
     # Check "Notify Coordinator" is hidden
-    assert not browser.find_element_by_id('notify-coordinator-btn').is_displayed()
+    assert not browser.find_element(By.ID, 'notify-coordinator-btn').is_displayed()
 
     # Click "Approve All"
-    browser.find_element_by_id('approve-all-btn').click()
-    approve_all_modal = browser.find_element_by_id('approveAllTables')
+    browser.find_element(By.ID, 'approve-all-btn').click()
+    approve_all_modal = browser.find_element(By.ID, 'approveAllTables')
     WebDriverWait(browser, 10).until(
         EC.visibility_of(approve_all_modal)
     )
-    approve_all_modal.find_element_by_id('confirmApproveAll').click()
-    approve_all_modal.find_element_by_css_selector('button[type=submit]').click()
+    approve_all_modal.find_element(By.ID, 'confirmApproveAll').click()
+    approve_all_modal.find_element(By.CSS_SELECTOR, 'button[type=submit]').click()
 
     # Wait for page reload
     WebDriverWait(browser, 10).until(
         EC.staleness_of(approve_all_modal)
     )
     # Check all statuses are now 'passed'
-    review_statuses = browser.find_element_by_id('table-list') \
+    review_statuses = browser.find_element(By.ID, 'table-list') \
         .find_elements_by_class_name('review-status')
     for element in review_statuses:
         assert "passed" in element.get_attribute('class')
 
     # Check that "Approve all" button is not visible and "Notify Coordinator"
     # is now visible
-    assert not browser.find_element_by_id('approve-all-btn').is_displayed()
-    assert browser.find_element_by_id('notify-coordinator-btn').is_displayed()
+    assert not browser.find_element(By.ID, 'approve-all-btn').is_displayed()
+    assert browser.find_element(By.ID, 'notify-coordinator-btn').is_displayed()
 
     # Delete the new version
     # Open admin slider
-    browser.find_element_by_id('admin-button').click()
-    admin_view = browser.find_element_by_class_name('admin-view')
+    browser.find_element(By.ID, 'admin-button').click()
+    admin_view = browser.find_element(By.CLASS_NAME, 'admin-view')
     WebDriverWait(browser, 10).until(
         EC.visibility_of(admin_view)
     )
     # Click "Delete"
-    admin_view.find_element_by_css_selector(
+    admin_view.find_element(By.CSS_SELECTOR, 
         "button.btn-danger[data-target='#deleteWidget']"
         ).click()
     # Wait for modal to load
-    delete_widget = browser.find_element_by_id('deleteWidget')
+    delete_widget = browser.find_element(By.ID, 'deleteWidget')
     WebDriverWait(browser, 10).until(
         EC.visibility_of(delete_widget)
     )
-    assert delete_widget.find_element_by_css_selector('#delete-confirm p').text \
+    assert delete_widget.find_element(By.CSS_SELECTOR, '#delete-confirm p').text \
         .startswith("Are you sure you want to delete the latest version of this submission?")
     # Click "Delete now"
-    delete_widget.find_element_by_class_name('confirm-delete').click()
+    delete_widget.find_element(By.CLASS_NAME, 'confirm-delete').click()
     # Wait for confirmation of deletion
     WebDriverWait(browser, 10).until(
         EC.text_to_be_present_in_element((By.ID, 'delete-success'), 'Submission deleted')
@@ -240,20 +240,20 @@ def test_sandbox(live_server, logged_in_browser):
     e2e_assert_url(browser, 'hepdata_records.sandbox')
 
     # Check there are no past sandbox submissions
-    assert browser.find_element_by_id('past_submissions') \
+    assert browser.find_element(By.ID, 'past_submissions') \
         .find_elements_by_xpath(".//*") == []
 
     # Try uploading a file
-    upload = browser.find_element_by_id('root_file_upload')
+    upload = browser.find_element(By.ID, 'root_file_upload')
     ActionChains(browser).move_to_element(upload).perform()
     upload.send_keys(os.path.abspath("tests/test_data/TestHEPSubmission.zip"))
-    browser.find_element_by_class_name('btn-primary').click()
+    browser.find_element(By.CLASS_NAME, 'btn-primary').click()
 
     # Should redirect to record page with confirmation message
     WebDriverWait(browser, 15).until(
         EC.url_matches(f'{sandbox_url}/\\d+')
     )
-    alert = browser.find_element_by_class_name('alert-info')
+    alert = browser.find_element(By.CLASS_NAME, 'alert-info')
     assert alert.text == "File saved. You will receive an email when the file has been processed."
 
     # Record should have been processed immediately by test celery runner
@@ -264,16 +264,16 @@ def test_sandbox(live_server, logged_in_browser):
     browser.get(sandbox_url)
 
     # Check that past submissions column now has a child
-    past_submissions_div = browser.find_element_by_id('past_submissions')
+    past_submissions_div = browser.find_element(By.ID, 'past_submissions')
     assert len(past_submissions_div.find_elements_by_class_name('col-md-10')) == 1
 
     # Delete the sandbox record
-    past_submissions_div.find_element_by_class_name('delete_button').click()
-    delete_modal = browser.find_element_by_id('deleteWidget')
+    past_submissions_div.find_element(By.CLASS_NAME, 'delete_button').click()
+    delete_modal = browser.find_element(By.ID, 'deleteWidget')
     WebDriverWait(browser, 10).until(
         EC.visibility_of(delete_modal)
     )
-    delete_modal.find_element_by_class_name('confirm-delete').click()
+    delete_modal.find_element(By.CLASS_NAME, 'confirm-delete').click()
     WebDriverWait(browser, 10).until(
         EC.text_to_be_present_in_element((By.ID, 'deleteDialogLabel'), 'Submission Deleted')
     )
@@ -282,7 +282,7 @@ def test_sandbox(live_server, logged_in_browser):
     browser.get(sandbox_url)
 
     # Check there are no past sandbox submissions
-    assert browser.find_element_by_id('past_submissions') \
+    assert browser.find_element(By.ID, 'past_submissions') \
         .find_elements_by_xpath(".//*") == []
 
 
@@ -291,45 +291,45 @@ def _check_record_common(browser):
     Check record features that are common to standard and sandbox records.
     Browser should be at relevant record URL before calling this function.
     """
-    assert browser.find_element_by_class_name('record-abstract-content').text \
+    assert browser.find_element(By.CLASS_NAME, 'record-abstract-content').text \
         .startswith('CERN-LHC.  Measurements of the cross section  for ZZ production')
-    table_items = browser.find_element_by_id('table-list').find_elements_by_tag_name('li')
+    table_items = browser.find_element(By.ID, 'table-list').find_elements_by_tag_name('li')
     assert len(table_items) == 8
     assert "active" in table_items[0].get_attribute("class")
-    assert table_items[0].find_element_by_tag_name('h4').text == "Table 1"
-    assert table_items[0].find_element_by_tag_name('p').text == "Data from Page 17 of preprint"
-    table_content = browser.find_element_by_id('hepdata_table_content')
-    assert table_content.find_element_by_id('table_name').text == "Table 1"
-    assert table_content.find_element_by_id('table_location').text == "Data from Page 17 of preprint"
+    assert table_items[0].find_element(By.TAG_NAME, 'h4').text == "Table 1"
+    assert table_items[0].find_element(By.TAG_NAME, 'p').text == "Data from Page 17 of preprint"
+    table_content = browser.find_element(By.ID, 'hepdata_table_content')
+    assert table_content.find_element(By.ID, 'table_name').text == "Table 1"
+    assert table_content.find_element(By.ID, 'table_location').text == "Data from Page 17 of preprint"
 
     # Check resources load (using button for table)
     # modal content should not be visible beforehand
-    modal_content = browser.find_element_by_id('resourceModal')
+    modal_content = browser.find_element(By.ID, 'resourceModal')
     assert not modal_content.is_displayed()
-    table_content.find_element_by_id('show_resources').click()
+    table_content.find_element(By.ID, 'show_resources').click()
     WebDriverWait(browser, 10).until(
         EC.visibility_of(modal_content)
     )
-    assert modal_content.find_element_by_id('additionalResource').text == \
+    assert modal_content.find_element(By.ID, 'additionalResource').text == \
         "Additional Publication Resources"
-    assert modal_content.find_element_by_id('selected_resource_item').text == \
+    assert modal_content.find_element(By.ID, 'selected_resource_item').text == \
         "Table 1"
 
     resource_list_items = modal_content \
-        .find_element_by_id('resource-list-items') \
+        .find_element(By.ID, 'resource-list-items') \
         .find_elements_by_tag_name('li')
 
     # Check we can select a different table/common resources
     resource_list_items[0].click()
-    assert modal_content.find_element_by_id('selected_resource_item').text == \
+    assert modal_content.find_element(By.ID, 'selected_resource_item').text == \
         "Common Resources"
     resource_list_items[8].click()
-    assert modal_content.find_element_by_id('selected_resource_item').text == \
+    assert modal_content.find_element(By.ID, 'selected_resource_item').text == \
         "Table 8"
 
     # Check filtering by table name
     assert len([e for e in resource_list_items if e.is_displayed()]) == 9
-    filter_field = modal_content.find_element_by_id('resource-filter-input')
+    filter_field = modal_content.find_element(By.ID, 'resource-filter-input')
 
     # Filter by 'tab'. First item ("Common resources") should fade out
     filter_field.send_keys('tab')
@@ -353,25 +353,25 @@ def _check_record_common(browser):
     assert len([e for e in resource_list_items if e.is_displayed()]) == 1
 
     # Close the modal
-    modal_content.find_element_by_class_name('close').click()
+    modal_content.find_element(By.CLASS_NAME, 'close').click()
     WebDriverWait(browser, 10).until(
         EC.invisibility_of_element(modal_content)
     )
 
     # Try uploading another file
-    browser.find_element_by_css_selector("button.btn-success[data-target='#uploadDialog']") \
+    browser.find_element(By.CSS_SELECTOR, "button.btn-success[data-target='#uploadDialog']") \
         .click()
-    upload_dialog = browser.find_element_by_id('uploadDialog')
+    upload_dialog = browser.find_element(By.ID, 'uploadDialog')
     WebDriverWait(browser, 10).until(
         EC.visibility_of(upload_dialog)
     )
-    upload = upload_dialog.find_element_by_id('file_upload_field')
+    upload = upload_dialog.find_element(By.ID, 'file_upload_field')
     ActionChains(browser).move_to_element(upload).perform()
     upload.send_keys(os.path.abspath("tests/test_data/sample.oldhepdata"))
-    upload_dialog.find_element_by_css_selector('input[type=submit]').click()
+    upload_dialog.find_element(By.CSS_SELECTOR, 'input[type=submit]').click()
     # Wait for page reload
     WebDriverWait(browser, 15).until(
         EC.staleness_of(upload_dialog)
     )
-    alert = browser.find_element_by_class_name('alert-info')
+    alert = browser.find_element(By.CLASS_NAME, 'alert-info')
     assert alert.text == "File saved. You will receive an email when the file has been processed."

--- a/tests/e2e/test_records.py
+++ b/tests/e2e/test_records.py
@@ -185,7 +185,7 @@ def test_record_update(live_server, logged_in_browser):
     )
     # Check all statuses are now 'passed'
     review_statuses = browser.find_element(By.ID, 'table-list') \
-        .find_elements_by_class_name('review-status')
+        .find_elements(By.CLASS_NAME, 'review-status')
     for element in review_statuses:
         assert "passed" in element.get_attribute('class')
 
@@ -241,7 +241,7 @@ def test_sandbox(live_server, logged_in_browser):
 
     # Check there are no past sandbox submissions
     assert browser.find_element(By.ID, 'past_submissions') \
-        .find_elements_by_xpath(".//*") == []
+        .find_elements(By.XPATH, ".//*") == []
 
     # Try uploading a file
     upload = browser.find_element(By.ID, 'root_file_upload')
@@ -265,7 +265,7 @@ def test_sandbox(live_server, logged_in_browser):
 
     # Check that past submissions column now has a child
     past_submissions_div = browser.find_element(By.ID, 'past_submissions')
-    assert len(past_submissions_div.find_elements_by_class_name('col-md-10')) == 1
+    assert len(past_submissions_div.find_elements(By.CLASS_NAME, 'col-md-10')) == 1
 
     # Delete the sandbox record
     past_submissions_div.find_element(By.CLASS_NAME, 'delete_button').click()
@@ -283,7 +283,7 @@ def test_sandbox(live_server, logged_in_browser):
 
     # Check there are no past sandbox submissions
     assert browser.find_element(By.ID, 'past_submissions') \
-        .find_elements_by_xpath(".//*") == []
+        .find_elements(By.XPATH, ".//*") == []
 
 
 def _check_record_common(browser):
@@ -293,7 +293,7 @@ def _check_record_common(browser):
     """
     assert browser.find_element(By.CLASS_NAME, 'record-abstract-content').text \
         .startswith('CERN-LHC.  Measurements of the cross section  for ZZ production')
-    table_items = browser.find_element(By.ID, 'table-list').find_elements_by_tag_name('li')
+    table_items = browser.find_element(By.ID, 'table-list').find_elements(By.TAG_NAME, 'li')
     assert len(table_items) == 8
     assert "active" in table_items[0].get_attribute("class")
     assert table_items[0].find_element(By.TAG_NAME, 'h4').text == "Table 1"
@@ -317,7 +317,7 @@ def _check_record_common(browser):
 
     resource_list_items = modal_content \
         .find_element(By.ID, 'resource-list-items') \
-        .find_elements_by_tag_name('li')
+        .find_elements(By.TAG_NAME, 'li')
 
     # Check we can select a different table/common resources
     resource_list_items[0].click()

--- a/tests/e2e/test_search.py
+++ b/tests/e2e/test_search.py
@@ -52,14 +52,14 @@ def test_search_from_home(live_server, env_browser, search_tests):
 
     # Check result count
     sleep(1)
-    results = browser.find_elements_by_class_name('search-result-item')
+    results = browser.find_elements(By.CLASS_NAME, 'search-result-item')
     assert(len(results) == 3)
 
     # Check "More" link works
-    table_list = results[0].find_elements_by_css_selector('.data-brief:not(.hidden)')
+    table_list = results[0].find_elements(By.CSS_SELECTOR, '.data-brief:not(.hidden)')
     assert len(table_list) == 3
     results[0].find_element(By.CLASS_NAME, 'data-more').click()
-    table_list = results[0].find_elements_by_css_selector('.data-brief:not(.hidden)')
+    table_list = results[0].find_elements(By.CSS_SELECTOR, '.data-brief:not(.hidden)')
     assert len(table_list) == 6
 
     # Check facet filtering for each facet
@@ -74,7 +74,7 @@ def test_search_from_home(live_server, env_browser, search_tests):
 
     for facet in facets:
         # Check the number of filters for the facet
-        facet_filters = browser.find_elements_by_css_selector('#' + facet['class_prefix'] + '-facet li.list-group-item a')
+        facet_filters = browser.find_elements(By.CSS_SELECTOR, '#' + facet['class_prefix'] + '-facet li.list-group-item a')
         assert(len(facet_filters) == facet['exp_filter_count'])
 
         if len(facet_filters) > 0 and facet['exp_first_result_count'] is not None:
@@ -89,7 +89,7 @@ def test_search_from_home(live_server, env_browser, search_tests):
                     browser.current_url)
 
             # Check the number of search results matches the number given in the filter
-            results = browser.find_elements_by_class_name('search-result-item')
+            results = browser.find_elements(By.CLASS_NAME, 'search-result-item')
             assert(len(results) == facet['exp_first_result_count'])
 
             # Go back to the previous search results
@@ -188,7 +188,7 @@ def test_author_search(live_server, env_browser):
     )
 
     # Check author results are as we expect
-    search_results = browser.find_elements_by_class_name('tt-suggestion')
+    search_results = browser.find_elements(By.CLASS_NAME, 'tt-suggestion')
     expected_authors = [
         'Solano, Ada',
         'Falkowski, Adam',

--- a/tests/e2e/test_search.py
+++ b/tests/e2e/test_search.py
@@ -42,7 +42,7 @@ def test_search_from_home(live_server, env_browser, search_tests):
             browser.current_url)
 
     # Click 'View all'
-    search_all_link = browser.find_element_by_css_selector('#latest_records_section').find_element_by_tag_name('a')
+    search_all_link = browser.find_element(By.CSS_SELECTOR, '#latest_records_section').find_element(By.TAG_NAME, 'a')
     search_all_link.click()
     element = WebDriverWait(browser, 10).until(
         EC.url_contains('search')
@@ -58,7 +58,7 @@ def test_search_from_home(live_server, env_browser, search_tests):
     # Check "More" link works
     table_list = results[0].find_elements_by_css_selector('.data-brief:not(.hidden)')
     assert len(table_list) == 3
-    results[0].find_element_by_class_name('data-more').click()
+    results[0].find_element(By.CLASS_NAME, 'data-more').click()
     table_list = results[0].find_elements_by_css_selector('.data-brief:not(.hidden)')
     assert len(table_list) == 6
 
@@ -79,7 +79,7 @@ def test_search_from_home(live_server, env_browser, search_tests):
 
         if len(facet_filters) > 0 and facet['exp_first_result_count'] is not None:
             # Check the number of results for first filter in the facet
-            result_count = int(facet_filters[0].find_element_by_class_name('facet-count').text.strip())
+            result_count = int(facet_filters[0].find_element(By.CLASS_NAME, 'facet-count').text.strip())
             assert(result_count == facet['exp_first_result_count'])
 
             # Move to the first filter and click
@@ -103,8 +103,8 @@ def test_search_from_home(live_server, env_browser, search_tests):
                     browser.current_url)
 
             # Find the search form, input the query and submit
-            search_form = browser.find_element_by_class_name('main-search-form')
-            search_input = search_form.find_element_by_name('q')
+            search_form = browser.find_element(By.CLASS_NAME, 'main-search-form')
+            search_input = search_form.find_element(By.NAME, 'q')
 
             search_term = search_config['search_term']
             search_input.send_keys(search_term)
@@ -118,16 +118,16 @@ def test_search_from_home(live_server, env_browser, search_tests):
                     browser.current_url)
 
             # Check the expected publication appears in the search results
-            publication = browser.find_element_by_class_name(search_config['exp_hepdata_id'])
+            publication = browser.find_element(By.CLASS_NAME, search_config['exp_hepdata_id'])
             assert (publication)
 
             # Check the expected collaboration facets appear in the filters
-            collab_facets = browser.find_element_by_css_selector('#collaboration-facet ul.list-group li.list-group-item a')
+            collab_facets = browser.find_element(By.CSS_SELECTOR, '#collaboration-facet ul.list-group li.list-group-item a')
             assert(collab_facets.text.startswith(search_config['exp_collab_facet']))
             assert(collab_facets.text.endswith('1'))
 
             # Check the first result has the expected number of data tables
-            data_table_count_span = browser.find_element_by_css_selector('.search-result-item .record-brief div:nth-child(3) span')
+            data_table_count_span = browser.find_element(By.CSS_SELECTOR, '.search-result-item .record-brief div:nth-child(3) span')
             assert(data_table_count_span.text == str(search_config['exp_table_count']))
 
             # Click on the link to the publication details
@@ -152,8 +152,8 @@ def test_search_from_home(live_server, env_browser, search_tests):
             browser.current_url)
 
     # Find the search form, input the query and submit
-    search_form = browser.find_element_by_class_name('main-search-form')
-    search_input = search_form.find_element_by_name('q')
+    search_form = browser.find_element(By.CLASS_NAME, 'main-search-form')
+    search_input = search_form.find_element(By.NAME, 'q')
 
     search_input.send_keys('/')
     search_form.submit()
@@ -179,7 +179,7 @@ def test_author_search(live_server, env_browser):
     browser.get(flask.url_for('es_search.search', _external=True))
 
     # Find the author search box
-    search_input = browser.find_element_by_css_selector('#author-suggest')
+    search_input = browser.find_element(By.CSS_SELECTOR, '#author-suggest')
     search_input.send_keys('ada')
 
     # Wait for search results to appear

--- a/tests/e2e/test_submit.py
+++ b/tests/e2e/test_submit.py
@@ -43,21 +43,21 @@ def test_create_submission(live_server, logged_in_browser):
     assert len(submissions) == 0
 
     # Click "submit"
-    submit_link = browser.find_element_by_link_text('Submit')
+    submit_link = browser.find_element(By.LINK_TEXT, 'Submit')
     submit_link.click()
 
     # Check we're at the submission page
     e2e_assert_url(browser, 'submission.submit_ui')
-    inspire_details_div = browser.find_element_by_id('inspire_details')
+    inspire_details_div = browser.find_element(By.ID, 'inspire_details')
     assert "Do you have an Inspire record associated with your submission?" \
         in inspire_details_div.text
     # Click "Yes" and check continue button appears
-    browser.find_element_by_id('has_inspire').click()
-    continue_button = browser.find_element_by_id('continue_btn')
+    browser.find_element(By.ID, 'has_inspire').click()
+    continue_button = browser.find_element(By.ID, 'continue_btn')
     e2e_assert(browser, not continue_button.is_enabled())
 
     # Fill in inspire id and check continue button is now enabled
-    browser.find_element_by_id('inspire_id').send_keys(inspire_id)
+    browser.find_element(By.ID, 'inspire_id').send_keys(inspire_id)
     e2e_assert(browser, continue_button.is_enabled())
 
     # Click 'continue'
@@ -69,33 +69,33 @@ def test_create_submission(live_server, logged_in_browser):
     )
 
     # Click continue and wait for animation to finish
-    browser.find_element_by_id('preview_continue_btn').click()
+    browser.find_element(By.ID, 'preview_continue_btn').click()
     WebDriverWait(browser, 10).until(
         EC.visibility_of_element_located((By.CSS_SELECTOR, "#reviewers_uploaders h4"))
     )
 
     # Check for reviewer/uploader form
-    reviewers_uploaders_title = browser.find_element_by_css_selector('#reviewers_uploaders h4')
+    reviewers_uploaders_title = browser.find_element(By.CSS_SELECTOR, '#reviewers_uploaders h4')
     assert "Please specify the Uploader and Reviewer for this submission" \
         in reviewers_uploaders_title.text
 
     # Fill in uploader/reviewer and submit
-    browser.find_element_by_id('uploader_name').send_keys('Ursula Uploader')
-    browser.find_element_by_id('uploader_email').send_keys('uu@hepdata.net')
-    browser.find_element_by_id('reviewer_name').send_keys('Rachel Reviewer')
-    browser.find_element_by_id('reviewer_email').send_keys('rr@hepdata.net')
+    browser.find_element(By.ID, 'uploader_name').send_keys('Ursula Uploader')
+    browser.find_element(By.ID, 'uploader_email').send_keys('uu@hepdata.net')
+    browser.find_element(By.ID, 'reviewer_name').send_keys('Rachel Reviewer')
+    browser.find_element(By.ID, 'reviewer_email').send_keys('rr@hepdata.net')
 
     # Click continue and wait for animation to finish
-    browser.find_element_by_id('people_continue_btn').click()
+    browser.find_element(By.ID, 'people_continue_btn').click()
     WebDriverWait(browser, 10).until(
         EC.visibility_of_element_located((By.CSS_SELECTOR, "#uploader_message h4"))
     )
 
     # Add message for uploader
-    browser.find_element_by_id('uploader-message-input').send_keys('Please could you upload something?')
+    browser.find_element(By.ID, 'uploader-message-input').send_keys('Please could you upload something?')
 
     # Click continue and wait for animation to finish
-    browser.find_element_by_id('message_continue_btn').click()
+    browser.find_element(By.ID, 'message_continue_btn').click()
     submission_state_p = WebDriverWait(browser, 10).until(
         EC.text_to_be_present_in_element(
             (By.CSS_SELECTOR, "#submission_state p"),
@@ -103,7 +103,7 @@ def test_create_submission(live_server, logged_in_browser):
     )
 
     # Click continue and wait for animation to finish
-    browser.find_element_by_id('submit_btn').click()
+    browser.find_element(By.ID, 'submit_btn').click()
     submission_state_p = WebDriverWait(browser, 10).until(
         EC.text_to_be_present_in_element(
             (By.CSS_SELECTOR, "#submission_state p"),
@@ -129,17 +129,17 @@ def test_create_submission(live_server, logged_in_browser):
     assert participants[1].status == "primary"
 
     # Try to create another submission with the same inspire id
-    browser.find_element_by_id('another_submission').click()
+    browser.find_element(By.ID, 'another_submission').click()
     e2e_assert_url(browser, 'submission.submit_ui')
-    browser.find_element_by_id('has_inspire').click()
-    browser.find_element_by_id('inspire_id').send_keys(inspire_id)
-    continue_button = browser.find_element_by_id('continue_btn')
+    browser.find_element(By.ID, 'has_inspire').click()
+    browser.find_element(By.ID, 'inspire_id').send_keys(inspire_id)
+    continue_button = browser.find_element(By.ID, 'continue_btn')
     continue_button.click()
     # Wait for alert to appear
     WebDriverWait(browser, 10).until(
         EC.presence_of_element_located((By.CSS_SELECTOR, "#inspire-result .alert-danger"))
     )
-    alert = browser.find_element_by_css_selector("#inspire-result .alert-danger")
+    alert = browser.find_element(By.CSS_SELECTOR, "#inspire-result .alert-danger")
     assert alert.text == 'A record with this Inspire ID already exists in HEPData.'
-    record_link = alert.find_element_by_tag_name('a')
+    record_link = alert.find_element(By.TAG_NAME, 'a')
     assert record_link.get_attribute('href').endswith(f'/record/{submissions[0].publication_recid}')


### PR DESCRIPTION
Fix #519 : Replaced use of deprecated find_element_by_* and find_elements_by_* with find_element. Also removes the setup.py reference to Selenium <4.3.0.