### PR TITLE
records: add `filename` to `analyses` metadata for HistFactory 

### DIFF
--- a/hepdata/ext/opensearch/config/record_mapping.py
+++ b/hepdata/ext/opensearch/config/record_mapping.py
@@ -95,7 +95,10 @@ mapping = {
             },
             "analysis": {
                 "type": "text"
-            }
+            },
+            "filename": {
+                "type": "text"
+            },
         },
         "include_in_parent": "true"
     },

--- a/hepdata/ext/opensearch/document_enhancers.py
+++ b/hepdata/ext/opensearch/document_enhancers.py
@@ -22,6 +22,7 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 """Enhancers for the document sent to opensearch """
+import os
 import re
 import datetime
 import logging
@@ -106,7 +107,8 @@ def add_analyses(doc):
             elif reference.file_type == HISTFACTORY_FILE_TYPE:
                 SITE_URL = current_app.config.get('SITE_URL', 'https://www.hepdata.net')
                 landing_page_url = f"{SITE_URL}/record/resource/{reference.id}?landing_page=true"
-                doc["analyses"].append({'type': reference.file_type, 'analysis': landing_page_url})
+                doc["analyses"].append({'type': reference.file_type, 'analysis': landing_page_url,
+                                        'filename': os.path.basename(reference.file_location)})
 
 
 def add_data_keywords(doc):

--- a/hepdata/modules/theme/templates/hepdata_theme/pages/formats.html
+++ b/hepdata/modules/theme/templates/hepdata_theme/pages/formats.html
@@ -186,7 +186,9 @@
               <h3>Direct download of resource files from DOI</h3>
               <p>
                 DOIs for resource files relating to a HEPData submission direct users to a landing page such as
-                <a href="{{ ctx.sample_resource_url }}">{{ ctx.sample_resource_url }}</a>.
+                <a href="{{ ctx.sample_resource_url|lower }}">{{ ctx.sample_resource_url|lower }}</a>.
+                Omitting the <code>landing_page=true</code> URL argument will return JSON metadata for the resource file,
+                while replacing it with <code>view=true</code> will download the resource file.
               </p>
               <p>
                 To download a resource file directly from its DOI, pass the relevant

--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20231207"
+__version__ = "0.9.4dev20231208"


### PR DESCRIPTION
* Add `filename` to `analyses` metadata for HistFactory resource files.  Closes #737.
* Add more information on resource files to `formats.html` documentation page.