### PR TITLE
docs: update Read the Docs configuration file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,12 @@
 # Required
 version: 2
 
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
@@ -12,12 +18,11 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF and ePub
 formats: all
 
-# Optionally set the version of Python and requirements required to build your docs
+# Optionally declare the Python requirements required to build your docs
 python:
-  version: 3.8
   install:
-    - requirements: requirements.txt
     - method: pip
       path: .
       extra_requirements:
         - docs
+    - requirements: requirements.txt

--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20221012"
+__version__ = "0.9.4dev20221013"


### PR DESCRIPTION
* Try to fix build by swapping order of python.install commands.
* Use build.tools.python instead of (deprecated) python.version.
* Upgrade from Python 3.8 to Python 3.9.

It looks like the Read the Docs build has been broken since April following PR #492 when I upgraded from Python 3.6 to Python 3.8.  Reversing the order of the two `python.install` commands is needed to install the correct dependency versions.