### PR TITLE
Display default license

### DIFF
--- a/hepdata/modules/records/assets/js/hepdata_tables.js
+++ b/hepdata/modules/records/assets/js/hepdata_tables.js
@@ -124,7 +124,7 @@ HEPDATA.table_renderer = {
         $("#table_doi_contents").html('<a href="https://doi.org/' + table_data.doi + '" target="_blank">' + table_data.doi + '</a>');
         $("#table_description").html((table_data.description.indexOf('.') == 0) ? '' : table_data.description.trim());
 
-        // Handle rendering of a licence if it exists
+        // Handle rendering of a license if it exists
         if(table_data.table_license) {
           // Set up anchor with url, text, and title/tooltip
           var license_url = $("<a>")

--- a/hepdata/modules/records/templates/hepdata_records/components/resource_details.html
+++ b/hepdata/modules/records/templates/hepdata_records/components/resource_details.html
@@ -27,6 +27,13 @@
   </div>
 
   <div class="resource-details">
+
+      {% if ctx.data_license %}
+        <div id="resource-data-license">
+          <p>Licence: <a href="{{ ctx.data_license.url }}" title="{{ ctx.data_license.description }}">{{ ctx.data_license.name }}</a></p>
+        </div>
+      {% endif %}
+
       <p>{{ctx.resource.file_description}}</p>
 
       {% if ctx.display_type == 'image' %}
@@ -34,13 +41,6 @@
       {% elif ctx.display_type == 'link' %}
         <p><a href="{{ ctx.resource.file_location }}">{{ ctx.resource.file_location }}</a></p>
       {% elif ctx.display_type == 'code' %}
-
-      {% if ctx.data_license %}
-        <div id="resource-data-license">
-          Licence: <a href="{{ ctx.data_license.url }}" title="{{ ctx.data_license.description }}">{{ ctx.data_license.name }}</a>
-        </div>
-      {% endif %}
-
         {% if ctx.contents and ctx.contents != 'Large text file' %}
           <textarea id="code-contents" height="70%">{{ ctx.contents }}</textarea>
         {% else %}

--- a/hepdata/modules/records/templates/hepdata_records/components/resource_details.html
+++ b/hepdata/modules/records/templates/hepdata_records/components/resource_details.html
@@ -30,7 +30,7 @@
 
       {% if ctx.data_license %}
         <div id="resource-data-license">
-          <p>Licence: <a href="{{ ctx.data_license.url }}" title="{{ ctx.data_license.description }}">{{ ctx.data_license.name }}</a></p>
+          <p>License: <a href="{{ ctx.data_license.url }}" title="{{ ctx.data_license.description }}">{{ ctx.data_license.name }}</a></p>
         </div>
       {% endif %}
 

--- a/hepdata/modules/records/utils/common.py
+++ b/hepdata/modules/records/utils/common.py
@@ -312,7 +312,7 @@ def generate_license_data_by_id(license_id):
     :return dict: Returns the license_data dictionary
     """
     license_data = License.query.filter_by(id=license_id).first()
-    if license_data:
+    if license_data and license_data.name is not None:
         # Generate and return the dictionary
         return {
             "name": license_data.name,

--- a/hepdata/modules/records/utils/common.py
+++ b/hepdata/modules/records/utils/common.py
@@ -254,6 +254,7 @@ def record_exists(*args, **kwargs):
     count = HEPSubmission.query.filter_by(**kwargs).count()
     return count > 0
 
+
 def load_table_data(recid, version):
     """
     Loads a specfic data file's yaml file data.
@@ -301,13 +302,14 @@ def file_size_check(file_location, load_all):
     status = True if load_all == 1 else size <= SIZE_LOAD_CHECK_THRESHOLD
     return { "size": size, "status": status}
 
+
 def generate_license_data_by_id(license_id):
     """
     Generates a dictionary from a License class selected by
-    its ID from the database.
+    its ID from the database or returns the default CC0 licence information.
 
     :param license_id:
-    :return dict: Returns the license_data dictionary, or None
+    :return dict: Returns the license_data dictionary
     """
     license_data = License.query.filter_by(id=license_id).first()
     if license_data:
@@ -318,5 +320,11 @@ def generate_license_data_by_id(license_id):
             "description": license_data.description
         }
     else:
-        # Return None if not found
-        return None
+        # If none, we return the default CC0 licence data
+        return {
+            "name": "CC0",
+            "url": "https://creativecommons.org/publicdomain/zero/1.0/",
+            "description": """CC0 enables reusers to distribute, remix,
+                            adapt, and build upon the material in any
+                            medium or format, with no conditions."""
+        }

--- a/hepdata/modules/records/utils/common.py
+++ b/hepdata/modules/records/utils/common.py
@@ -306,7 +306,7 @@ def file_size_check(file_location, load_all):
 def generate_license_data_by_id(license_id):
     """
     Generates a dictionary from a License class selected by
-    its ID from the database or returns the default CC0 licence information.
+    its ID from the database or returns the default CC0 license information.
 
     :param license_id:
     :return dict: Returns the license_data dictionary
@@ -320,7 +320,7 @@ def generate_license_data_by_id(license_id):
             "description": license_data.description
         }
     else:
-        # If none, we return the default CC0 licence data
+        # If none, we return the default CC0 license data
         return {
             "name": "CC0",
             "url": "https://creativecommons.org/publicdomain/zero/1.0/",

--- a/hepdata/modules/records/utils/common.py
+++ b/hepdata/modules/records/utils/common.py
@@ -324,7 +324,7 @@ def generate_license_data_by_id(license_id):
         return {
             "name": "CC0",
             "url": "https://creativecommons.org/publicdomain/zero/1.0/",
-            "description": """CC0 enables reusers to distribute, remix,
-                            adapt, and build upon the material in any
-                            medium or format, with no conditions."""
+            "description": ("CC0 enables reusers to distribute, remix, "
+                            "adapt, and build upon the material in any "
+                            "medium or format, with no conditions.")
         }

--- a/hepdata/modules/records/views.py
+++ b/hepdata/modules/records/views.py
@@ -690,7 +690,7 @@ def process_resource(reference):
 
     _reference_data = {'id': reference.id, 'file_type': reference.file_type,
                        'file_description': reference.file_description,
-                       'data_license' : generate_license_data_by_id(reference.file_license),
+                       'data_license': generate_license_data_by_id(reference.file_license),
                        'location': _location, 'doi': reference.doi}
 
     if reference.file_type.lower() in IMAGE_TYPES:

--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20240520"
+__version__ = "0.9.4dev20240529"

--- a/tests/records_test.py
+++ b/tests/records_test.py
@@ -1104,7 +1104,7 @@ def test_generate_license_data_by_id(app):
             assert check_license == {
                 "name": "CC0",
                 "url": "https://creativecommons.org/publicdomain/zero/1.0/",
-                "description": """CC0 enables reusers to distribute, remix,
-                                adapt, and build upon the material in any
-                                medium or format, with no conditions."""
+                "description": ("CC0 enables reusers to distribute, remix, "
+                                "adapt, and build upon the material in any "
+                                "medium or format, with no conditions.")
             }

--- a/tests/records_test.py
+++ b/tests/records_test.py
@@ -1067,19 +1067,27 @@ def test_generate_license_data_by_id(app):
     test_cases = [
         {  # Test licence containing junk data
             "id": 1,
+            "insert": True,
             "name": "test_license",
             "url": "test_url",
             "description": "test_description"
         },
         {  # Licence which doesnt exist
             "id": 2,
-            "name": None
-        }
+            "insert": True,
+            "name": None,
+            "url": None,
+            "description": None
+        },
+        {  # Licence which doesnt exist
+            "id": 3,
+            "insert": False
+        },
     ]
 
     for test in test_cases:
         # If the license is supposed to exist.
-        if test["name"] is not None:
+        if test["insert"]:
             test_license = License(
                 id=test["id"],
                 name=test["name"],
@@ -1093,7 +1101,7 @@ def test_generate_license_data_by_id(app):
         check_license = generate_license_data_by_id(test["id"])
 
         # If test was supposed to insert, confirm return is the same as insertion
-        if test["name"] is not None:
+        if test["insert"] and test.get("name") is not None:
             assert check_license == {
                 "name": test["name"],
                 "url": test["url"],


### PR DESCRIPTION
Adds a default return value to the generate_license_data_by_id function which returns data for a CC0 licence if none is found, or the found license object has null values (for old hepdata entries). Also adds testing for this. closes #792