### PR TITLE
Add Submission Participants and fix record links in Submissions Overview

### DIFF
--- a/hepdata/modules/dashboard/assets/js/hepdata_dashboard_submissions_vis.js
+++ b/hepdata/modules/dashboard/assets/js/hepdata_dashboard_submissions_vis.js
@@ -245,6 +245,12 @@ var submissions_vis = (function () {
                 return '<a href="/search/?q=&collaboration=' +
                   d.collaboration + '" target="_blank">' + '<span class="label ' + d.collaboration + '">' + d.collaboration + '</span>' + '</a>';
               }
+            },
+            function (d) {
+              if(d.participants) {
+                // Add in a space after each comma (end of participant).
+                return '<span>' + String(d.participants).replace(',', ', ') + '</span>';
+              }
             }
           ]).sortBy(function (d) {
           return d.last_updated;

--- a/hepdata/modules/dashboard/assets/js/hepdata_dashboard_submissions_vis.js
+++ b/hepdata/modules/dashboard/assets/js/hepdata_dashboard_submissions_vis.js
@@ -228,7 +228,7 @@ var submissions_vis = (function () {
             },
 
             function (d) {
-              var link_id = d.inspire_id ? 'ins' + d.inspire_id : d.recid;
+              var link_id = d.inspire_id && d.status == 'finished' ? 'ins' + d.inspire_id : d.recid;
               return '<div class="label version">Version ' + d.version + '</div>' +
                 '<a href="/record/' + link_id + '" target="_blank">' + d.title + '</a>';
             },
@@ -247,7 +247,7 @@ var submissions_vis = (function () {
               }
             },
             function (d) {
-              if(d.participants) {
+              if (d.participants) {
                 // Add in a space after each comma (end of participant).
                 return '<span>' + String(d.participants).replace(',', ', ') + '</span>';
               }

--- a/hepdata/modules/dashboard/templates/hepdata_dashboard/submissions.html
+++ b/hepdata/modules/dashboard/templates/hepdata_dashboard/submissions.html
@@ -116,7 +116,7 @@
                                     <th>Data Count</th>
                                     <th>Status</th>
                                     <th>Collaboration</th>
-
+                                    <th>Submission Participants</th>
                                 </tr>
                                 </thead>
                             </table>


### PR DESCRIPTION
Adds a new column containing submission participant information to the Submissions Overview in the Dashboard.  Closes #564.

Also fix record links in the Submission Overview, where links containing the INSPIRE ID didn't work for unfinished records.