### PR TITLE
global: adapt code to add MadAnalysis 5 support

### DIFF
--- a/hepdata/cli.py
+++ b/hepdata/cli.py
@@ -223,9 +223,10 @@ def do_unload(records_to_unload):
 
 @utils.command()
 @with_appcontext
-def find_and_add_record_analyses():
-    """Finds analyses such as Rivet and adds them to records."""
-    update_analyses()
+@click.option('--endpoint', '-e', type=str, help='Specific endpoint to update (e.g. "rivet" or "MadAnalysis"). Omit for all.')
+def find_and_add_record_analyses(endpoint):
+    """Finds analyses such as Rivet and MadAnalysis 5 and adds them to records."""
+    update_analyses(endpoint)
 
 
 @utils.command()

--- a/hepdata/config.py
+++ b/hepdata/config.py
@@ -313,11 +313,14 @@ ANALYSES_ENDPOINTS = {
         'endpoint_url': 'http://rivet.hepforge.org/analyses.json',
         'url_template': 'http://rivet.hepforge.org/analyses/{0}'
     },
+    'MadAnalysis': {
+        'endpoint_url': 'https://madanalysis.irmp.ucl.ac.be/raw-attachment/wiki/MA5SandBox/analyses.json',
+        'url_template': 'https://doi.org/{0}'
+    },
     #'ufo': {},
     #'xfitter': {},
     #'applgrid': {},
     #'fastnlo': {},
-    #'madanalysis': {},
 }
 
 HISTFACTORY_FILE_TYPE = 'HistFactory'

--- a/hepdata/ext/opensearch/document_enhancers.py
+++ b/hepdata/ext/opensearch/document_enhancers.py
@@ -91,7 +91,8 @@ def add_shortened_authors(doc):
 
 def add_analyses(doc):
     """
-    TODO: Generalise for badges other than Rivet
+    Add analyses links such as Rivet, MadAnalysis 5 and HistFactory to the index.
+
     :param doc:
     :return:
     """

