### PR TITLE
Remove use of `setuptools.command.test` in `setup.py`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of Zenodo.
+# This file is part of HEPData.
 # Copyright (C) 2015 CERN.
 #
-# Zenodo is free software; you can redistribute it
+# HEPData is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
 # published by the Free Software Foundation; either version 2 of the
 # License, or (at your option) any later version.
 #
-# Zenodo is distributed in the hope that it will be
+# HEPData is distributed in the hope that it will be
 # useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with Zenodo; if not, write to the
+# along with HEPData; if not, write to the
 # Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 # MA 02111-1307, USA.
 #

--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20240703"
+__version__ = "0.9.4dev20240731"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of Zenodo.
+# This file is part of HEPData.
 # Copyright (C) 2015 CERN.
 #
 # HEPData is free software; you can redistribute it

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ directory = hepdata/translations/
 
 [extract_messages]
 copyright_holder = CERN
-msgid_bugs_address = info@zenodo.org
+msgid_bugs_address = info@hepdata.net
 mapping-file = babel.ini
 output-file = hepdata/translations/messages.pot
 

--- a/setup.py
+++ b/setup.py
@@ -25,10 +25,8 @@
 """hepdata - Research. Shared."""
 
 import os
-import sys
 
 from setuptools import find_packages, setup
-from setuptools.command.test import test as TestCommand
 
 readme = open('README.rst').read()
 history = open('CHANGES.rst').read()
@@ -56,46 +54,10 @@ extras_require = {
 for name, reqs in extras_require.items():
     extras_require['all'].extend(reqs)
 
-setup_requires = [
-    'Babel>=1.3',
-]
-
 # Packages moved to requirements.txt with specific versions
 install_requires = []
 
 packages = find_packages()
-
-
-class PyTest(TestCommand):
-    """PyTest Test."""
-
-    user_options = [('pytest-args=', 'a', "Arguments to pass to pytest")]
-
-    def initialize_options(self):
-        """Init pytest."""
-        TestCommand.initialize_options(self)
-        self.pytest_args = []
-        try:
-            from ConfigParser import ConfigParser
-        except ImportError:
-            from configparser import ConfigParser
-        config = ConfigParser()
-        config.read('pytest.ini')
-        self.pytest_args = config.get('pytest', 'addopts').split(' ')
-
-    def finalize_options(self):
-        """Finalize pytest."""
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        """Run tests."""
-        # import here, cause outside the eggs aren't loaded
-        import pytest
-        errno = pytest.main(self.pytest_args)
-        sys.exit(errno)
-
 
 # Get the version string. Cannot be done with import!
 g = {}
@@ -170,8 +132,6 @@ setup(
     },
     extras_require=extras_require,
     install_requires=install_requires,
-    setup_requires=setup_requires,
-    tests_require=tests_require,
     classifiers=[
         'Environment :: Web Environment',
         'Intended Audience :: Developers',
@@ -185,6 +145,5 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Development Status :: Production',
     ],
-    cmdclass={'test': PyTest},
     python_requires='>=3.8, <3.10',
 )


### PR DESCRIPTION
`setuptools` [v72.0.0](https://setuptools.pypa.io/en/stable/history.html#v72-0-0) removed the `setuptools.command.test` module causing the [CI to fail](https://github.com/HEPData/hepdata/actions/runs/10136790267/attempts/1).  The release v72.0.0 was later yanked and a new release [v72.1.0](https://setuptools.pypa.io/en/stable/history.html#v72-1-0) reinstated the deprecated `setuptools.command.test` module.  However, running tests with `python setup.py test` is deprecated and the `setuptools.command.test` module may be removed in a future release of `setuptools`, so this PR removes it from the `setup.py` file.  It also removes the deprecated `setup_requires` keyword, since Babel should be installed indirectly by Sphinx or the Invenio packages.  Finally, some instances of "Zenodo" are replaced by "HEPData" in the code comments, an artifact of the original creation of the repository as a fork of Zenodo in 2015.