### PR TITLE
Filter Permissions-Policy browser warning

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -244,9 +244,17 @@ def env_browser(request):
 
     # Check browser logs before quitting
     log = browser.get_log('browser')
-    assert len(log) == 0, \
+
+    # Very crude solution to tolerate a non-critical error
+    # Could have been list comprehension instead
+    temp_log = []
+    for t in log:
+        if 'interest-cohort' not in t['message']:
+            temp_log.append(t)
+
+    assert len(temp_log) == 0, \
         "Errors in browser log:\n" + \
-        "\n".join([f"{line['level']}: {line['message']}" for line in log])
+        "\n".join([f"{line['level']}: {line['message']}" for line in temp_log])
 
 
 @pytest.fixture()

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -245,12 +245,9 @@ def env_browser(request):
     # Check browser logs before quitting
     log = browser.get_log('browser')
 
-    # Very crude solution to tolerate a non-critical error
-    # Could have been list comprehension instead
-    temp_log = []
-    for t in log:
-        if 'interest-cohort' not in t['message']:
-            temp_log.append(t)
+    # Filter out error message for:
+    # WARNING: security - Error with Permissions-Policy header: Unrecognized feature: 'interest-cohort'
+    temp_log = [t for t in log if 'interest-cohort' not in t['message']]
 
     assert len(temp_log) == 0, \
         "Errors in browser log:\n" + \


### PR DESCRIPTION
Filters out an warning in the browser logs with the Permissions-Policy browser header that occurs during local e2e tests.

Closes #566.