--- a/hepdata/modules/records/assets/js/hepdata_common.js
+++ b/hepdata/modules/records/assets/js/hepdata_common.js
@@ -44,7 +44,7 @@ HEPDATA.file_type_to_details = {
   "bitbucket": {"icon": "bitbucket", "description": "Bitbucket Repository"},
   "fastnlo": {"icon": "area-chart", "description": "fastNLO Analysis"},
   "rivet": {"icon": "area-chart", "description": "Rivet Analysis"},
-  "madanalysis": {"icon": "area-chart", "description": "MadAnalysis5 Analysis"},
+  "madanalysis": {"icon": "area-chart", "description": "MadAnalysis 5 Analysis"},
   "xfitter": {"icon": "area-chart", "description": "xFitter Analysis"},
   "applgrid": {"icon": "area-chart", "description": "APPLgrid Analysis"},
   "ufo": {"icon": "rocket", "description": "Universal Feynrules Output (UFO)"},

--- a/hepdata/modules/records/templates/hepdata_records/components/resources-widget.html
+++ b/hepdata/modules/records/templates/hepdata_records/components/resources-widget.html
@@ -39,7 +39,7 @@
                                                 <select name="analysisType" id="analysisType" class="form-control">
                                                     <option disabled>Analyses</option>
                                                     <option value="applgrid">APPLgrid</option>
-                                                    <option value="madanalysis">MadAnalysis5</option>
+                                                    <option value="MadAnalysis">MadAnalysis 5</option>
                                                     <option value="rivet">Rivet</option>
                                                     <option value="fastnlo">fastNLO</option>
                                                     <option value="ufo">Universal Feynrules Output (UFO)</option>

--- a/hepdata/modules/records/templates/hepdata_records/publication_record.html
+++ b/hepdata/modules/records/templates/hepdata_records/publication_record.html
@@ -153,7 +153,7 @@
                             <ul>
                               {% for analysis in ctx.record.analyses %}
                                 <li><div class="analysis"><a href="{{ analysis.analysis }}" target="_blank"><span
-                                  class="fa fa-line-chart"></span> {{ analysis.type }}{% if analysis.type != config.HISTFACTORY_FILE_TYPE %} Analysis{% endif %}</a></div></li>
+                                  class="fa fa-line-chart"></span> {{ analysis.type }}{% if analysis.type == 'rivet' %} Analysis{% endif %}</a></div></li>
                               {% endfor %}
                             </ul>
                         </div>

--- a/hepdata/modules/records/templates/hepdata_records/related_record.html
+++ b/hepdata/modules/records/templates/hepdata_records/related_record.html
@@ -142,7 +142,7 @@
                         <ul>
                           {% for analysis in ctx.record.analyses %}
                             <li><div class="analysis"><a href="{{ analysis.analysis }}" target="_blank"><span
-                              class="fa fa-line-chart"></span> {{ analysis.type }}{% if analysis.type != config.HISTFACTORY_FILE_TYPE %} Analysis{% endif %}</a></div></li>
+                              class="fa fa-line-chart"></span> {{ analysis.type }}{% if analysis.type == 'rivet' %} Analysis{% endif %}</a></div></li>
                           {% endfor %}
                         </ul>
                     </div>

--- a/hepdata/modules/records/utils/analyses.py
+++ b/hepdata/modules/records/utils/analyses.py
@@ -38,10 +38,17 @@ log = logging.getLogger(__name__)
 
 
 @shared_task
-def update_analyses():
-    """Update (Rivet) analyses and remove outdated resources."""
+def update_analyses(endpoint=None):
+    """
+    Update (Rivet and MadAnalysis 5) analyses and remove outdated resources.
+
+    :param endpoint: either "Rivet" or "MadAnalysis" or None (default) for both
+    """
     endpoints = current_app.config["ANALYSES_ENDPOINTS"]
     for analysis_endpoint in endpoints:
+
+        if endpoint and endpoint != analysis_endpoint:
+            continue
 
         if "endpoint_url" in endpoints[analysis_endpoint]:
 

--- a/hepdata/modules/search/templates/hepdata_search/modals/search_help.html
+++ b/hepdata/modules/search/templates/hepdata_search/modals/search_help.html
@@ -184,6 +184,13 @@
                                      </span>
                                 </li>
                                 <li>
+                                    <a href='/search?q=analysis:MadAnalysis'
+                                       target="_new">analysis:MadAnalysis</a>
+                                    <span class="text-muted">
+                                       (MadAnalysis 5 analysis)
+                                    </span>
+                                </li>
+                                <li>
                                     <a href='/search?q=analysis:HistFactory'
                                        target="_new">analysis:HistFactory</a>
                                     <span class="text-muted">

--- a/hepdata/modules/search/templates/hepdata_search/search_results.html
+++ b/hepdata/modules/search/templates/hepdata_search/search_results.html
@@ -101,7 +101,7 @@
                                             <div class="analysis">
                                                 <a href="{{ analysis.analysis }}" target="_blank"><span
                                                         class="fa fa-line-chart"></span>
-                                                    {{ analysis.type }}{% if analysis.type != config.HISTFACTORY_FILE_TYPE %} Analysis{% endif %}
+                                                    {{ analysis.type }}{% if analysis.type == 'rivet' %} Analysis{% endif %}
                                                   </a>
                                             </div>
                                         {% endfor %}

--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20230926"
+__version__ = "0.9.4dev20231005"

--- a/tests/records_test.py
+++ b/tests/records_test.py
@@ -1029,13 +1029,22 @@ def test_update_analyses(app):
     assert analysis_resources[0].file_location == 'http://rivet.hepforge.org/analyses#ATLAS_2012_I1203852'
 
     # Call update_analyses(): should add new resource and delete existing one
-    update_analyses()
+    update_analyses('rivet')
     analysis_resources = DataResource.query.filter_by(file_type='rivet').all()
     assert len(analysis_resources) == 1
     assert analysis_resources[0].file_location == 'http://rivet.hepforge.org/analyses/ATLAS_2012_I1203852'
 
     # Call update_analyses() again: should be no further changes (but covers more lines of code)
-    update_analyses()
+    update_analyses('rivet')
     analysis_resources = DataResource.query.filter_by(file_type='rivet').all()
     assert len(analysis_resources) == 1
     assert analysis_resources[0].file_location == 'http://rivet.hepforge.org/analyses/ATLAS_2012_I1203852'
+
+    # Import a record that has an associated MadAnalysis 5 analyses
+    import_records(['ins1811596'], synchronous=True)
+    analysis_resources = DataResource.query.filter_by(file_type='MadAnalysis').all()
+    assert len(analysis_resources) == 0
+    update_analyses('MadAnalysis')
+    analysis_resources = DataResource.query.filter_by(file_type='MadAnalysis').all()
+    assert len(analysis_resources) == 1
+    assert analysis_resources[0].file_location == 'https://doi.org/10.14428/DVN/I2CZWU'


### PR DESCRIPTION
* Add `MadAnalysis` details to `ANALYSES_ENDPOINTS` in `config.py`.
* Modify `update_analyses` function and corresponding CLI command `hepdata utils find-and-add-record-analyses` to take an optional argument `endpoint` allowing `rivet` or `MadAnalysis` updates to be made separately, with the default to update all endpoints.
* Update "Advanced Search Tips" to mention new search query [`analysis:MadAnalysis`](https://www.hepdata.net/search?q=analysis:MadAnalysis).

Closes #710.