### PR TITLE
Simplify Twitter widget, improve Read the Docs, lower converter timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
     - name: Build docs
       run: |
         python -m pip install -e .[docs]
-        cd docs && make html SPHINXOPTS="-W"
+        cd docs && make html
     - uses: actions/upload-artifact@v2
       if: ${{ failure() }}
       with:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,7 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
     python: "3.9"
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,6 +14,7 @@ build:
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
+  fail_on_warning: true
 
 # Optionally build your docs in additional formats such as PDF and ePub
 formats: all

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -295,7 +295,7 @@ If any changes were to be made to the installation docs, to check docs can be lo
 .. code-block:: console
 
    (venv)$ cd docs
-   (venv)$ make html SPHINXOPTS="-W"
+   (venv)$ make html
    (venv)$ open _build/html/index.html
 
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W --keep-going
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build
@@ -52,7 +52,7 @@ clean:
 	rm -rf $(BUILDDIR)/*
 
 html:
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) -b html -t html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,7 +66,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u''
+project = u'HEPData'
 copyright = u'2016, CERN'
 author = u'CERN'
 

--- a/docs/info.rst
+++ b/docs/info.rst
@@ -1,27 +1,28 @@
+.. only:: html
 
-.. image:: https://github.com/HEPData/hepdata/workflows/Continuous%20Integration/badge.svg?branch=master
-   :target: https://github.com/HEPData/hepdata/actions?query=branch%3Amaster
-   :alt: GitHub Actions Build Status
+    .. image:: https://github.com/HEPData/hepdata/workflows/Continuous%20Integration/badge.svg?branch=master
+       :target: https://github.com/HEPData/hepdata/actions?query=branch%3Amaster
+       :alt: GitHub Actions Build Status
 
-.. image:: https://coveralls.io/repos/github/HEPData/hepdata/badge.svg?branch=master
-   :target: https://coveralls.io/github/HEPData/hepdata?branch=master
-   :alt: Coveralls Status
+    .. image:: https://coveralls.io/repos/github/HEPData/hepdata/badge.svg?branch=master
+       :target: https://coveralls.io/github/HEPData/hepdata?branch=master
+       :alt: Coveralls Status
 
-.. image:: https://img.shields.io/github/license/HEPData/hepdata.svg
-   :target: https://github.com/HEPData/hepdata/blob/master/LICENSE
-   :alt: License
+    .. image:: https://img.shields.io/github/license/HEPData/hepdata.svg
+       :target: https://github.com/HEPData/hepdata/blob/master/LICENSE
+       :alt: License
 
-.. image:: https://img.shields.io/docker/image-size/hepdata/hepdata/latest
-   :target: https://hub.docker.com/r/hepdata/hepdata/tags
-   :alt: Docker Image Size
+    .. image:: https://img.shields.io/docker/image-size/hepdata/hepdata/latest
+       :target: https://hub.docker.com/r/hepdata/hepdata/tags
+       :alt: Docker Image Size
 
-.. image:: https://img.shields.io/github/issues/hepdata/hepdata.svg?maxAge=2592000
-   :target: https://github.com/HEPData/hepdata/issues
-   :alt: GitHub Issues
+    .. image:: https://img.shields.io/github/issues/hepdata/hepdata.svg?maxAge=2592000
+       :target: https://github.com/HEPData/hepdata/issues
+       :alt: GitHub Issues
 
-.. image:: https://readthedocs.org/projects/hepdata/badge/?version=latest
-   :target: http://hepdata.readthedocs.io/en/latest/?badge=latest
-   :alt: Documentation Status
+    .. image:: https://readthedocs.org/projects/hepdata/badge/?version=latest
+       :target: http://hepdata.readthedocs.io/en/latest/?badge=latest
+       :alt: Documentation Status
 
 The Durham High-Energy Physics Database (HEPData) has been built up over the past four decades as a unique open-access
 repository for scattering data from experimental particle physics. It currently comprises the data points from plots and

--- a/hepdata/config.py
+++ b/hepdata/config.py
@@ -186,7 +186,7 @@ CFG_DATA_KEYWORDS = ['observables', 'reactions', 'cmenergies', 'phrases']
 
 CFG_CONVERTER_URL = 'https://converter.hepdata.net'
 CFG_SUPPORTED_FORMATS = ['yaml', 'root', 'csv', 'yoda', 'original']
-CFG_CONVERTER_TIMEOUT = CLIENT_TIMEOUT # timeout in seconds
+CFG_CONVERTER_TIMEOUT = 220  # timeout in seconds
 
 CFG_TMPDIR = tempfile.gettempdir()
 CFG_DATADIR = tempfile.gettempdir()

--- a/hepdata/modules/theme/assets/scss/home.scss
+++ b/hepdata/modules/theme/assets/scss/home.scss
@@ -171,12 +171,15 @@
 }
 
 .disclaimer-area, .twitter-area {
+  display: flex;
+  justify-content: center;
   background-color: $navy-light;
   padding-top: 1.5vh;
   padding-bottom: 1vh;
   color: white;
   p {
     font-size: 1.1em;
+    text-align: center;
   }
 
   a {

--- a/hepdata/modules/theme/templates/hepdata_theme/home.html
+++ b/hepdata/modules/theme/templates/hepdata_theme/home.html
@@ -35,29 +35,6 @@
 </script>
 {%- endblock json_ld %}
 
-{%- block header %}
-  {# https://developer.twitter.com/en/docs/twitter-for-websites/javascript-api/guides/set-up-twitter-for-websites #}
-  <script>window.twttr = (function(d, s, id) {
-    var js, fjs = d.getElementsByTagName(s)[0],
-      t = window.twttr || {};
-    if (d.getElementById(id)) return t;
-    js = d.createElement(s);
-    js.id = id;
-    js.src = "https://platform.twitter.com/widgets.js";
-    fjs.parentNode.insertBefore(js, fjs);
-
-    t._e = [];
-    t.ready = function(f) {
-      t._e.push(f);
-    };
-
-    return t;
-  }(document, "script", "twitter-wjs"));</script>
-  <meta name="twitter:dnt" content="on">
-  <meta name="twitter:widgets:csp" content="on">
-  <meta name="twitter:widgets:autoload" content="off">
-{% endblock header %}
-
 {%- block header_bars %}
 {%- endblock header_bars %}
 
@@ -177,10 +154,15 @@
 
             </div>
 
-            <div class="twitter-area" id="twitter-feed">
-              <a class="twitter-timeline" data-height="200"
-                 href="https://twitter.com/HEPData?ref_src=twsrc%5Etfw">Tweets by HEPData</a>
-            </div>
+            {% if not config['TESTING'] %}
+              <div class="twitter-area">
+                <p>
+                  <a class="twitter-timeline" data-width="800" data-height="200" data-dnt="true"
+                     href="https://twitter.com/HEPData?ref_src=twsrc%5Etfw">Tweets by HEPData</a>
+                </p>
+                <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+              </div>
+            {% endif %}
 
             {% include "hepdata_search/modals/search_help.html" %}
 
@@ -189,9 +171,6 @@
 
 {%- block javascript %}
   {{ webpack['hepdata-home-js.js'] }}
-  {% if not config['TESTING'] %}
-    <script>twttr.widgets.load(document.getElementById("twitter-feed"));</script>
-  {%  endif %}
 {% endblock %}
 
 {%- block trackingcode %}

--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20221013"
+__version__ = "0.9.4dev20221024"


### PR DESCRIPTION
This PR addresses three unrelated recent issues.

1. Following on from PR #546, the Twitter widget sometimes (but not always) fails to load on the [hepdata.net](https://www.hepdata.net) homepage with an error message in the JavaScript console `TypeError: undefined is not an object (evaluating 'twttr.widgets.load')`.  I've simplified the display of the Twitter widget (if not `TESTING`) to avoid using `twttr.widgets.load`.  I've also reverted to the previous width `data-width="800"` and centred the widget horizontally.
2. Following on from PR #548, I've added `SPHINXOPTS = -W --keep-going` to the `Makefile` for the Sphinx docs to turn warnings into errors, meaning that the Read the Docs build will fail.  This will catch cases like that found in #548 where incorrect installation of Python packages led to `autodoc` failing to import Python modules for six months.  With this option switched on, I had to omit the inclusion of SVG images unless the target is `html`, since this gave warnings when generating the LaTeX docs.  I also upgraded the Docker image used for building the docs from `ubuntu-20.04` to `ubuntu-22.04`.  **Update**: It looks like Read the Docs doesn't use the `Makefile` from the repo, so I've added [`sphinx.fail_on_warning: true`](https://docs.readthedocs.io/en/stable/config-file/v2.html#sphinx-fail-on-warning) to the `.readthedocs.yml` file, which should have the same effect as `SPHINXOPTS = -W --keep-going`.
3. Converting individual tables of https://www.hepdata.net/record/ins2132368?version=1 gives a "504 Gateway Time-out" after 5 minutes due to the large size of the submission.  Instead an error message should be returned by the web application after a time controlled by `CFG_CONVERTER_TIMEOUT`.  I've lowered this variable from 298s to 220s after some experimentation on my local installation.