### PR TITLE
Upgrade invenio-assets from v1.2.6 to v1.3.0

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -172,12 +172,6 @@ Next, build assets using webpack (via `invenio-assets <https://invenio-assets.re
 
    (hepdata)$ ./scripts/clean_assets.sh
 
-On an M1 MacBook, until an `issue with Invenio-Assets <https://github.com/inveniosoftware/invenio-assets/issues/144>`_
-is addressed, you will need to replace
-``"node-sass": "^4.12.0",`` with ``"sass": "^1.50.0",`` (or another `Dart Sass <https://sass-lang.com/dart-sass>`_
-version) in the ``package.json`` file of the ``invenio-assets`` installation
-(e.g. ``venv/lib/python3.9/site-packages/invenio_assets/assets/package.json``).
-
 Celery
 ------
 

--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20220719"
+__version__ = "0.9.4dev20220720"

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ invenio-access==1.4.2      # Indirect (needed by invenio-admin)
 invenio-accounts==1.4.9
 invenio-admin==1.3.0
 invenio-app==1.3.1
-invenio-assets==1.2.6
+invenio-assets==1.3.0
 invenio-base==1.2.5
 invenio-config==1.0.3
 invenio-db==1.0.9


### PR DESCRIPTION
* Fixes installation issue on an M1 MacBook (inveniosoftware/invenio-assets#144), so remove mention in docs.