### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,7 @@ jobs:
       matrix:
         postgres-version: [ 14 ]
         os-version: [ '2.11.0' ]
-        python-version: [ '3.8', '3.9' ]
-        exclude:
-          - python-version: ${{ github.event.act && '3.8' }}
+        python-version: [ '3.9' ]
 
     # Service containers to run with `runner-job`
     services:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -92,7 +92,7 @@ Before you submit a pull request, check that it meets these guidelines:
 1. The pull request should include tests and must not decrease test coverage.
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring.
-3. The pull request should work for Python 3.8 and 3.9. Check
+3. The pull request should work for Python 3.9. Check
    https://github.com/HEPData/hepdata/actions?query=event%3Apull_request
    and make sure that the tests pass.  Sometimes there are temporary failures,
    for example, due to unavailability of an external service or the test infrastructure.

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -29,7 +29,7 @@ Running services locally
 Prerequisites
 =============
 
-HEPData runs with Python 3.8 or 3.9. It also uses several services, which you will need to install before running HEPData.
+HEPData runs with Python 3.9. It also uses several services, which you will need to install before running HEPData.
 
 These services can be installed using the relevant package manager for your system,
 for example, using ``yum`` or ``apt-get`` for Linux or ``brew`` for macOS:
@@ -84,7 +84,7 @@ Installation
 
 Python
 ------
-The HEPData code is only compatible with Python 3.8 or 3.9 (not Python 2 or other 3.x versions).  We recommend Python 3.9.
+The HEPData code is only compatible with Python 3.9 (not Python 2 or other 3.x versions).
 
 First install all requirements in a Python virtual environment.
 (Use `virtualenv <https://virtualenv.pypa.io/en/stable/installation.html>`_ or

--- a/setup.py
+++ b/setup.py
@@ -141,9 +141,8 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Development Status :: Production',
     ],
-    python_requires='>=3.8, <3.10',
+    python_requires='>=3.9, <3.10',
 )


### PR DESCRIPTION
Python 3.8 reached [end-of-life](https://endoflife.date/python) on 7th October 2024.  A recent Dependabot PR #832 bumps `bleach` from 6.1.0 to 6.2.0, dropping support for Python 3.8.  I anticipate that other packages will also drop support for Python 3.8 in the coming months.  To avoid pinning packages to older versions that support Python 3.8, it's better just to drop Python 3.8 support in this repository.