### PR TITLE
Large file bugfixes fix

### DIFF
--- a/hepdata/modules/records/assets/js/hepdata_tables.js
+++ b/hepdata/modules/records/assets/js/hepdata_tables.js
@@ -75,19 +75,16 @@ HEPDATA.switch_table = function (listId, table_requested, table_name, status) {
       HEPDATA.current_table_id);
   }
 
-  var web_url = '/record/data/' + HEPDATA.current_record_id + '/' + table_requested + "/" + HEPDATA.current_table_version + "/";
-  HEPDATA.table_renderer.display_table_headers(web_url, 0);
+  var header_url = '/record/data/' + HEPDATA.current_record_id + '/' + table_requested + "/" + HEPDATA.current_table_version + "/" + 0;
+  var data_url = '/record/data/tabledata/' + table_requested + "/" + HEPDATA.current_table_version;
+  HEPDATA.table_renderer.display_table_headers(header_url, data_url);
 
   // Function to initiate the button to attempt loading of the table
   // We also clear the event listeners
   $("#hepdata_filesize_loading_button").off('click').on('click', function() {
     $("#filesize_table_confirm").addClass("hidden");
     $("#filesize_table_loading").removeClass("hidden");
-    HEPDATA.table_renderer.display_table(
-      web_url,
-      '#data_table_region',
-      '#data_visualization_region', 1
-    );
+    HEPDATA.table_renderer.get_and_display_table(data_url);
   });
 
   $(".data_download_link").each(function () {
@@ -105,14 +102,14 @@ HEPDATA.switch_table = function (listId, table_requested, table_name, status) {
 };
 
 HEPDATA.table_renderer = {
-  display_table_headers: function(url, load_all) {
+  display_table_headers: function(url, data_url) {
     /*
       Render only the main table information (name, details, etc.) at the top,
       then decides whether to trigger render of the table or not.
     */
     $.ajax({
       dataType: "json",
-      url: url + load_all,
+      url: url,
       processData: false,
       cache: true,
       success: function (table_data) {
@@ -148,8 +145,12 @@ HEPDATA.table_renderer = {
         // We also need to clear the figure
         $("#figures").html('');
 
+        if (HEPDATA.show_review) {
+          HEPDATA.table_renderer.update_reviewer_button(table_data.review);
+        }
+
         // Check that the table is both empty, and is larger than an empty table (bytes)
-        if(table_data.size > HEPDATA.size_load_check_threshold) {
+        if(table_data.size_check == false) {
           // Set up filesize attempt section
           $("#hepdata_table_loader").addClass("hidden");
           var megabyte_size = (table_data.size / (1024 * 1024)).toFixed(2);
@@ -160,9 +161,7 @@ HEPDATA.table_renderer = {
           $("filesize_table_confirm").removeClass("hidden");
         }
         else {
-          HEPDATA.table_renderer.display_table(url,
-            '#data_table_region',
-            '#data_visualization_region', load_all);
+          HEPDATA.table_renderer.display_table(table_data, '#data_table_region', '#data_visualization_region');
         }
       },
       error: function (data, error) {
@@ -173,63 +172,67 @@ HEPDATA.table_renderer = {
       }
     });
   },
-  display_table: function (url, table_placement, visualization_placement, load_all) {
-    /*
-      Triggers the table (bottom section) render of the records table table section.
-    */
+  get_and_display_table: function(url) {
     $.ajax({
       dataType: "json",
-      url: url + load_all,
+      url: url,
       processData: false,
       cache: true,
       success: function (table_data) {
-        HEPDATA.reset_stats();
-        HEPDATA.render_associated_files(table_data.associated_files, '#support-files');
-
-        // If it is larger than an empty table (bytes)
-        HEPDATA.table_renderer.render_qualifiers(table_data, table_placement);
-        HEPDATA.table_renderer.render_headers(table_data, table_placement);
-        HEPDATA.table_renderer.render_data(table_data, table_placement);
-
-        if (table_data["x_count"] > 1) {
-          HEPDATA.visualization.heatmap.reset();
-          HEPDATA.visualization.heatmap.render(table_data, visualization_placement, {
-            width: 300,
-            height: 300
-          });
-          HEPDATA.table_renderer.attach_row_listener(table_placement, 'heatmap');
-        } else if (table_data["values"].length == 0) {
-          // No data to display
-          d3.select(visualization_placement).html("");
-          d3.select("#legend").html("");
-          var no_data_info = d3.select(visualization_placement).append("div").style("text-align","center");
-          no_data_info.append("img").attr("src", "/static/img/nodata.svg").attr({"width": 100, height: 100});
-          no_data_info.append("p").text("No data to display...").style({"font-size": 14, "color": "#aaa"})
-        } else if (table_data["x_count"] === 1) {
-          HEPDATA.visualization.histogram.render(table_data, visualization_placement, {
-            width: 300,
-            height: 300,
-            "mode": "histogram"
-          });
-          HEPDATA.table_renderer.attach_row_listener(table_placement, 'histogram');
-        }
-        // Show the table finally
-        $("#hep_table").removeClass("hidden");
-
-        if (HEPDATA.show_review) {
-          HEPDATA.table_renderer.update_reviewer_button(table_data.review);
-        }
-
-        // Hide error element
-        $("#hepdata_filesize_loader").addClass("hidden");
-        HEPDATA.typeset($("#hepdata_table_content").get());
+        HEPDATA.table_renderer.display_table(
+          table_data,
+          '#data_table_region',
+          '#data_visualization_region'
+        );
       },
       error: function (data, error) {
         console.error(error);
         $("#filesize_table_loading_failed").removeClass("hidden");
-        d3.select("#filesize_table_failed_text").html('Failed to load table data defined by ' + url + load_all);
+        d3.select("#filesize_table_failed_text").html('Failed to load table data defined by ' + url);
       }
     });
+  },
+  display_table: function (table_data, table_placement, visualization_placement) {
+    /*
+      Triggers the table (bottom section) render of the records table table section.
+    */
+    HEPDATA.reset_stats();
+    HEPDATA.render_associated_files(table_data.associated_files, '#support-files');
+
+    // If it is larger than an empty table (bytes)
+    HEPDATA.table_renderer.render_qualifiers(table_data, table_placement);
+    HEPDATA.table_renderer.render_headers(table_data, table_placement);
+    HEPDATA.table_renderer.render_data(table_data, table_placement);
+
+    if (table_data["x_count"] > 1) {
+      HEPDATA.visualization.heatmap.reset();
+      HEPDATA.visualization.heatmap.render(table_data, visualization_placement, {
+        width: 300,
+        height: 300
+      });
+      HEPDATA.table_renderer.attach_row_listener(table_placement, 'heatmap');
+    } else if (table_data["values"].length == 0) {
+      // No data to display
+      d3.select(visualization_placement).html("");
+      d3.select("#legend").html("");
+      var no_data_info = d3.select(visualization_placement).append("div").style("text-align","center");
+      no_data_info.append("img").attr("src", "/static/img/nodata.svg").attr({"width": 100, height: 100});
+      no_data_info.append("p").text("No data to display...").style({"font-size": 14, "color": "#aaa"})
+    } else if (table_data["x_count"] === 1) {
+      HEPDATA.visualization.histogram.render(table_data, visualization_placement, {
+        width: 300,
+        height: 300,
+        "mode": "histogram"
+      });
+      HEPDATA.table_renderer.attach_row_listener(table_placement, 'histogram');
+    }
+    // Show the table finally
+    $("#hep_table").removeClass("hidden");
+
+    // Hide error element
+    $("#hepdata_filesize_loader").addClass("hidden");
+    $("#filesize_table_loading").addClass("hidden");
+    HEPDATA.typeset($("#hepdata_table_content").get());
   },
   attach_row_listener: function (table_placement, type) {
 

--- a/hepdata/modules/records/assets/js/hepdata_tables.js
+++ b/hepdata/modules/records/assets/js/hepdata_tables.js
@@ -79,7 +79,8 @@ HEPDATA.switch_table = function (listId, table_requested, table_name, status) {
   HEPDATA.table_renderer.display_table_headers(web_url, 0);
 
   // Function to initiate the button to attempt loading of the table
-  $("#hepdata_filesize_loading_button").on('click', function() {
+  // We also clear the event listeners
+  $("#hepdata_filesize_loading_button").off('click').on('click', function() {
     $("#filesize_table_confirm").addClass("hidden");
     $("#filesize_table_loading").removeClass("hidden");
     HEPDATA.table_renderer.display_table(

--- a/hepdata/modules/records/assets/js/hepdata_tables.js
+++ b/hepdata/modules/records/assets/js/hepdata_tables.js
@@ -486,6 +486,8 @@ HEPDATA.table_renderer = {
     }
 
     if (table_data.values.length > HEPDATA.default_row_limit) {
+      // Clear the element first
+      d3.select("#table_options_region").html('');
       d3.select("#table_options_region").append('span').text('Showing ' + HEPDATA.default_row_limit + ' of ' + table_data.values.length + ' values');
       var btn = d3.select("#table_options_region").append('a')
         .attr('class', 'btn-show-all-rows pull-right')

--- a/hepdata/modules/records/assets/js/hepdata_tables.js
+++ b/hepdata/modules/records/assets/js/hepdata_tables.js
@@ -140,6 +140,8 @@ HEPDATA.table_renderer = {
         HEPDATA.table_renderer.render_related_dois(table_data.related_tables, "#related-tables");
         HEPDATA.table_renderer.render_related_dois(table_data.related_to_this, "#related-to-this-tables");
         HEPDATA.table_renderer.render_keywords(table_data.keywords, "#table_keywords");
+        // Render any LaTeX in the table description element.
+        HEPDATA.typeset($("#table_description").get());
         $("#hepdata_table_loader").addClass("hidden");
         $("#hepdata_table_content").removeClass("hidden");
         // We also need to clear the figure

--- a/hepdata/modules/records/utils/common.py
+++ b/hepdata/modules/records/utils/common.py
@@ -21,6 +21,8 @@
 # In applying this license, CERN does not
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
+import yaml
+from yaml import CBaseLoader as Loader
 from invenio_db import db
 from invenio_pidstore.errors import PIDDoesNotExistError
 from invenio_pidstore.resolver import Resolver
@@ -30,7 +32,7 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from hepdata.config import HISTFACTORY_FILE_TYPE, SIZE_LOAD_CHECK_THRESHOLD
 from hepdata.ext.opensearch.api import get_record
-from hepdata.modules.submission.models import HEPSubmission, License
+from hepdata.modules.submission.models import HEPSubmission, License, DataSubmission, DataResource
 
 FILE_TYPES = {
     "py": "Python",
@@ -252,21 +254,52 @@ def record_exists(*args, **kwargs):
     count = HEPSubmission.query.filter_by(**kwargs).count()
     return count > 0
 
+def load_table_data(recid, version):
+    """
+    Loads a specfic data file's yaml file data.
+
+    :param recid: The recid used for the query
+    :param version: The data version to select
+    :return table_contents: A dict containing the table data
+    """
+
+    datasub_query = DataSubmission.query.filter_by(id=recid, version=version)
+    table_contents = {}
+    if datasub_query.count() > 0:
+        datasub_record = datasub_query.one()
+        data_query = db.session.query(DataResource).filter(
+            DataResource.id == datasub_record.data_file)
+
+        if data_query.count() > 0:
+            data_record = data_query.one()
+            file_location = data_record.file_location
+
+            attempts = 0
+            while True:
+                try:
+                    with open(file_location, 'r') as table_file:
+                        table_contents = yaml.load(table_file, Loader=Loader)
+                except (FileNotFoundError, PermissionError) as e:
+                    attempts += 1
+                # allow multiple attempts to read file in case of temporary disk problems
+                if (table_contents and table_contents is not None) or attempts > 5:
+                    break
+
+    return table_contents
+
 
 def file_size_check(file_location, load_all):
     """
-        Decides if a file breaks the maximum size threshold
-            for immediate loading on the records page.
+    Decides if a file breaks the maximum size threshold
+        for immediate loading on the records page.
 
-        :param file_location: Location of the data file on disk
-        :param load_all: If the check should be run
-        :return bool: Pass or fail
+    :param file_location: Location of the data file on disk
+    :param load_all: If the check should be run
+    :return bool: Pass or fail
     """
-    size_check = { "status": True, "size": os.path.getsize(file_location) }
-    # We do the check only if told to, otherwise we just pass as true
-    if load_all == 0:
-        size_check["status"] = size_check["size"] <= SIZE_LOAD_CHECK_THRESHOLD
-    return size_check
+    size = os.path.getsize(file_location)
+    status = True if load_all == 1 else size <= SIZE_LOAD_CHECK_THRESHOLD
+    return { "size": size, "status": status}
 
 def generate_licence_data_by_id(licence_id):
     """

--- a/hepdata/modules/records/utils/data_processing_utils.py
+++ b/hepdata/modules/records/utils/data_processing_utils.py
@@ -199,37 +199,19 @@ def process_dependent_variables(group_count, record, table_contents,
         group_count += 1
 
 
-def generate_table_structure(table_contents):
+def generate_table_data(table_contents):
     """
-    Creates a renderable structure from the table structure we've defined.
+    Creates a renderable data table structure.
 
     :param table_contents:
-    :return: a dictionary encompassing the qualifiers, headers and values
+    :return: A dictionary containing the table headers/values
     """
-
-    record = {"name": table_contents["name"], "doi": table_contents["doi"],
-              "location": table_contents["location"],
-              "table_license": table_contents["table_license"],
-              "related_tables" : table_contents["related_tables"],
-              "related_to_this" : table_contents["related_to_this"],
-              "qualifiers": {},
-              "qualifier_order": [], "headers": [],
-              "review": table_contents["review"],
-              "associated_files": table_contents["associated_files"],
-              "keywords": {},
-              "values": [],
-              "size": table_contents["size"]}
-
-    record["description"] = sanitize_html(table_contents["title"])
-
-    # add in keywords
-    if table_contents['keywords'] is not None:
-        for keyword in table_contents['keywords']:
-            if keyword.name not in record['keywords']:
-                record['keywords'][keyword.name] = []
-
-            if keyword.value not in record['keywords'][keyword.name]:
-                record['keywords'][keyword.name].append(keyword.value)
+    record = {
+        "qualifier_order": [],
+        "headers": [],
+        "values": [],
+        "qualifiers": {}
+    }
 
     tmp_values = {}
     x_axes = OrderedDict()
@@ -260,6 +242,42 @@ def generate_table_structure(table_contents):
 
     for tmp_value in tmp_values:
         record["values"].append(tmp_values[tmp_value])
+
+    return record
+
+
+def generate_table_headers(table_contents):
+    """
+    Prepares the table header data for rendering
+
+    :param table_contents:
+    :return: a dictionary encompassing the qualifiers, headers and values
+    """
+
+    record = {
+        "name": table_contents["name"],
+        "doi": table_contents["doi"],
+        "location": table_contents["location"],
+        "table_license": table_contents["table_license"],
+        "related_tables" : table_contents["related_tables"],
+        "related_to_this" : table_contents["related_to_this"],
+        "review": table_contents["review"],
+        "associated_files": table_contents["associated_files"],
+        "keywords": {},
+        "size": table_contents["size"],
+        "size_check": table_contents["size_check"]
+    }
+
+    record["description"] = sanitize_html(table_contents["title"])
+
+    # add in keywords
+    if table_contents['keywords'] is not None:
+        for keyword in table_contents['keywords']:
+            if keyword.name not in record['keywords']:
+                record['keywords'][keyword.name] = []
+
+            if keyword.value not in record['keywords'][keyword.name]:
+                record['keywords'][keyword.name].append(keyword.value)
 
     return record
 

--- a/hepdata/modules/records/views.py
+++ b/hepdata/modules/records/views.py
@@ -55,9 +55,9 @@ from hepdata.modules.submission.api import get_submission_participants_for_recor
 from hepdata.modules.submission.models import HEPSubmission, DataSubmission, \
     DataResource, DataReview, Message, Question
 from hepdata.modules.records.utils.common import get_record_by_id, \
-    default_time, IMAGE_TYPES, decode_string, file_size_check, generate_licence_data_by_id
+    default_time, IMAGE_TYPES, decode_string, file_size_check, generate_licence_data_by_id, load_table_data
 from hepdata.modules.records.utils.data_processing_utils import \
-    generate_table_structure, process_ctx
+    generate_table_headers, process_ctx, generate_table_data
 from hepdata.modules.records.utils.submission import create_data_review, \
     get_or_create_hepsubmission
 from hepdata.modules.submission.api import get_latest_hepsubmission
@@ -289,8 +289,23 @@ def get_latest():
     return jsonify(result)
 
 
-@blueprint.route('/data/<int:recid>/<int:data_recid>/<int:version>/<int:load_all>', methods=['GET'])
-def get_table_details(recid, data_recid, version, load_all=1):
+@blueprint.route('/data/tabledata/<int:data_recid>/<int:version>', methods=['GET'])
+def get_table_data(data_recid, version):
+    """
+    Gets the table data only for a specific recid/version.
+
+    :param data_recid: The data recid used for retrieval
+    :param version: The data version to retrieve
+    :return:
+    """
+    # Run the function to load table data and return
+    table_contents = load_table_data(data_recid, version)
+    return jsonify(generate_table_data(table_contents))
+
+
+@blueprint.route('/data/<int:recid>/<int:data_recid>/<int:version>/', defaults={'load_all': 1})
+@blueprint.route('/data/<int:recid>/<int:data_recid>/<int:version>/<int:load_all>')
+def get_table_details(recid, data_recid, version, load_all):
     """
     Get the table details of a given datasubmission.
 
@@ -312,28 +327,8 @@ def get_table_details(recid, data_recid, version, load_all=1):
         if data_query.count() > 0:
             data_record = data_query.one()
             file_location = data_record.file_location
-            load_fail = True
 
-            # Perform filesize check, returns the status and size of the file
             size_check = file_size_check(file_location, load_all)
-            if size_check["status"]:
-                attempts = 0
-                while True:
-                    try:
-                        with open(file_location, 'r') as table_file:
-                            table_contents = yaml.load(table_file, Loader=Loader)
-                            if table_contents:
-                                load_fail = False
-
-                    except (FileNotFoundError, PermissionError) as e:
-                        attempts += 1
-                    # allow multiple attempts to read file in case of temporary disk problems
-                    if (table_contents and table_contents is not None) or attempts > 5:
-                        break
-            if load_fail:
-                # TODO - Needs to be initialised for later
-                table_contents["dependent_variables"] = []
-                table_contents["independent_variables"] = []
 
             table_contents["name"] = datasub_record.name
             table_contents["title"] = datasub_record.description
@@ -344,6 +339,7 @@ def get_table_details(recid, data_recid, version, load_all=1):
             table_contents["doi"] = datasub_record.doi
             table_contents["location"] = datasub_record.location_in_publication
             table_contents["size"] = size_check["size"]
+            table_contents["size_check"] = size_check["status"]
 
         # we create a map of files mainly to accommodate the use of thumbnails for images where possible.
         tmp_assoc_files = {}
@@ -397,7 +393,15 @@ def get_table_details(recid, data_recid, version, load_all=1):
     # x and y headers (should not require a colspan)
     # values, that also encompass the errors
 
-    return jsonify(generate_table_structure(table_contents))
+    fixed_table = generate_table_headers(table_contents)
+
+    # If the size is below the threshold, we just pass the table contents now
+    if size_check["status"] or load_all == 1:
+        table_data = generate_table_data(load_table_data(data_recid, version))
+        # Combine the dictionaries if required
+        fixed_table = {**fixed_table, **table_data}
+
+    return jsonify(fixed_table)
 
 
 @blueprint.route('/coordinator/view/<int:recid>', methods=['GET', ])

--- a/tests/records_test.py
+++ b/tests/records_test.py
@@ -49,7 +49,7 @@ from hepdata.modules.records.importer.api import import_records
 from hepdata.modules.records.utils.analyses import update_analyses
 from hepdata.modules.records.utils.submission import get_or_create_hepsubmission, process_submission_directory, do_finalise, unload_submission
 from hepdata.modules.records.utils.common import get_record_by_id, get_record_contents
-from hepdata.modules.records.utils.data_processing_utils import generate_table_structure
+from hepdata.modules.records.utils.data_processing_utils import generate_table_headers, generate_table_data
 from hepdata.modules.records.utils.data_files import get_data_path_for_record
 from hepdata.modules.records.utils.json_ld import get_json_ld
 from hepdata.modules.records.utils.users import get_coordinators_in_system, has_role
@@ -158,8 +158,9 @@ def test_data_processing(app):
     data["review"] = []
     data["associated_files"] = []
     data["size"] = 0
+    data["size_check"] = True
 
-    table_structure = generate_table_structure(data)
+    table_structure = generate_table_data(data)
 
     assert(table_structure["x_count"] == 1)
     assert(len(table_structure["headers"]) == 2)


### PR DESCRIPTION
Adds a new endpoint for specifically selecting individual data tables to avoid duplicate selecting of data, and allow specific table data selecting, where previously all table data was returned.

Fixes a number of bugs introduced in pull request #733:

- LaTeX encoding would not render before the full table is loaded.
- Duplication of value display headers for tables appears incorrectly
- Fixes triggering of multiple requests on the large file loading button where previous table requests are repeated.
- Fixes double loading of the YAML file
- Fixes JSON linking for individual tables broken by the large file flag


Closes #756.