### PR TITLE
requirements: remove Babel and pin Flask-Babel

### DIFF
--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20230220"
+__version__ = "0.9.4dev20230302"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-Babel==2.11.0
 beautifulsoup4==4.11.2
 bleach==6.0.0
 celery==5.2.7
@@ -6,6 +5,7 @@ click==8.1.3
 datacite==1.1.2
 email-validator==1.3.1
 Flask==2.2.3
+Flask-Babel==2.0.0
 Flask-CeleryExt==0.5.0
 Flask-Cors==3.0.10
 Flask-Login==0.6.2


### PR DESCRIPTION
* Babel installed by other packages, so direct dependence not needed.
* Pin on Flask-Babel needed for latest Flask-Security-Invenio.
* Fixes #613.