### PR TITLE
ci: fix Sauce Connect Proxy GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,14 +137,14 @@ jobs:
       run: |
         py.test -vv tests/*_test.py
     - name: Setup Sauce Connect
-      uses: saucelabs/sauce-connect-action@main
+      uses: saucelabs/sauce-connect-action@v2
       if: startsWith(matrix.postgres-version, '12') && startsWith(matrix.os-image, 'opensearchproject/opensearch') && startsWith(matrix.python-version, '3.9')
       with:
         username: ${{ secrets.SAUCE_USERNAME }}
         accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
-        restUrl: https://eu-central-1.saucelabs.com/rest/v1
+        restUrl: https://api.eu-central-1.saucelabs.com/rest/v1
         tunnelIdentifier: ${{ github.run_id }}
-        scVersion: 4.7.0
+        scVersion: 4.8.1
         verbose: true
     - name: Run end-to-end tests
       if: startsWith(matrix.postgres-version, '12') && startsWith(matrix.os-image, 'opensearchproject/opensearch') && startsWith(matrix.python-version, '3.9')

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,8 @@ RUN hepdata collect -v  && \
 
 RUN bash -c "echo $APP_ENVIRONMENT"
 
-RUN bash -c "set -x; [[ ${APP_ENVIRONMENT:-prod} = local-web ]] && (cd /usr/local/var && wget https://saucelabs.com/downloads/sc-4.7.1-linux.tar.gz && \
-  tar -xvf sc-4.7.1-linux.tar.gz) || echo 'Not installing SC on prod or worker build'"
+RUN bash -c "set -x; [[ ${APP_ENVIRONMENT:-prod} = local-web ]] && (cd /usr/local/var && wget https://saucelabs.com/downloads/sc-4.8.1-linux.tar.gz && \
+  tar -xvf sc-4.8.1-linux.tar.gz) || echo 'Not installing SC on prod or worker build'"
 
 WORKDIR /code
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -353,7 +353,7 @@ To run the tests:
 
 .. code-block:: console
 
-   $ docker-compose exec web bash -c "/usr/local/var/sc-4.7.1-linux/bin/sc -u $SAUCE_USERNAME -k $SAUCE_ACCESS_KEY --region eu-central & ./run-tests.sh"
+   $ docker-compose exec web bash -c "/usr/local/var/sc-4.8.1-linux/bin/sc -u $SAUCE_USERNAME -k $SAUCE_ACCESS_KEY --region eu-central & ./run-tests.sh"
 
 
 .. _docker-compose-tips:

--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20220826"
+__version__ = "0.9.4dev20220913"


### PR DESCRIPTION
* Switch from `main` to `v2` of sauce-connect-action (closes #372).
* Upgrade Sauce Connect Proxy version from v4.7.0 to latest v4.8.1.