### PR TITLE
requirements: remove some indirect dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,4 @@ updates:
       interval: "weekly"
     ignore:
       - dependency-name: "pytest-cov"  # see https://github.com/HEPData/hepdata/issues/580
+      - dependency-name: "Sphinx"  # see https://github.com/HEPData/hepdata/issues/594

--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20230428"
+__version__ = "0.9.4dev20230502"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,6 @@
 beautifulsoup4==4.12.2
 bleach==6.0.0
-celery==5.2.7
-click==8.1.3
 datacite==1.1.3
-Flask==2.2.3
-Flask-CeleryExt==0.5.0
-Flask-Cors==3.0.10
-Flask-Login==0.6.2
 gunicorn==20.1.0
 hepdata-converter-ws-client==0.2.2
 hepdata-validator==0.3.3
@@ -25,18 +19,7 @@ invenio-records==2.1.0
 invenio-search[opensearch2]==2.2.0
 invenio-theme==2.1.2
 invenio-userprofiles==2.2.0
-jsmin==3.0.1
-lxml==4.9.2
-MarkupSafe==2.1.2
-msgpack==1.0.5
 psycopg2==2.9.6
-python-dateutil==2.8.2
 python-twitter-v2==0.8.1
-pyyaml==6.0
-requests==2.28.2
 responses==0.23.1
-speaklater==1.3
-SQLAlchemy-Continuum==1.3.14   # Indirect: see https://github.com/inveniosoftware/invenio-records/issues/250
-timestring==1.6.4
 unicodeit==0.7.5
-werkzeug==2.2.3


### PR DESCRIPTION
* Reduce the number of PRs bumping versions opened by Dependabot.
* Ignore Sphinx in Dependabot version updates until next Celery release.