### PR TITLE
global: add YODA1 download option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 HEPData
 =======
 
-.. image:: https://github.com/HEPData/hepdata/workflows/Continuous%20Integration/badge.svg?branch=main
+.. image:: https://github.com/HEPData/hepdata/actions/workflows/ci.yml/badge.svg?branch=main
    :target: https://github.com/HEPData/hepdata/actions?query=branch%3Amain
    :alt: GitHub Actions Build Status
 

--- a/hepdata/config.py
+++ b/hepdata/config.py
@@ -185,7 +185,7 @@ CFG_SUBMISSIONS_TYPE = 'submission'
 CFG_DATA_KEYWORDS = ['observables', 'reactions', 'cmenergies', 'phrases']
 
 CFG_CONVERTER_URL = 'https://converter.hepdata.net'
-CFG_SUPPORTED_FORMATS = ['yaml', 'root', 'csv', 'yoda', 'original']
+CFG_SUPPORTED_FORMATS = ['yaml', 'root', 'csv', 'yoda', 'yoda1', 'original']
 CFG_CONVERTER_TIMEOUT = 220  # timeout in seconds
 
 CFG_TMPDIR = tempfile.gettempdir()

--- a/hepdata/modules/records/api.py
+++ b/hepdata/modules/records/api.py
@@ -384,7 +384,7 @@ def render_record(recid, record, version, output_format, light_mode=False):
             redirect_url_after_login = '%2Frecord%2F{0}%3Fversion%3D{1}%26format%3D{2}'.format(recid, version, output_format)
             if 'table' in request.args:
                 redirect_url_after_login += '%26table%3D{0}'.format(request.args['table'])
-            if output_format == 'yoda' and 'rivet' in request.args:
+            if output_format.startswith('yoda') and 'rivet' in request.args:
                 redirect_url_after_login += '%26rivet%3D{0}'.format(request.args['rivet'])
             return redirect('/login/?next={0}'.format(redirect_url_after_login))
         else:
@@ -423,14 +423,14 @@ def render_record(recid, record, version, output_format, light_mode=False):
                 if output_format == 'json':
                     ctx = process_ctx(ctx, light_mode)
                     return jsonify(ctx)
-                elif output_format == 'yoda' and 'rivet' in request.args:
+                elif output_format.startswith('yoda') and 'rivet' in request.args:
                     return redirect('/download/submission/{0}/{1}/{2}/{3}'.format(recid, version, output_format,
                                                                               request.args['rivet']))
                 else:
                     return redirect('/download/submission/{0}/{1}/{2}'.format(recid, version, output_format))
             else:
                 file_identifier = 'ins{}'.format(hepdata_submission.inspire_id) if hepdata_submission.inspire_id else recid
-                if output_format == 'yoda' and 'rivet' in request.args:
+                if output_format.startswith('yoda') and 'rivet' in request.args:
                     return redirect('/download/table/{0}/{1}/{2}/{3}/{4}'.format(
                         file_identifier, request.args['table'].replace('%', '%25').replace('\\', '%5C'), version, output_format,
                         request.args['rivet']))
@@ -474,7 +474,7 @@ def render_record(recid, record, version, output_format, light_mode=False):
 
                 return render_template('hepdata_records/related_record.html', ctx=ctx)
 
-            elif output_format == 'yoda' and 'rivet' in request.args:
+            elif output_format.startswith('yoda') and 'rivet' in request.args:
                 return redirect('/download/table/{0}/{1}/{2}/{3}/{4}'.format(
                     publication_recid, ctx['table_name'].replace('%', '%25').replace('\\', '%5C'), datasubmission.version, output_format,
                     request.args['rivet']))

--- a/hepdata/modules/records/templates/hepdata_records/components/table_details.html
+++ b/hepdata/modules/records/templates/hepdata_records/components/table_details.html
@@ -63,6 +63,11 @@
                             <li>
                                 <a href="#"
                                    class="data_download_link"
+                                   id="download_yoda1_data">YODA1</a>
+                            </li>
+                            <li>
+                                <a href="#"
+                                   class="data_download_link"
                                    id="download_root_data">ROOT</a>
                             </li>
                             <li>

--- a/hepdata/modules/records/templates/hepdata_records/components/table_list.html
+++ b/hepdata/modules/records/templates/hepdata_records/components/table_list.html
@@ -58,6 +58,8 @@
                        id="download_yaml">YAML</a></li>
                 <li><a href="{{ download_base_url }}/yoda"
                        id="download_yoda">YODA</a></li>
