### PR TITLE
Fix do finalise

### DIFF
--- a/hepdata/modules/records/api.py
+++ b/hepdata/modules/records/api.py
@@ -315,16 +315,19 @@ def should_send_json_ld(request):
 def get_commit_message(ctx, recid):
     """
     Returns a commit message for the current version if present.
+    Will return the highest ID of a version-recid pairing.
 
     :param ctx:
     :param recid:
     """
     try:
+        # Select the most recent commit (greatest ID)
         commit_message_query = RecordVersionCommitMessage.query \
-            .filter_by(version=ctx["version"], recid=recid)
+            .filter_by(version=ctx["version"], recid=recid) \
+            .order_by(RecordVersionCommitMessage.id.desc())
 
         if commit_message_query.count() > 0:
-            commit_message = commit_message_query.one()
+            commit_message = commit_message_query.first()
             ctx["revision_message"] = {
                 'version': commit_message.version,
                 'message': commit_message.message}

--- a/hepdata/modules/records/utils/submission.py
+++ b/hepdata/modules/records/utils/submission.py
@@ -715,6 +715,7 @@ def do_finalise(recid, publication_record=None, force_finalise=False,
     print('Finalising record {}'.format(recid))
 
     hep_submission = get_latest_hepsubmission(publication_recid=recid)
+    error_message = None
 
     generated_record_ids = []
     if hep_submission \
@@ -809,14 +810,26 @@ def do_finalise(recid, publication_record=None, force_finalise=False,
                 site_url = current_app.config.get('SITE_URL', 'https://www.hepdata.net')
                 tweet(record.get('title'), record.get('collaborations'),
                       site_url + '/record/ins{0}'.format(record.get('inspire_id')), version)
-
             return json.dumps({"success": True, "recid": recid,
                                "data_count": len(submissions),
                                "generated_records": generated_record_ids})
-
         except NoResultFound:
-            print('No record found to update. Which is super strange.')
+            error_message = 'No record found to update. Which is super strange.'
 
+        # If we have not returned, then we set an error message
+        if error_message is None:
+            error_message = "An error occurred, please try again"
+
+        # If we get to here, we have not returned
+        # Do some cleanup (rollback and return error message)
+        if error_message:
+            print(error_message)
+            db.session.rollback()
+            return json.dumps({
+                "success": False,
+                "recid": recid,
+                "errors": [error_message]
+            })
     else:
         return json.dumps(
             {"success": False, "recid": recid,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -187,10 +187,11 @@ def create_blank_test_record():
     return submission
 
 
-def create_test_record(file_location):
+def create_test_record(file_location, overall_status='finished'):
     """
     Helper function to create a dummy record with data.
     :param file_location: Path to the data directory.
+    :param overall_status: Allows setting of custom overall status. Defaults to 'finished'.
     :returns test_submission: The newly created submission object
     """
     record = {'title': 'HEPData Testing',
@@ -201,7 +202,7 @@ def create_test_record(file_location):
     # Set up a new test submission
     test_submission = process_submission_payload(**record)
     # Ensure the status is set to `finished` so the related data can be accessed.
-    test_submission.overall_status = 'finished'
+    test_submission.overall_status = overall_status
     record_dir = get_data_path_for_record(test_submission.publication_recid, str(int(round(time.time()))))
     shutil.copytree(file_location, record_dir)
     process_submission_directory(record_dir, os.path.join(record_dir, 'submission.yaml'),

--- a/tests/records_test.py
+++ b/tests/records_test.py
@@ -1127,20 +1127,23 @@ def test_get_commit_message(app):
     """
     # We want to ensure duplicate entries
     test_version, test_recid = 1, 1
+    # How many records we want to insert
+    insert_amount = 5
 
     # First we check no insertion, then we check insertion
     for should_insert in [False, True]:
         # Only insert on the second go
         if should_insert:
             # Insert a bunch of duplicate entries
-            for i in range(0, 5):
+            for i in range(0, insert_amount):
                 new_record = RecordVersionCommitMessage(
                     recid=test_recid,
                     version=test_version,
-                    message="Test Message"
+                    # Setting message to a unique value
+                    message=str(insert_amount)
                 )
                 db.session.add(new_record)
-                db.session.commit()
+            db.session.commit()
 
         # Result of get_commit_message is added to ctx as revision_message
         ctx = {"version": test_version}
@@ -1153,3 +1156,9 @@ def test_get_commit_message(app):
 
         # revision_message only exists if we should insert
         assert ("revision_message" in ctx) == should_insert
+
+        # Check the most recent has been retrieved
+        if should_insert:
+            # We know it's the most recent as message
+            # is set to the highest inserted range, equal to insert_amount.
+            ctx["revision_message"]["message"] = str(insert_amount)

--- a/tests/records_test.py
+++ b/tests/records_test.py
@@ -1122,8 +1122,9 @@ def test_generate_license_data_by_id(app):
 def test_get_commit_message(app):
     """
         Tests functionality of the get_commit_message function.
-        Ensures that no instances of none, and duplicate commit messages
-        are handled correctly.
+        Ensures no instances of None, that duplicate commit messages
+        are handled correctly, and only the most recent
+        RecordVersionCommitMessage is returned.
     """
     # We want to ensure duplicate entries
     test_version, test_recid = 1, 1

--- a/tests/submission_test.py
+++ b/tests/submission_test.py
@@ -732,7 +732,7 @@ def test_do_finalise_commit_message(app, admin_idx):
         admin_idx.recreate_index()
         # Create test submission/record
         hepdata_submission = create_test_record(
-            'test_data/test_submission',
+            os.path.abspath('tests/test_data/test_submission'),
             overall_status='todo'
         )
 


### PR DESCRIPTION
Closes #761 by making a number of improvements:

- Increase defensive programming in the do_finalise function
- Modify code to now tolerate the case where multiple commit message objects are inserted, and ensure records containing such a case have the most recent entry retrieved only.
- Add tests to cover duplicate commit message entries.