### PR TITLE
Display data license

### DIFF
--- a/hepdata/modules/records/assets/js/hepdata_resources.js
+++ b/hepdata/modules/records/assets/js/hepdata_resources.js
@@ -76,7 +76,7 @@ HEPDATA.hepdata_resources = (function () {
       .attr("href", function(d) {
         return '/record/resource/' + d.id + '?landing_page=true';
       })
-      .text("Resource Page");
+      .text("Landing Page");
 
     resource_item.append("a")
       .attr('target', '_new')

--- a/hepdata/modules/records/assets/js/hepdata_resources.js
+++ b/hepdata/modules/records/assets/js/hepdata_resources.js
@@ -60,7 +60,8 @@ HEPDATA.hepdata_resources = (function () {
       })
       .text(function(d) {
         return d['data_license'] ? d['data_license'].name : null;
-      });
+      })
+      .attr("class", "licence-url");
 
     resource_item.append("p")
       .attr('display', function(d){

--- a/hepdata/modules/records/assets/js/hepdata_resources.js
+++ b/hepdata/modules/records/assets/js/hepdata_resources.js
@@ -44,6 +44,19 @@ HEPDATA.hepdata_resources = (function () {
       return d['file_description'];
     });
 
+    // Manage rendering of the data license value
+    // Uses url, description and name from data_licence for anchor url, title, and text respectively
+    resource_item.append("a")
+      .attr('href', function(d) {
+        return d['data_license'] ? d['data_license'].url : null;
+      })
+      .attr('title', function(d) {
+        return d['data_license'] ? d['data_license'].description : null;
+      })
+      .text(function(d) {
+        return d['data_license'] ? d['data_license'].name : null;
+      });
+
     resource_item.append("p")
       .attr('display', function(d){
         return d['doi'] == null ? 'none' : 'block';

--- a/hepdata/modules/records/assets/js/hepdata_resources.js
+++ b/hepdata/modules/records/assets/js/hepdata_resources.js
@@ -76,7 +76,7 @@ HEPDATA.hepdata_resources = (function () {
       .attr("href", function(d) {
         return '/record/resource/' + d.id + '?landing_page=true';
       })
-      .text("View Here");
+      .text("Resource Page");
 
     resource_item.append("a")
       .attr('target', '_new')

--- a/hepdata/modules/records/assets/js/hepdata_resources.js
+++ b/hepdata/modules/records/assets/js/hepdata_resources.js
@@ -44,6 +44,11 @@ HEPDATA.hepdata_resources = (function () {
       return d['file_description'];
     });
 
+    // Render the licence header text if required
+    resource_item.append("span").text(function(d) {
+      return d['data_license'] && d['data_license'].url ? "Licence: " : "";
+    });
+
     // Manage rendering of the data license value
     // Uses url, description and name from data_licence for anchor url, title, and text respectively
     resource_item.append("a")
@@ -63,6 +68,15 @@ HEPDATA.hepdata_resources = (function () {
       }).html(function (d) {
         return d['doi'] == null ? '' : '<a href="https://doi.org/' + d['doi'] + '" class="resource-doi">' + d['doi'] + '</a>';
       });
+
+    // Add the landing page button
+    resource_item.append("a")
+      .attr('target', '_new')
+      .attr("class", "btn btn-primary btn-sm")
+      .attr("href", function(d) {
+        return '/record/resource/' + d.id + '?landing_page=true';
+      })
+      .text("View Here");
 
     resource_item.append("a")
       .attr('target', '_new')

--- a/hepdata/modules/records/assets/js/hepdata_tables.js
+++ b/hepdata/modules/records/assets/js/hepdata_tables.js
@@ -134,9 +134,8 @@ HEPDATA.table_renderer = {
             .attr("href", table_data.table_license.url)
             .attr('title', table_data.table_license.description)
           // Add the anchor to the section, and show it
-          $("#table_data_license")
-            .append(licence_url)
-            .removeClass("hidden");
+          $("#table_data_license_url").append(licence_url);
+          $("#table_data_license").removeClass("hidden");
         }
 
         // Initiates rendering of both related DOI table areas

--- a/hepdata/modules/records/assets/js/hepdata_tables.js
+++ b/hepdata/modules/records/assets/js/hepdata_tables.js
@@ -63,6 +63,8 @@ HEPDATA.switch_table = function (listId, table_requested, table_name, status) {
   $("#filesize_table_loading").addClass("hidden");
   $("#filesize_table_loading_failed").addClass("hidden");
   $("#hep_table").addClass("hidden");
+  // Hide the license information section
+  $("#table_data_license").addClass("hidden");
 
   HEPDATA.current_table_id = table_requested;
 
@@ -122,6 +124,19 @@ HEPDATA.table_renderer = {
         $("#table_location").html(table_data.location);
         $("#table_doi_contents").html('<a href="https://doi.org/' + table_data.doi + '" target="_blank">' + table_data.doi + '</a>');
         $("#table_description").html((table_data.description.indexOf('.') == 0) ? '' : table_data.description.trim());
+
+        // Handle rendering of a licence if it exists
+        if(table_data.table_license) {
+          // Set up anchor with url, text, and title/tooltip
+          var licence_url = $("<a>")
+            .text(table_data.table_license.name)
+            .attr("href", table_data.table_license.url)
+            .attr('title', table_data.table_license.description)
+          // Add the anchor to the section, and show it
+          $("#table_data_license")
+            .append(licence_url)
+            .removeClass("hidden");
+        }
 
         // Initiates rendering of both related DOI table areas
         HEPDATA.table_renderer.render_related_dois(table_data.related_tables, "#related-tables");

--- a/hepdata/modules/records/assets/js/hepdata_tables.js
+++ b/hepdata/modules/records/assets/js/hepdata_tables.js
@@ -63,8 +63,9 @@ HEPDATA.switch_table = function (listId, table_requested, table_name, status) {
   $("#filesize_table_loading").addClass("hidden");
   $("#filesize_table_loading_failed").addClass("hidden");
   $("#hep_table").addClass("hidden");
-  // Hide the license information section
+  // Hide and clear the license information section
   $("#table_data_license").addClass("hidden");
+  $("#table_data_license_url").html("");
 
   HEPDATA.current_table_id = table_requested;
 

--- a/hepdata/modules/records/templates/hepdata_records/components/record-breadcrumbs.html
+++ b/hepdata/modules/records/templates/hepdata_records/components/record-breadcrumbs.html
@@ -29,11 +29,13 @@
 
                 <div class="cite">
 
-                    <button id="citeLabel" type="button" data-toggle="modal" data-target="#citeModal"
-                            class="btn btn-sm btn-primary"
-                            aria-haspopup="true" aria-expanded="false">
-                        <i class="fa fa-quote-right"></i> Cite
-                    </button>
+                    {% if ctx.record.title %}
+                        <button id="citeLabel" type="button" data-toggle="modal" data-target="#citeModal"
+                                class="btn btn-sm btn-primary"
+                                aria-haspopup="true" aria-expanded="false">
+                            <i class="fa fa-quote-right"></i> Cite
+                        </button>
+                    {% endif %}
 
                     {% if current_user.is_authenticated and ctx.status == 'finished' %}
                         <button id="watch_btn" type="button" data-toggle="modal"

--- a/hepdata/modules/records/templates/hepdata_records/components/resource_details.html
+++ b/hepdata/modules/records/templates/hepdata_records/components/resource_details.html
@@ -35,6 +35,12 @@
         <p><a href="{{ ctx.resource.file_location }}">{{ ctx.resource.file_location }}</a></p>
       {% elif ctx.display_type == 'code' %}
 
+      {% if ctx.data_licence %}
+      <div id="resource-data-licence">
+        <a href="{{ ctx.data_licence.url }}" title="{{ ctx.data_licence.description }}">{{ ctx.data_licence.name }}</a>
+      </div>
+      {% endif %}
+
         {% if ctx.contents and ctx.contents != 'Large text file' %}
           <textarea id="code-contents" height="70%">{{ ctx.contents }}</textarea>
         {% else %}

--- a/hepdata/modules/records/templates/hepdata_records/components/resource_details.html
+++ b/hepdata/modules/records/templates/hepdata_records/components/resource_details.html
@@ -36,9 +36,9 @@
       {% elif ctx.display_type == 'code' %}
 
       {% if ctx.data_licence %}
-      <div id="resource-data-licence">
-        Licence: <a href="{{ ctx.data_licence.url }}" title="{{ ctx.data_licence.description }}">{{ ctx.data_licence.name }}</a>
-      </div>
+        <div id="resource-data-licence">
+          Licence: <a href="{{ ctx.data_licence.url }}" title="{{ ctx.data_licence.description }}">{{ ctx.data_licence.name }}</a>
+        </div>
       {% endif %}
 
         {% if ctx.contents and ctx.contents != 'Large text file' %}

--- a/hepdata/modules/records/templates/hepdata_records/components/resource_details.html
+++ b/hepdata/modules/records/templates/hepdata_records/components/resource_details.html
@@ -37,7 +37,7 @@
 
       {% if ctx.data_licence %}
       <div id="resource-data-licence">
-        <a href="{{ ctx.data_licence.url }}" title="{{ ctx.data_licence.description }}">{{ ctx.data_licence.name }}</a>
+        Licence: <a href="{{ ctx.data_licence.url }}" title="{{ ctx.data_licence.description }}">{{ ctx.data_licence.name }}</a>
       </div>
       {% endif %}
 

--- a/hepdata/modules/records/templates/hepdata_records/components/table_details.html
+++ b/hepdata/modules/records/templates/hepdata_records/components/table_details.html
@@ -90,7 +90,7 @@
 
                 <div class="clearfix"></div>
 
-                <p id="table_data_license" class="hidden"></p>
+                <p id="table_data_license" class="hidden">Licence: <span id="table_data_license_url"></span></p>
 
                 <div class="clearfix"></div>
 

--- a/hepdata/modules/records/templates/hepdata_records/components/table_details.html
+++ b/hepdata/modules/records/templates/hepdata_records/components/table_details.html
@@ -88,7 +88,11 @@
                     <span class="pull-right" id="support-files" style="margin-right: 20px; margin-top:1px"></span>
                 </h4>
 
-               <div class="clearfix"></div>
+                <div class="clearfix"></div>
+
+                <p id="table_data_license" class="hidden"></p>
+
+                <div class="clearfix"></div>
 
                 <p id="table_location"></p>
 

--- a/hepdata/modules/records/templates/hepdata_records/related_record.html
+++ b/hepdata/modules/records/templates/hepdata_records/related_record.html
@@ -26,7 +26,11 @@
 {% if ctx.record.year %}
   {% set title = title + ' | ' + ctx.record.year|string %}
 {% endif %}
-{% set title = title + ' | ' + ctx.record.title %}
+{% if ctx.record.title %}
+  {% set title = title + ' | ' + ctx.record.title %}
+{% else %}
+  {% set title = title + ' Sandbox | ' + ctx.recid|string %}
+{% endif %}
 {% if ctx.record_type == 'resource' %}
   {% set title = title + ' | ' + ctx.resource_filename %}
 {% else %}

--- a/hepdata/modules/records/utils/common.py
+++ b/hepdata/modules/records/utils/common.py
@@ -267,3 +267,23 @@ def file_size_check(file_location, load_all):
     if load_all == 0:
         size_check["status"] = size_check["size"] <= SIZE_LOAD_CHECK_THRESHOLD
     return size_check
+
+def generate_licence_data_by_id(licence_id):
+    """
+    Generates a dictionary from a Licence class selected by
+    its ID from the database.
+
+    :param licence_id:
+    :return dict: Returns the licence_data dictionary, or None
+    """
+    license_data = License.query.filter_by(id=licence_id).first()
+    if license_data:
+        # Generate and return the dictionary
+        return {
+            "name": license_data.name,
+            "url": license_data.url,
+            "description": license_data.description
+        }
+    else:
+        # Return None if not found
+        return None

--- a/hepdata/modules/records/utils/data_processing_utils.py
+++ b/hepdata/modules/records/utils/data_processing_utils.py
@@ -209,6 +209,7 @@ def generate_table_structure(table_contents):
 
     record = {"name": table_contents["name"], "doi": table_contents["doi"],
               "location": table_contents["location"],
+              "table_license": table_contents["table_license"],
               "related_tables" : table_contents["related_tables"],
               "related_to_this" : table_contents["related_to_this"],
               "qualifiers": {},

--- a/hepdata/modules/records/views.py
+++ b/hepdata/modules/records/views.py
@@ -771,6 +771,7 @@ def get_resource(resource_id):
                     if filesize:
                         ctx['filesize'] = '%.2f'%((filesize / 1024) / 1024) # Set filesize if exists
                         ctx['ADDITIONAL_SIZE_LOAD_CHECK_THRESHOLD'] = '%.2f'%((ADDITIONAL_SIZE_LOAD_CHECK_THRESHOLD / 1024) / 1024)
+                    ctx['data_licence'] = generate_licence_data_by_id(resource_obj.file_license)
                     return render_template('hepdata_records/related_record.html', ctx=ctx)
 
             else:

--- a/hepdata/modules/records/views.py
+++ b/hepdata/modules/records/views.py
@@ -711,7 +711,9 @@ def get_resource(resource_id):
     if resource_obj:
         contents = ''
         if landing_page or not view_mode:
-            if resource_obj.file_type.lower() not in IMAGE_TYPES and 'http' not in resource_obj.file_location.lower():
+            if resource_obj.file_location.lower().startswith('http'):
+                contents = resource_obj.file_location
+            elif resource_obj.file_type.lower() not in IMAGE_TYPES:
                 print("Resource is at: " + resource_obj.file_location)
                 try:
                     with open(resource_obj.file_location, 'r', encoding='utf-8') as resource_file:
@@ -752,7 +754,10 @@ def get_resource(resource_id):
                     }), 406
 
         if view_mode:
-            return send_file(resource_obj.file_location, as_attachment=True)
+            if resource_obj.file_location.lower().startswith('http'):
+                return redirect(resource_obj.file_location)
+            else:
+                return send_file(resource_obj.file_location, as_attachment=True)
         elif 'html' in resource_obj.file_location and 'http' not in resource_obj.file_location.lower() and not landing_page:
             with open(resource_obj.file_location, 'r') as resource_file:
                 return contents

--- a/hepdata/modules/records/views.py
+++ b/hepdata/modules/records/views.py
@@ -55,7 +55,7 @@ from hepdata.modules.submission.api import get_submission_participants_for_recor
 from hepdata.modules.submission.models import HEPSubmission, DataSubmission, \
     DataResource, DataReview, Message, Question
 from hepdata.modules.records.utils.common import get_record_by_id, \
-    default_time, IMAGE_TYPES, decode_string, file_size_check
+    default_time, IMAGE_TYPES, decode_string, file_size_check, generate_licence_data_by_id
 from hepdata.modules.records.utils.data_processing_utils import \
     generate_table_structure, process_ctx
 from hepdata.modules.records.utils.submission import create_data_review, \
@@ -338,6 +338,7 @@ def get_table_details(recid, data_recid, version, load_all=1):
             table_contents["name"] = datasub_record.name
             table_contents["title"] = datasub_record.description
             table_contents["keywords"] = datasub_record.keywords
+            table_contents["table_license"] = generate_licence_data_by_id(data_record.file_license)
             table_contents["related_tables"] = get_table_data_list(datasub_record, "related")
             table_contents["related_to_this"] = get_table_data_list(datasub_record, "related_to_this")
             table_contents["doi"] = datasub_record.doi
@@ -683,6 +684,7 @@ def process_resource(reference):
 
     _reference_data = {'id': reference.id, 'file_type': reference.file_type,
                        'file_description': reference.file_description,
+                       'data_license' : generate_licence_data_by_id(reference.file_license),
                        'location': _location, 'doi': reference.doi}
 
     if reference.file_type.lower() in IMAGE_TYPES:

--- a/hepdata/modules/theme/assets/scss/record.scss
+++ b/hepdata/modules/theme/assets/scss/record.scss
@@ -1353,3 +1353,7 @@ g.node {
   }
 
 }
+
+.licence-url {
+    color: lightblue;
+}

--- a/hepdata/modules/theme/assets/scss/record.scss
+++ b/hepdata/modules/theme/assets/scss/record.scss
@@ -1174,6 +1174,12 @@ g.node {
         font-size: 2em;
       }
 
+      a {
+        display: block;
+        width: fit-content;
+        margin: 0 auto 5px auto;
+      }
+
       .resource-doi {
         background-color: $lightgrey;
         padding: 4px;

--- a/tests/e2e/test_general.py
+++ b/tests/e2e/test_general.py
@@ -119,11 +119,10 @@ def test_home(app, live_server, env_browser, e2e_identifiers):
     python_resources = [e for e in submission_resources if e.find_element(By.TAG_NAME, 'h4').text == 'Python File']
     assert len(python_resources) == 1
     python_resource = python_resources[0]
-    download_btn = python_resource.find_element(By.CSS_SELECTOR, 'a.btn-sm')
-    assert download_btn.text == 'Download'
+    download_btns = [btn for btn in python_resource.find_elements(By.CSS_SELECTOR, 'a.btn-sm')]
+    assert download_btns[1].text == 'Download'
     # Get landing page URL from download link and load
-    landing_page_url = download_btn.get_attribute("href").replace('view=true', 'landing_page=true')
-    browser.get(landing_page_url)
+    browser.get(download_btns[0].get_attribute("href"))
     # Check landing page has appropriate elements
     header_h4 = browser.find_element(By.CSS_SELECTOR, ".hepdata_table_detail_header h4")
     assert header_h4.find_element(By.CLASS_NAME, "pull-left").text.strip() == \

--- a/tests/e2e/test_records.py
+++ b/tests/e2e/test_records.py
@@ -612,6 +612,13 @@ def _check_record_common(browser):
         .find_element(By.ID, 'resource-list-items') \
         .find_elements(By.TAG_NAME, 'li')
 
+    # Assuming you run this with TestHEPSubmission.zip
+    # Collect text of all a tags found within the resource-items
+    resource_elements = browser.find_elements(By.CLASS_NAME, "resource-item")
+    links = [x.text for e in resource_elements for x in e.find_elements(By.TAG_NAME, "a")]
+    # Check to see if the licence text appears within
+    assert "GPL2" not in links
+
     # Check we can select a different table/common resources
     resource_list_items[0].click()
     assert modal_content.find_element(By.ID, 'selected_resource_item').text == \

--- a/tests/records_test.py
+++ b/tests/records_test.py
@@ -385,9 +385,8 @@ def test_upload_max_size(app):
             response, code = process_payload(recid, test_file, '/test_redirect_url', synchronous=True)
 
         assert(code == 413)
-        assert(response.json == {
-            'message': 'TestHEPSubmission.zip too large (1818265 bytes > 1000000 bytes)'
-        })
+        pattern = re.compile(r"TestHEPSubmission\.zip too large \((\d+) bytes > (\d+) bytes\)")
+        assert pattern.match(response.json['message'])
 
 
 def test_has_upload_permissions(app):

--- a/tests/records_test.py
+++ b/tests/records_test.py
@@ -153,6 +153,7 @@ def test_data_processing(app):
     data["doi"] = 'doi/10.2342'
     data["related_tables"] = []
     data["related_to_this"] = []
+    data["table_license"] = []
     data["location"] = 'Data from Figure 2 of preprint'
     data["review"] = []
     data["associated_files"] = []


### PR DESCRIPTION
Closes #740, closes #744. Updates record page to show licence information in the table section. Also displays record licence information on the additional resources widget and resource landing page. Adds a button link to the landing page to the additional resources widget.