### PR TITLE
Render MathML in titles/abstracts and use INSPIRE `"source":"submitter"` abstract

### DIFF
--- a/hepdata/modules/inspire_api/parser.py
+++ b/hepdata/modules/inspire_api/parser.py
@@ -89,7 +89,7 @@ def get_abstract(metadata):
     if 'abstracts' in metadata.keys():
         abstract = metadata['abstracts'][0]['value']
         for _abstract in metadata['abstracts']:
-            if 'value' in _abstract.keys() and 'source' in _abstract.keys() and _abstract['source'] == 'arXiv':
+            if 'value' in _abstract.keys() and 'source' in _abstract.keys() and _abstract['source'] in ['arXiv', 'submitter']:
                 abstract = _abstract['value']
                 break
     return abstract

--- a/hepdata/modules/records/templates/hepdata_records/publication_record.html
+++ b/hepdata/modules/records/templates/hepdata_records/publication_record.html
@@ -78,7 +78,7 @@
 
                     <div>
                         <div class="record-title">
-                            {{ ctx.record.title }}
+                            {{ ctx.record.title|safe }}
                         </div>
 
                     <br/>
@@ -169,7 +169,7 @@
                             {% if ctx.record.data_abstract %}
                                 {{ ctx.record.data_abstract|safe }}
                             {% elif ctx.record.abstract %}
-                                {{ ctx.record.abstract }}
+                                {{ ctx.record.abstract|safe }}
                             {% else %}
                                 No abstract available.
                             {% endif %}

--- a/hepdata/modules/records/templates/hepdata_records/related_record.html
+++ b/hepdata/modules/records/templates/hepdata_records/related_record.html
@@ -80,7 +80,7 @@
 
                 <div>
                     <div class="record-title">
-                        {{ ctx.record.title }}
+                        {{ ctx.record.title|safe }}
                     </div>
 
                     <br/>
@@ -162,7 +162,7 @@
                         {% if ctx.record.data_abstract %}
                             {{ ctx.record.data_abstract|safe }}
                         {% elif ctx.record.abstract %}
-                            {{ ctx.record.abstract }}
+                            {{ ctx.record.abstract|safe }}
                         {% else %}
                             No abstract available.
                         {% endif %}

--- a/hepdata/modules/search/templates/hepdata_search/record_content.html
+++ b/hepdata/modules/search/templates/hepdata_search/record_content.html
@@ -52,7 +52,7 @@
 
         {% if record.abstract %}
             <p class="truncated-record-abstract" style="padding-top: 10px;">
-                {{ record.abstract }}
+                {{ record.abstract|safe }}
             </p>
         {% endif %}
 

--- a/hepdata/modules/search/templates/hepdata_search/search_results.html
+++ b/hepdata/modules/search/templates/hepdata_search/search_results.html
@@ -109,7 +109,7 @@
 
                                         {% set record_link = '/record/ins' + record.inspire_id|string %}
                                         <a href={{ record_link }}>
-                                            {{ record.title }}
+                                            {{ record.title|safe }}
                                         </a>
 
                                     </h4>

--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20250501"
+__version__ = "0.9.4dev20250502"


### PR DESCRIPTION
* Render MathML in titles and abstracts on record and search pages (closes #874).
* Use abstract from `"source":"submitter"` if no `"source":"arXiv"` (similar issue as for title in #875).