+                <li><a href="{{ download_base_url }}/yoda1"
+                       id="download_yoda1">YODA1</a></li>
                 <li><a href="{{ download_base_url }}/root"
                        id="download_root">ROOT</a></li>
                 <li><a href="{{ download_base_url }}/csv"

--- a/hepdata/modules/records/utils/data_processing_utils.py
+++ b/hepdata/modules/records/utils/data_processing_utils.py
@@ -299,6 +299,8 @@ def process_ctx(ctx, light_mode=False):
                         site_url, _recid, _cleaned_table_name),
                     'yoda': '{0}/download/table/{1}/{2}/yoda'.format(
                         site_url, _recid, _cleaned_table_name),
+                    'yoda1': '{0}/download/table/{1}/{2}/yoda1'.format(
+                        site_url, _recid, _cleaned_table_name),
                     'yaml': '{0}/download/table/{1}/{2}/yaml'.format(
                         site_url, _recid, _cleaned_table_name)}
 

--- a/hepdata/modules/records/views.py
+++ b/hepdata/modules/records/views.py
@@ -102,7 +102,7 @@ def sandbox_display(id):
             if output_format == 'html':
                 return render_template('hepdata_records/sandbox.html', ctx=ctx)
             elif 'table' in request.args:
-                if output_format == 'yoda' and 'rivet' in request.args:
+                if output_format.startswith('yoda') and 'rivet' in request.args:
                     return redirect('/download/table/{0}/{1}/{2}/{3}/{4}'.format(
                         id,
                         request.args['table'].replace('%', '%25').replace('\\', '%5C'),
@@ -115,7 +115,7 @@ def sandbox_display(id):
             elif output_format == 'json':
                 ctx = process_ctx(ctx, light_mode)
                 return jsonify(ctx)
-            elif output_format == 'yoda' and 'rivet' in request.args:
+            elif output_format.startswith('yoda') and 'rivet' in request.args:
                 return redirect('/download/submission/{0}/{1}/{2}/{3}'.format(
                     id, 1, output_format, request.args['rivet']))
             else:

--- a/hepdata/modules/theme/templates/hepdata_theme/pages/formats.html
+++ b/hepdata/modules/theme/templates/hepdata_theme/pages/formats.html
@@ -106,9 +106,9 @@
                   </li>
                   <li>
                     <b>YODA</b>: The data analysis classes used in the <a href="https://rivet.hepforge.org" target="_blank" style="text-decoration: underline">Rivet</a>
-                    toolkit. Again, the appropriate <a href="https://yoda.hepforge.org" target="_blank" style="text-decoration: underline">YODA</a> object (<code>Scatter1D</code>,
-                    <code>Scatter2D</code>, <code>Scatter3D</code>) is written according to the number of independent
-                    variables in a table.
+                    toolkit. Again, the appropriate <a href="https://yoda.hepforge.org" target="_blank" style="text-decoration: underline">YODA</a> object
+                    is written according to the number of independent variables in a table. The default <code>yoda</code> output is now
+                    in the YODA2 format, but there is still an option <code>yoda1</code> to output the legacy YODA1 format.
                   </li>
                 </ul>
                 <p>
@@ -122,6 +122,7 @@
                   <li><code>?format=csv</code></li>
                   <li><code>?format=root</code></li>
                   <li><code>?format=yoda</code></li>
+                  <li><code>?format=yoda1</code></li>
                 </ul>
                 <p>Optional parameters can also be added (separated by a <code>&</code> symbol):</p>
                 <ul>
@@ -139,7 +140,7 @@
                     the data tables from the response.
                   </li>
                   <li>
-                    <code>rivet=ALICE_2016_I1419244</code>: when using <code>format=yoda</code>, specify the desired
+                    <code>rivet=ALICE_2016_I1419244</code>: when using <code>format=yoda</code> or <code>format=yoda1</code>, specify the desired
                     Rivet analysis name to be written in the YODA files if it does not match the automatically generated name.
                   </li>
                 </ul>

--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20231106"
+__version__ = "0.9.4dev20231114"


### PR DESCRIPTION
* Allow YODA and YODA1 downloads, both with file extension `.yoda`.  Closes #728.
* Remove unused `convert_endpoint` function from `converter` module (see #317).