### PR TITLE
Disable self relation

### DIFF
--- a/hepdata/modules/records/utils/submission.py
+++ b/hepdata/modules/records/utils/submission.py
@@ -276,8 +276,9 @@ def process_data_file(recid, version, basepath, data_obj, datasubmission, main_f
         if "related_to_table_dois" in data_obj:
             for related_doi in data_obj["related_to_table_dois"]:
                 this_doi = f"{HEPDATA_DOI_PREFIX}/hepdata.{recid}.v{version}/t{tablenum}"
-                related_table = RelatedTable(table_doi=this_doi, related_doi=related_doi)
-                datasubmission.related_tables.append(related_table)
+                if this_doi != related_doi:
+                    related_table = RelatedTable(table_doi=this_doi, related_doi=related_doi)
+                    datasubmission.related_tables.append(related_table)
 
     cleanup_data_resources(datasubmission)
 
@@ -328,8 +329,9 @@ def process_general_submission_info(basepath, submission_info_document, recid):
     if hepsubmission.overall_status not in ("sandbox", "sandbox_processing"):
         if 'related_to_hepdata_records' in submission_info_document:
             for related_id in submission_info_document['related_to_hepdata_records']:
-                related = RelatedRecid(this_recid=hepsubmission.publication_recid, related_recid=related_id)
-                hepsubmission.related_recids.append(related)
+                if hepsubmission.publication_recid != related_id:
+                    related = RelatedRecid(this_recid=hepsubmission.publication_recid, related_recid=related_id)
+                    hepsubmission.related_recids.append(related)
 
     db.session.add(hepsubmission)
     db.session.commit()

--- a/tests/test_data/related_submission_test/related_submission_1/submission.yaml
+++ b/tests/test_data/related_submission_test/related_submission_1/submission.yaml
@@ -3,6 +3,7 @@
 description: "Test Data"
 comment: Test
 related_to_hepdata_records:
+- 1
 - 2
 ---
 name: "Table 1"
@@ -11,6 +12,7 @@ keywords:
 - {name: cmenergies, values: [0]}
 data_file: data1.yaml
 related_to_table_dois:
+- "10.17182/hepdata.1.v1/t1"
 - "10.17182/hepdata.2.v1/t1"
 ---
 name: "Table 2"
@@ -19,6 +21,7 @@ keywords:
 - {name: cmenergies, values: [0]}
 data_file: data2.yaml
 related_to_table_dois:
+- "10.17182/hepdata.1.v1/t2"
 - "10.17182/hepdata.2.v1/t2"
 ---
 name: "Table 3"
@@ -27,4 +30,5 @@ keywords:
 - {name: cmenergies, values: [0]}
 data_file: data3.yaml
 related_to_table_dois:
+- "10.17182/hepdata.1.v1/t3"
 - "10.17182/hepdata.2.v1/t3"

--- a/tests/test_data/related_submission_test/related_submission_2/submission.yaml
+++ b/tests/test_data/related_submission_test/related_submission_2/submission.yaml
@@ -3,6 +3,7 @@
 description: "Test Data"
 comment: Test
 related_to_hepdata_records:
+- 2
 - 1
 ---
 name: "Table 1"
@@ -11,6 +12,7 @@ keywords:
 - {name: cmenergies, values: [0]}
 data_file: data1.yaml
 related_to_table_dois:
+- "10.17182/hepdata.2.v1/t1"
 - "10.17182/hepdata.1.v1/t1"
 ---
 name: "Table 2"
@@ -19,6 +21,7 @@ keywords:
 - {name: cmenergies, values: [0]}
 data_file: data2.yaml
 related_to_table_dois:
+- "10.17182/hepdata.2.v1/t2"
 - "10.17182/hepdata.1.v1/t2"
 ---
 name: "Table 3"
@@ -27,4 +30,5 @@ keywords:
 - {name: cmenergies, values: [0]}
 data_file: data3.yaml
 related_to_table_dois:
+- "10.17182/hepdata.2.v1/t3"
 - "10.17182/hepdata.1.v1/t3"

--- a/tests/test_data/related_submission_test/related_submission_3/submission.yaml
+++ b/tests/test_data/related_submission_test/related_submission_3/submission.yaml
@@ -3,6 +3,7 @@
 description: "Test Data"
 comment: Test
 related_to_hepdata_records:
+- 3
 - "2"
 ---
 name: "Table 1"
@@ -11,4 +12,5 @@ keywords:
 - {name: cmenergies, values: [0]}
 data_file: data1.yaml
 related_to_table_dois:
+- "10.17182/hepdata.3.v1/t1"
 - "10.17182/hepdata.1.v1/t1"

--- a/tests/test_data/related_submission_test/related_submission_4/submission.yaml
+++ b/tests/test_data/related_submission_test/related_submission_4/submission.yaml
@@ -2,6 +2,8 @@
 ---
 description: "Test Data"
 comment: Test
+related_to_hepdata_records:
+- 4
 ---
 name: "Table 1"
 description: Test Table 1
@@ -9,4 +11,5 @@ keywords:
 - {name: cmenergies, values: [0]}
 data_file: data1.yaml
 related_to_table_dois:
+- "10.17182/hepdata.4.v1/t1"
 - "10.17182/hepdaaaaaaaata.25.v1/t1"


### PR DESCRIPTION
Disables insertion of self-related Record ID/DOI values for related HEPSubmission/DataSubmission objects during submission. Updates testing to check this.

Closes #765.