### PR TITLE
Reinstate FLASK_ENV and add custom icon & description for Zenodo

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -113,11 +113,12 @@ reinstall PyYAML to ensure it's built with LibYAML bindings, e.g. on an M1 MacBo
 
    (venv)$ LDFLAGS="-L$(brew --prefix)/lib" CFLAGS="-I$(brew --prefix)/include" pip install --global-option="--with-libyaml" --force pyyaml==5.4.1
 
-The next line sets an environment variable to switch Flask to run in development mode.
-You may want to set this automatically in your bash or zsh profile.
+The next line sets environment variables to switch Flask to run in development mode.
+You may want to set these automatically in your bash or zsh profile.
 
 .. code-block:: console
 
+   (venv)$ export FLASK_ENV=development
    (venv)$ export FLASK_DEBUG=1
 
 Use of config_local.py

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
     - "APP_SQLALCHEMY_DATABASE_URI=postgresql://hepdata:hepdata@db/hepdata"
     - "SAUCE_USERNAME=${SAUCE_USERNAME}"
     - "SAUCE_ACCESS_KEY=${SAUCE_ACCESS_KEY}"
+    - "FLASK_ENV=development"
     - "FLASK_DEBUG=1"
     read_only: false
     volumes:

--- a/hepdata/modules/records/assets/js/hepdata_common.js
+++ b/hepdata/modules/records/assets/js/hepdata_common.js
@@ -50,7 +50,8 @@ HEPDATA.file_type_to_details = {
   "ufo": {"icon": "rocket", "description": "Universal Feynrules Output (UFO)"},
   "html": {"icon": "code", "description": "External Link"},
   "oldhepdata": {"icon": "file-text-o", "description": "Legacy HEPData Format"},
-  "root": {"icon": "line-chart", "description": "ROOT File"}
+  "root": {"icon": "line-chart", "description": "ROOT File"},
+  "zenodo": {"icon": "code", "description": "Zenodo Record"}
 };
 
 HEPDATA.stats = {

--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20221101"
+__version__ = "0.9.4dev20221110"


### PR DESCRIPTION
* Reinstate `FLASK_ENV` removed in e22276235293da071d36a7d5475412623bcf3cea.
* This variable is used in `hepdata/cli.py` to check for production mode.
* Add custom icon & description for Zenodo (closes #558).