### PR TITLE
converter: get `CFG_CONVERTER_URL` from `current_app`

### DIFF
--- a/hepdata/modules/converter/__init__.py
+++ b/hepdata/modules/converter/__init__.py
@@ -53,7 +53,7 @@ def convert_zip_archive(input_archive, output_archive, options):
         input_directory, input_file = validation
 
         successful = convert(
-            CFG_CONVERTER_URL,
+            current_app.config.get('CFG_CONVERTER_URL', CFG_CONVERTER_URL),
             input_directory if input == 'yaml' else input_file,
             output=output_archive,
             options=options,
@@ -84,7 +84,7 @@ def convert_oldhepdata_to_yaml(input_path, output_path):
         'output_format': 'yaml',
     }
     successful = convert(
-        CFG_CONVERTER_URL,
+        current_app.config.get('CFG_CONVERTER_URL', CFG_CONVERTER_URL),
         input_path,
         output=output_path,
         options=options,

--- a/hepdata/modules/converter/views.py
+++ b/hepdata/modules/converter/views.py
@@ -456,7 +456,7 @@ def download_datatable(datasubmission, file_format, *args, **kwargs):
 
     try:
         successful = convert(
-            CFG_CONVERTER_URL,
+            current_app.config.get('CFG_CONVERTER_URL', CFG_CONVERTER_URL),
             record_path,
             output=output_path + '-dir',
             options=options,

--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20231114"
+__version__ = "0.9.4dev20231115"

--- a/tests/converter_test.py
+++ b/tests/converter_test.py
@@ -42,7 +42,7 @@ def test_convert_and_store_valid_yaml(app, capsys, load_submission):
         base_dir = os.path.dirname(os.path.realpath(__file__))
         test_tar_gz_file = os.path.join(base_dir, 'test_data', '1396331.tar.gz')
         with open(test_tar_gz_file, "rb") as stream:
-            responses.add(responses.GET, CFG_CONVERTER_URL + '/convert',
+            responses.add(responses.GET, app.config.get('CFG_CONVERTER_URL', CFG_CONVERTER_URL) + '/convert',
                           status=200, headers={'mimetype': 'application/x-gzip'},
                           body=stream.read(), stream=True)
 


### PR DESCRIPTION
* Allows Kubernetes configuration to specify different URLs for QA/prod.
* Closes #730.