### PR TITLE
global: upgrade OpenSearch from v2.2.0 to v2.7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
 
       matrix:
         postgres-version: [ 12, 13 ]
-        os-version: [ '2.2.0' ]
+        os-version: [ '2.7.0' ]
         python-version: [ '3.7', '3.8', '3.9' ]
         exclude:
           - postgres-version: ${{ github.event.act && 13 }}

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -36,26 +36,27 @@ for example, using ``yum`` or ``apt-get`` for Linux or ``brew`` for macOS:
 
  * `PostgreSQL <http://www.postgresql.org/>`_ (version 12) database server
  * `Redis <http://redis.io/>`_ for caching
- * `OpenSearch <https://opensearch.org/>`_ (version 2.2.0) for indexing and information retrieval. See below for further instructions.
+ * `OpenSearch <https://opensearch.org/>`_ (version 2.7.0) for indexing and information retrieval. See below for further instructions.
  * `Node.js <https://nodejs.org>`_ (version 18) JavaScript run-time environment and its package manager `npm <https://www.npmjs.com/>`_.
 
-OpenSearch v2.2.0
+OpenSearch v2.7.0
 -----------------
 
-We are currently using OpenSearch v2.2.0. Here, you can find the `download instructions. <https://opensearch.org/versions/opensearch-2-2-0.html>`_
+We are currently using OpenSearch v2.7.0. Here, you can find the `download instructions. <https://opensearch.org/versions/opensearch-2-7-0.html>`_
 
 There are some examples below:
 
 **MacOS**
 
-Install the latest version with ``brew install opensearch``.  Alternatively, to install v2.2.0 via Homebrew, run:
+Install the latest version (currently, v2.8.0) with ``brew install opensearch``.
+Alternatively, to install a specific version like v2.6.0 via Homebrew (v2.7.0 is unavailable), run:
 
 .. code-block:: console
 
     $ brew tap-new opensearch/tap
-    $ brew extract --version=2.2.0 opensearch opensearch/tap
-    $ brew install opensearch/tap/opensearch@2.2.0
-    $ brew services restart opensearch/tap/opensearch@2.2.0
+    $ brew extract --version=2.6.0 opensearch opensearch/tap
+    $ brew install opensearch/tap/opensearch@2.6.0
+    $ brew services restart opensearch/tap/opensearch@2.6.0
 
 **Linux**
 
@@ -73,8 +74,8 @@ Alternatively, run OpenSearch after `installing Docker <https://docs.docker.com/
 
 .. code-block:: console
 
-    $ docker pull opensearchproject/opensearch:2.2.0
-    $ docker run -d -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" -e "plugins.security.disabled=true" opensearchproject/opensearch:2.2.0
+    $ docker pull opensearchproject/opensearch:2.7.0
+    $ docker run -d -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" -e "plugins.security.disabled=true" opensearchproject/opensearch:2.7.0
 
 .. _installation:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
     - "5432:5432"
     read_only: false
   os:
-    image: opensearchproject/opensearch:2.2.0
+    image: opensearchproject/opensearch:2.7.0
     read_only: false
     environment:
       - node.name=os01

--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20230703"
+__version__ = "0.9.4dev20230710"


### PR DESCRIPTION
Upgrade OpenSearch to match the version soon to be used in production (and already used for the QA instance).