### PR TITLE
ci: remove PostgreSQL v12 from testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,11 +53,10 @@ jobs:
     strategy:
 
       matrix:
-        postgres-version: [ 12, 13 ]
+        postgres-version: [ 13 ]
         os-version: [ '2.7.0' ]
         python-version: [ '3.7', '3.8', '3.9' ]
         exclude:
-          - postgres-version: ${{ github.event.act && 13 }}
           - python-version: ${{ github.event.act && '3.7' }}
           - python-version: ${{ github.event.act && '3.8' }}
 
@@ -159,7 +158,7 @@ jobs:
         py.test -vv tests/*_test.py
     - name: Setup Sauce Connect
       uses: saucelabs/sauce-connect-action@v2
-      if: startsWith(matrix.postgres-version, '12') && startsWith(matrix.python-version, '3.9')
+      if: startsWith(matrix.python-version, '3.9')
       with:
         username: ${{ secrets.SAUCE_USERNAME }}
         accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
@@ -168,7 +167,7 @@ jobs:
         scVersion: 4.9.1
         verbose: true
     - name: Run end-to-end tests
-      if: startsWith(matrix.postgres-version, '12') && startsWith(matrix.python-version, '3.9')
+      if: startsWith(matrix.python-version, '3.9')
       env:
         SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
         SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
@@ -176,7 +175,7 @@ jobs:
       run: |
         if [[ -n ${{ secrets.SAUCE_USERNAME }} && -n ${{ secrets.SAUCE_ACCESS_KEY}} ]]; then py.test -vv tests/e2e; fi
     - name: Run coveralls
-      if: ${{ startsWith(matrix.postgres-version, '12') && startsWith(matrix.python-version, '3.9') && !env.ACT }}
+      if: ${{ startsWith(matrix.python-version, '3.9') && !env.ACT }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         COVERALLS_SERVICE_NAME: github

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -34,7 +34,7 @@ HEPData runs with Python 3.7, 3.8 or 3.9. It also uses several services, which y
 These services can be installed using the relevant package manager for your system,
 for example, using ``yum`` or ``apt-get`` for Linux or ``brew`` for macOS:
 
- * `PostgreSQL <http://www.postgresql.org/>`_ (version 12) database server
+ * `PostgreSQL <http://www.postgresql.org/>`_ (version 13) database server
  * `Redis <http://redis.io/>`_ for caching
  * `OpenSearch <https://opensearch.org/>`_ (version 2.7.0) for indexing and information retrieval. See below for further instructions.
  * `Node.js <https://nodejs.org>`_ (version 18) JavaScript run-time environment and its package manager `npm <https://www.npmjs.com/>`_.
@@ -181,7 +181,7 @@ PostgreSQL
 
 See `YUM Installation <https://wiki.postgresql.org/wiki/YUM_Installation>`_ and
 `First steps <https://wiki.postgresql.org/wiki/First_steps>`_.  On Linux you might need ``sudo su - postgres`` before
-executing the steps below.  On macOS you can install with ``brew install postgresql@12``.
+executing the steps below.  On macOS you can install with ``brew install postgresql@13``.
 
 .. code-block:: console
 
@@ -224,9 +224,9 @@ Set email confirmation for the test user within the database.
    UPDATE 1
 
 If you're having problems with access permissions to the database (on Linux), a simple solution is to edit the
-PostgreSQL Client Authentication Configuration File (e.g. ``/var/lib/pgsql/12/data/pg_hba.conf``) to
+PostgreSQL Client Authentication Configuration File (e.g. ``/var/lib/pgsql/13/data/pg_hba.conf``) to
 ``trust`` local and IPv4/IPv6 connections (instead of ``peer`` or ``ident``), then restart the PostgreSQL
-server (e.g. ``sudo systemctl restart postgresql-12``).
+server (e.g. ``sudo systemctl restart postgresql-13``).
 
 Recreate the OpenSearch index
 -----------------------------

--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20230920"
+__version__ = "0.9.4dev20230926"


### PR DESCRIPTION
* Also revise INSTALL.rst now PostgreSQL v13 is used in production.