### PR TITLE
Fix problem loading Twitter widget when E2E tests run via Sauce Labs

### DIFF
--- a/hepdata/config.py
+++ b/hepdata/config.py
@@ -266,6 +266,7 @@ TWITTER_HANDLE_MAPPINGS = {
     "bicep2": "@BICEPTWO",
     "xenon": "@Xenon1T",
     "microboone": "@Microboone",
+    "belle-II": "@belle2collab",
 }
 
 INVALID_DOI_TEMPLATE = "hepdata_theme/invalid_doi.html"

--- a/hepdata/modules/permissions/api.py
+++ b/hepdata/modules/permissions/api.py
@@ -147,16 +147,16 @@ def write_submissions_to_files():
     """Writes some statistics on number of submissions per Coordinator to files."""
 
     import csv
-    from datetime import date
+    from datetime import datetime
 
     # Open a CSV file to write the number of unfinished and finished submissions for each Coordinator.
-    csvfile = open('submissions_per_coordinator_{}.csv'.format(date.today()), 'w')
+    csvfile = open('submissions_per_coordinator_{}.csv'.format(datetime.utcnow().date()), 'w')
     writer = csv.writer(csvfile)
     writer.writerow(['user_id', 'user_email', 'collaboration', 'version',
                  'number_todo', 'number_finished'])
 
     # Open another CSV file to write the collaboration and date of each finished version 1 submission.
-    csvfile1 = open('submissions_with_date_{}.csv'.format(date.today()), 'w')
+    csvfile1 = open('submissions_with_date_{}.csv'.format(datetime.utcnow().date()), 'w')
     writer1 = csv.writer(csvfile1)
     writer1.writerow(['collaboration', 'publication_recid', 'inspire_id',
                   'created', 'last_updated'])

--- a/hepdata/modules/records/utils/records_update_utils.py
+++ b/hepdata/modules/records/utils/records_update_utils.py
@@ -173,7 +173,7 @@ def _get_time(date):
     date_is_int = (type(date) is int or type(date) is str and date.isdigit())
 
     if date_is_int:
-        specified_time = datetime.datetime.today() + datetime.timedelta(days=-abs(int(date)))
+        specified_time = datetime.datetime.utcnow() + datetime.timedelta(days=-abs(int(date)))
     else:
         specified_time = datetime.datetime.strptime(date, "%Y-%m-%d")
 

--- a/hepdata/modules/theme/templates/hepdata_theme/home.html
+++ b/hepdata/modules/theme/templates/hepdata_theme/home.html
@@ -35,6 +35,28 @@
 </script>
 {%- endblock json_ld %}
 
+{%- block header %}
+  {# https://developer.twitter.com/en/docs/twitter-for-websites/javascript-api/guides/set-up-twitter-for-websites #}
+  <script>window.twttr = (function(d, s, id) {
+    var js, fjs = d.getElementsByTagName(s)[0],
+      t = window.twttr || {};
+    if (d.getElementById(id)) return t;
+    js = d.createElement(s);
+    js.id = id;
+    js.src = "https://platform.twitter.com/widgets.js";
+    fjs.parentNode.insertBefore(js, fjs);
+
+    t._e = [];
+    t.ready = function(f) {
+      t._e.push(f);
+    };
+
+    return t;
+  }(document, "script", "twitter-wjs"));</script>
+  <meta name="twitter:dnt" content="on">
+  <meta name="twitter:widgets:csp" content="on">
+{% endblock header %}
+
 {%- block header_bars %}
 {%- endblock header_bars %}
 
@@ -155,11 +177,8 @@
             </div>
 
             <div class="twitter-area">
-                <a class="twitter-timeline" data-width="800" data-height="200" data-dnt="true"
-                   href="https://twitter.com/HEPData?ref_src=twsrc%5Etfw">
-                    Tweets by HEPData
-                </a>
-                <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
+              <a class="twitter-timeline" data-height="200"
+                 href="https://twitter.com/HEPData?ref_src=twsrc%5Etfw">Tweets by HEPData</a>
             </div>
 
             {% include "hepdata_search/modals/search_help.html" %}

--- a/hepdata/modules/theme/templates/hepdata_theme/home.html
+++ b/hepdata/modules/theme/templates/hepdata_theme/home.html
@@ -55,6 +55,7 @@
   }(document, "script", "twitter-wjs"));</script>
   <meta name="twitter:dnt" content="on">
   <meta name="twitter:widgets:csp" content="on">
+  <meta name="twitter:widgets:autoload" content="off">
 {% endblock header %}
 
 {%- block header_bars %}
