### PR TITLE
Bump Invenio packages to latest supporting SQLAlchemy 1.4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,11 @@ updates:
     ignore:
       - dependency-name: "pytest"  # see https://github.com/HEPData/hepdata/issues/815
       - dependency-name: "pytest-cov"  # see https://github.com/HEPData/hepdata/issues/580
+      - dependency-name: "invenio-access"  # see https://github.com/HEPData/hepdata/issues/848
+      - dependency-name: "invenio-assets"  # see https://github.com/HEPData/hepdata/issues/848
+      - dependency-name: "invenio-logging"  # see https://github.com/HEPData/hepdata/issues/848
+      - dependency-name: "invenio-oauthclient"  # see https://github.com/HEPData/hepdata/issues/848
+      - dependency-name: "invenio-pidstore"  # see https://github.com/HEPData/hepdata/issues/848
+      - dependency-name: "invenio-records"  # see https://github.com/HEPData/hepdata/issues/848
+      - dependency-name: "invenio-search"  # see https://github.com/HEPData/hepdata/issues/848
+      - dependency-name: "invenio-userprofiles"  # see https://github.com/HEPData/hepdata/issues/848

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -249,7 +249,7 @@ Now start the HEPData web application in debug mode:
 
 Then open your preferred web browser (Chrome, Firefox, Safari, etc.) at http://localhost:5000/ .
 
-On macOS Monterey you might find that ControlCenter is already listening to port 5000
+On macOS Monterey (and later) you might find that ControlCenter is already listening to port 5000
 (check with ``lsof -i -P | grep 5000``).  If this is the case,
 `turn off AirPlay Receiver <https://support.apple.com/en-gb/guide/mac-help/mchl15c9e4b5/12.0/mac/12.0>`_.
 

--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20241204"
+__version__ = "0.9.4dev20241211"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,19 +4,15 @@ datacite==1.2.0
 gunicorn==23.0.0
 hepdata-converter-ws-client==0.2.2
 hepdata-validator==0.3.5
-invenio-access==3.0.1     # Indirect (needed by invenio-admin)
-invenio-accounts==5.1.7
-invenio-admin==1.5.1
-invenio-assets==3.0.3
+invenio-access[admin]==3.0.2
+invenio-assets==3.1.0
 invenio-config==1.0.4
-invenio-db[postgresql]==1.1.5
 invenio-logging[sentry_sdk]==2.1.1
-invenio-oauthclient==4.0.2
-invenio-pidstore==1.3.1
-invenio-records==2.4.1
+invenio-oauthclient==4.1.3
+invenio-pidstore==1.3.4
+invenio-records[postgresql]==2.4.1
 invenio-search[opensearch2]==2.4.1
-invenio-theme==3.4.3
-invenio-userprofiles==3.0.0
+invenio-userprofiles==3.0.1
 python-twitter-v2==0.9.2
 responses==0.25.3
 unicodeit==0.7.5


### PR DESCRIPTION
* Upgrade the Invenio packages to the latest ones that don't require SQLAlchemy 2.0, removing some explicit packages that will be installed indirectly as dependencies.
* Change the Dependabot configuration to prevent PRs being opened to update Invenio packages until #848 is addressed.
* Clarify that the issue with ControlCenter listening on port 5000 applies to macOS Monterey (and later) after I encountered the issue again when upgrading to macOS Sequoia.