### PR TITLE
Fix end-to-end tests to support Selenium v4.32.0

### DIFF
--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20250502"
+__version__ = "0.9.4dev20250506"

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -37,6 +37,7 @@ from invenio_accounts.models import User, Role
 from invenio_db.shared import metadata, SQLAlchemy as InvenioSQLAlchemy
 from selenium import webdriver
 from selenium.webdriver.common.by import By
+from selenium.webdriver.remote.command import Command
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from sqlalchemy_utils.functions import create_database, database_exists
@@ -241,7 +242,7 @@ def env_browser(request):
     yield browser
 
     # Check browser logs before quitting
-    log = browser.get_log('browser')
+    log = browser.execute(Command.GET_LOG, {"type": "browser"})["value"]
 
     # Filter out error message for:
     # WARNING: security - Error with Permissions-Policy header:


### PR DESCRIPTION
* `get_log` removed in Selenium v4.32 (see SeleniumHQ/selenium#15641).
* Apply same fix as in commit https://github.com/goauthentik/authentik/commit/48d5f4ec4bb05514df8a3df684827d5e0c375ec2.