@@ -176,7 +177,7 @@
 
             </div>
 
-            <div class="twitter-area">
+            <div class="twitter-area" id="twitter-feed">
               <a class="twitter-timeline" data-height="200"
                  href="https://twitter.com/HEPData?ref_src=twsrc%5Etfw">Tweets by HEPData</a>
             </div>
@@ -188,6 +189,9 @@
 
 {%- block javascript %}
   {{ webpack['hepdata-home-js.js'] }}
+  {% if not config['TESTING'] %}
+    <script>twttr.widgets.load(document.getElementById("twitter-feed"));</script>
+  {%  endif %}
 {% endblock %}
 
 {%- block trackingcode %}

--- a/hepdata/modules/theme/templates/hepdata_theme/pages/about.html
+++ b/hepdata/modules/theme/templates/hepdata_theme/pages/about.html
@@ -242,6 +242,11 @@
 
             <ul class="talks">
                 {% with talks = [
+                {'meeting': 'Belle II Data Preservation Workshop',
+                'location': 'Roma Tre University, Rome',
+                'speaker': 'Graeme Watt',
+                'date': 'Oct 2022',
+                'link': 'https://indico.belle2.org/event/7653/contributions/44066/attachments/18872/28052/watt_hepdata_oct2022.pdf'},
                 {'meeting': 'STRONG-2020 meeting on database for hadronic cross sections',
                  'location': 'Virtual Zoom',
                  'speaker': 'Graeme Watt',

--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20221011"
+__version__ = "0.9.4dev20221012"

--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20220926"
+__version__ = "0.9.4dev20221011"

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ history = open('CHANGES.rst').read()
 
 tests_require = [
     'pytest>=6.0.2',
-    'pytest-cov>=2.9.0',
+    'pytest-cov>=2.9.0,<4.0.0',
     'pytest-flask>=1.0.0',
     'pytest-mock>=3.1.0',
     'pytest-timeout>=1.4.2',

--- a/tests/dashboard_test.py
+++ b/tests/dashboard_test.py
@@ -476,7 +476,7 @@ def test_submissions_csv(app, admin_idx, load_default_data, identifiers):
         csv_lines = csv_data.splitlines()
         assert len(csv_lines) == 3
         assert csv_lines[0] == 'hepdata_id,version,url,inspire_id,arxiv_id,title,collaboration,creation_date,last_updated,status,uploaders,reviewers'
-        today = datetime.date.today().isoformat()
+        today = datetime.datetime.utcnow().date().isoformat()
         assert csv_lines[1] == f'16,1,http://localhost/record/16,1245023,arXiv:1307.7457,High-statistics study of $K^0_S$ pair production in two-photon collisions,Belle,{today},2013-12-17,finished,,'
         assert csv_lines[2] == f'1,1,http://localhost/record/1,1283842,arXiv:1403.1294,Measurement of the forward-backward asymmetry in the distribution of leptons in $t\\bar{{t}}$ events in the lepton$+$jets channel,D0,{today},2014-08-11,finished,,'
 


### PR DESCRIPTION
* Fixes #545.

After multiple force-pushes trying different options, I sometimes got the end-to-end tests to pass on GitHub Actions by making three main changes:

1. Including the [Twitter for Websites JavaScript](https://developer.twitter.com/en/docs/twitter-for-websites/javascript-api/guides/set-up-twitter-for-websites) in the homepage template instead of using the simpler HTML snippet given by [Twitter Publish](https://publish.twitter.com).
2. Using `<meta name="twitter:widgets:csp" content="on">` to [turn off functionality](https://developer.twitter.com/en/docs/twitter-for-websites/webpage-properties) which may trigger [Content Security Policy](https://en.wikipedia.org/wiki/Content_Security_Policy) warnings.
3. Using `WebDriverWait` in the end-to-end tests to wait for the Twitter timeline to render.

However, eventually I decided that it's simpler and more reliable to only [load](https://developer.twitter.com/en/docs/twitter-for-websites/javascript-api/guides/scripting-loading-and-initialization) the Twitter timeline if the `TESTING` configuration variable is `False`.

I've also added the Twitter account `@belle2collab` for the Belle II experiment and added a link to the slides for my presentation at the [Belle II Data Preservation Workshop](https://indico.belle2.org/event/7653/) last Friday.

I've pinned `pytest-cov<4.0.0` (see [comment below](https://github.com/HEPData/hepdata/pull/546#issuecomment-1275350242)) and fixed a bug which caused a test to fail if run shortly after midnight due to time-zone differences between the date given by `today()` and `utcnow()`.