### PR TITLE
Fix Sauce Connect Proxy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,8 +142,8 @@ jobs:
       with:
         username: ${{ secrets.SAUCE_USERNAME }}
         accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
-        restUrl: https://api.eu-central-1.saucelabs.com/rest/v1
-        tunnelIdentifier: ${{ github.run_id }}
+        region: eu-central
+        tunnelName: ${{ github.run_id }}
         scVersion: 4.8.1
         verbose: true
     - name: Run end-to-end tests


### PR DESCRIPTION
The Sauce Connect Proxy has started ignoring the `restUrl: https://api.eu-central-1.saucelabs.com/rest/v1` option and is using the default value of `restUrl: https://api.us-west-1.saucelabs.com/rest/v1`, resulting in a failed connection.  The problem is fixed by instead specifying `region: eu-central` instead of the deprecated `restUrl`.  I've also changed `tunnelIdentifier` to `tunnelName`.

This PR partially addresses #534, but when that issue was opened, `region: eu-central` did not work.  v3 of `sauce-connect-action` has still not been tagged, so we'll stick with v2 for now.