### PR TITLE
Replace "licence" with "license" in code

### DIFF
--- a/hepdata/modules/records/assets/js/hepdata_resources.js
+++ b/hepdata/modules/records/assets/js/hepdata_resources.js
@@ -44,9 +44,9 @@ HEPDATA.hepdata_resources = (function () {
       return d['file_description'];
     });
 
-    // Render the licence header text if required
+    // Render the license header text if required
     resource_item.append("span").text(function(d) {
-      return d['data_license'] && d['data_license'].url ? "license: " : "";
+      return d['data_license'] && d['data_license'].url ? "License: " : "";
     });
 
     // Manage rendering of the data license value

--- a/hepdata/modules/records/assets/js/hepdata_resources.js
+++ b/hepdata/modules/records/assets/js/hepdata_resources.js
@@ -46,11 +46,11 @@ HEPDATA.hepdata_resources = (function () {
 
     // Render the licence header text if required
     resource_item.append("span").text(function(d) {
-      return d['data_license'] && d['data_license'].url ? "Licence: " : "";
+      return d['data_license'] && d['data_license'].url ? "license: " : "";
     });
 
     // Manage rendering of the data license value
-    // Uses url, description and name from data_licence for anchor url, title, and text respectively
+    // Uses url, description and name from data_license for anchor url, title, and text respectively
     resource_item.append("a")
       .attr('href', function(d) {
         return d['data_license'] ? d['data_license'].url : null;
@@ -61,7 +61,7 @@ HEPDATA.hepdata_resources = (function () {
       .text(function(d) {
         return d['data_license'] ? d['data_license'].name : null;
       })
-      .attr("class", "licence-url");
+      .attr("class", "license-url");
 
     resource_item.append("p")
       .attr('display', function(d){

--- a/hepdata/modules/records/assets/js/hepdata_tables.js
+++ b/hepdata/modules/records/assets/js/hepdata_tables.js
@@ -129,12 +129,12 @@ HEPDATA.table_renderer = {
         // Handle rendering of a licence if it exists
         if(table_data.table_license) {
           // Set up anchor with url, text, and title/tooltip
-          var licence_url = $("<a>")
+          var license_url = $("<a>")
             .text(table_data.table_license.name)
             .attr("href", table_data.table_license.url)
             .attr('title', table_data.table_license.description)
           // Add the anchor to the section, and show it
-          $("#table_data_license_url").append(licence_url);
+          $("#table_data_license_url").append(license_url);
           $("#table_data_license").removeClass("hidden");
         }
 

--- a/hepdata/modules/records/templates/hepdata_records/components/resource_details.html
+++ b/hepdata/modules/records/templates/hepdata_records/components/resource_details.html
@@ -35,9 +35,9 @@
         <p><a href="{{ ctx.resource.file_location }}">{{ ctx.resource.file_location }}</a></p>
       {% elif ctx.display_type == 'code' %}
 
-      {% if ctx.data_licence %}
-        <div id="resource-data-licence">
-          Licence: <a href="{{ ctx.data_licence.url }}" title="{{ ctx.data_licence.description }}">{{ ctx.data_licence.name }}</a>
+      {% if ctx.data_license %}
+        <div id="resource-data-license">
+          Licence: <a href="{{ ctx.data_license.url }}" title="{{ ctx.data_license.description }}">{{ ctx.data_license.name }}</a>
         </div>
       {% endif %}
 

--- a/hepdata/modules/records/templates/hepdata_records/components/table_details.html
+++ b/hepdata/modules/records/templates/hepdata_records/components/table_details.html
@@ -90,7 +90,7 @@
 
                 <div class="clearfix"></div>
 
-                <p id="table_data_license" class="hidden">Licence: <span id="table_data_license_url"></span></p>
+                <p id="table_data_license" class="hidden">License: <span id="table_data_license_url"></span></p>
 
                 <div class="clearfix"></div>
 

--- a/hepdata/modules/records/templates/hepdata_records/sandbox.html
+++ b/hepdata/modules/records/templates/hepdata_records/sandbox.html
@@ -15,7 +15,7 @@
 ## You should have received a copy of the GNU General Public License
 ## along with HEPData. If not, see
 ##
-## In applying this licence, CERN does not waive the privileges and immunities
+## In applying this license, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization
 ## or submit itself to any jurisdiction.
 #}

--- a/hepdata/modules/records/utils/common.py
+++ b/hepdata/modules/records/utils/common.py
@@ -268,15 +268,15 @@ def file_size_check(file_location, load_all):
         size_check["status"] = size_check["size"] <= SIZE_LOAD_CHECK_THRESHOLD
     return size_check
 
-def generate_licence_data_by_id(licence_id):
+def generate_license_data_by_id(license_id):
     """
-    Generates a dictionary from a Licence class selected by
+    Generates a dictionary from a license class selected by
     its ID from the database.
 
-    :param licence_id:
-    :return dict: Returns the licence_data dictionary, or None
+    :param license_id:
+    :return dict: Returns the license_data dictionary, or None
     """
-    license_data = License.query.filter_by(id=licence_id).first()
+    license_data = License.query.filter_by(id=license_id).first()
     if license_data:
         # Generate and return the dictionary
         return {

--- a/hepdata/modules/records/utils/common.py
+++ b/hepdata/modules/records/utils/common.py
@@ -270,7 +270,7 @@ def file_size_check(file_location, load_all):
 
 def generate_license_data_by_id(license_id):
     """
-    Generates a dictionary from a license class selected by
+    Generates a dictionary from a License class selected by
     its ID from the database.
 
     :param license_id:

--- a/hepdata/modules/records/views.py
+++ b/hepdata/modules/records/views.py
@@ -55,7 +55,7 @@ from hepdata.modules.submission.api import get_submission_participants_for_recor
 from hepdata.modules.submission.models import HEPSubmission, DataSubmission, \
     DataResource, DataReview, Message, Question
 from hepdata.modules.records.utils.common import get_record_by_id, \
-    default_time, IMAGE_TYPES, decode_string, file_size_check, generate_licence_data_by_id
+    default_time, IMAGE_TYPES, decode_string, file_size_check, generate_license_data_by_id
 from hepdata.modules.records.utils.data_processing_utils import \
     generate_table_structure, process_ctx
 from hepdata.modules.records.utils.submission import create_data_review, \
@@ -338,7 +338,7 @@ def get_table_details(recid, data_recid, version, load_all=1):
             table_contents["name"] = datasub_record.name
             table_contents["title"] = datasub_record.description
             table_contents["keywords"] = datasub_record.keywords
-            table_contents["table_license"] = generate_licence_data_by_id(data_record.file_license)
+            table_contents["table_license"] = generate_license_data_by_id(data_record.file_license)
             table_contents["related_tables"] = get_table_data_list(datasub_record, "related")
             table_contents["related_to_this"] = get_table_data_list(datasub_record, "related_to_this")
             table_contents["doi"] = datasub_record.doi
@@ -684,7 +684,7 @@ def process_resource(reference):
 
     _reference_data = {'id': reference.id, 'file_type': reference.file_type,
                        'file_description': reference.file_description,
-                       'data_license' : generate_licence_data_by_id(reference.file_license),
+                       'data_license' : generate_license_data_by_id(reference.file_license),
                        'location': _location, 'doi': reference.doi}
 
     if reference.file_type.lower() in IMAGE_TYPES:
@@ -776,7 +776,7 @@ def get_resource(resource_id):
                     if filesize:
                         ctx['filesize'] = '%.2f'%((filesize / 1024) / 1024) # Set filesize if exists
                         ctx['ADDITIONAL_SIZE_LOAD_CHECK_THRESHOLD'] = '%.2f'%((ADDITIONAL_SIZE_LOAD_CHECK_THRESHOLD / 1024) / 1024)
-                    ctx['data_licence'] = generate_licence_data_by_id(resource_obj.file_license)
+                    ctx['data_license'] = generate_license_data_by_id(resource_obj.file_license)
                     return render_template('hepdata_records/related_record.html', ctx=ctx)
 
             else:

--- a/hepdata/modules/submission/templates/hepdata_submission/submit.html
+++ b/hepdata/modules/submission/templates/hepdata_submission/submit.html
@@ -15,7 +15,7 @@
 ## You should have received a copy of the GNU General Public License
 ## along with HEPData. If not, see
 ##
-## In applying this licence, CERN does not waive the privileges and immunities
+## In applying this license, CERN does not waive the privileges and immunities
 ## granted to it by virtue of its status as an Intergovernmental Organization
 ## or submit itself to any jurisdiction.
 #}

--- a/hepdata/modules/theme/assets/scss/record.scss
+++ b/hepdata/modules/theme/assets/scss/record.scss
@@ -1354,6 +1354,6 @@ g.node {
 
 }
 
-.licence-url {
+.license-url {
     color: lightblue;
 }

--- a/hepdata/modules/theme/assets/scss/search.scss
+++ b/hepdata/modules/theme/assets/scss/search.scss
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with HEPData. If not, see <http://www.gnu.org/licenses/>.
  *
- * In applying this licence, CERN does not waive the privileges and immunities
+ * In applying this license, CERN does not waive the privileges and immunities
  * granted to it by virtue of its status as an Intergovernmental Organization
  * or submit itself to any jurisdiction.
  */

--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20240212"
+__version__ = "0.9.4dev20240308"

--- a/scripts/clean_assets.sh
+++ b/scripts/clean_assets.sh
@@ -17,7 +17,7 @@ set -e
 # You should have received a copy of the GNU General Public License
 # along with HEPData. If not, see <http://www.gnu.org/licenses/>.
 #
-# In applying this licence, CERN does not waive the privileges and immunities
+# In applying this license, CERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 

--- a/tests/e2e/test_records.py
+++ b/tests/e2e/test_records.py
@@ -616,7 +616,7 @@ def _check_record_common(browser):
     # Collect text of all a tags found within the resource-items
     resource_elements = browser.find_elements(By.CLASS_NAME, "resource-item")
     links = [x.text for e in resource_elements for x in e.find_elements(By.TAG_NAME, "a")]
-    # Check to see if the licence text appears within
+    # Check to see if the license text appears within
     assert "GPL2" not in links
 
     # Check we can select a different table/common resources


### PR DESCRIPTION
Replaces the spelling "licence" with "license" in code for improved maintainability.

Closes #759.