### PR TITLE
Add HackAnalysis analyses to endpoints

### DIFF
--- a/hepdata/cli.py
+++ b/hepdata/cli.py
@@ -223,9 +223,9 @@ def do_unload(records_to_unload):
 
 @utils.command()
 @with_appcontext
-@click.option('--endpoint', '-e', type=str, help='Specific endpoint to update (e.g. "rivet" or "MadAnalysis" or "SModelS" or "CheckMATE" or "Combine"). Omit for all.')
+@click.option('--endpoint', '-e', type=str, help='Specific endpoint to update (e.g. "rivet" or "MadAnalysis" or "SModelS" or "CheckMATE" or "HackAnalysis" or "Combine"). Omit for all.')
 def find_and_add_record_analyses(endpoint):
-    """Finds analyses such as Rivet, MadAnalysis 5, SModelS, CheckMATE and Combine and adds them to records."""
+    """Finds analyses such as Rivet, MadAnalysis 5, SModelS, CheckMATE, HackAnalysis and Combine and adds them to records."""
     update_analyses(endpoint)
 
 

--- a/hepdata/config.py
+++ b/hepdata/config.py
@@ -322,21 +322,35 @@ SPECIAL_VALUES = ['inf', '+inf', '-inf', 'nan']
 ANALYSES_ENDPOINTS = {
     'rivet': {
         'endpoint_url': 'https://cedar-tools.web.cern.ch/rivet/analyses.json',
-        'url_template': 'http://rivet.hepforge.org/analyses/{0}'
+        'url_template': 'http://rivet.hepforge.org/analyses/{0}',
+        'description': 'Rivet analysis'
     },
     'MadAnalysis': {
         'endpoint_url': 'https://madanalysis.irmp.ucl.ac.be/raw-attachment/wiki/MA5SandBox/analyses.json',
-        'url_template': 'https://doi.org/{0}'
+        'url_template': 'https://doi.org/{0}',
+        'description': 'MadAnalysis 5 analysis'
     },
     'SModelS': {
         'endpoint_url': 'https://zenodo.org/records/13952092/files/smodels-analyses.hepdata.json?download=1',
         'url_template': '{0}',
+        'description': 'SModelS analysis',
         'subscribe_user_id': 7766
     },
     'CheckMATE': {
         'endpoint_url': 'https://checkmate.hepforge.org/AnalysesList/analyses.json',
         'url_template': '{0}',
+        'description': 'CheckMATE analysis',
         'subscribe_user_id': 6977
+    },
+    'HackAnalysis': {
+        'endpoint_url': 'https://goodsell.pages.in2p3.fr/hackanalysis/json/HackAnalysis_HEPData.json',
+        'url_template': '{0}',
+        'description': 'HackAnalysis analysis',
+        'subscribe_user_id': 7919,
+        'license': {
+            'name': 'gnu-gpl-3.0',
+            'url': 'https://www.gnu.org/licenses/gpl-3.0.html'
+        },
     },
     'Combine': {
         'endpoint_url': 'https://cms-public-likelihoods-list.web.cern.ch/artifacts/output.json',

--- a/hepdata/ext/opensearch/document_enhancers.py
+++ b/hepdata/ext/opensearch/document_enhancers.py
@@ -94,7 +94,7 @@ def add_shortened_authors(doc):
 
 def add_analyses(doc):
     """
-    Add analyses links such as Rivet, MadAnalysis 5, SModelS, CheckMATE, Combine, HistFactory and NUISANCE to the index.
+    Add analyses links such as Rivet, MadAnalysis 5, SModelS, CheckMATE, HackAnalysis, Combine, HistFactory and NUISANCE to the index.
 
     :param doc:
     :return:

--- a/hepdata/modules/records/assets/js/hepdata_common.js
+++ b/hepdata/modules/records/assets/js/hepdata_common.js
@@ -47,6 +47,7 @@ HEPDATA.file_type_to_details = {
   "madanalysis": {"icon": "area-chart", "description": "MadAnalysis 5 Analysis"},
   "smodels": {"icon": "area-chart", "description": "SModelS Analysis"},
   "checkmate": {"icon": "area-chart", "description": "CheckMATE Analysis"},
+  "hackanalysis": {"icon": "area-chart", "description": "HackAnalysis Analysis"},
   "combine": {"icon": "area-chart", "description": "Combine Analysis"},
   "xfitter": {"icon": "area-chart", "description": "xFitter Analysis"},
   "applgrid": {"icon": "area-chart", "description": "APPLgrid Analysis"},

--- a/hepdata/modules/records/templates/hepdata_records/components/resources-widget.html
+++ b/hepdata/modules/records/templates/hepdata_records/components/resources-widget.html
@@ -42,6 +42,7 @@
                                                     <option value="MadAnalysis">MadAnalysis 5</option>
                                                     <option value="SModelS">SModelS</option>
                                                     <option value="CheckMATE">CheckMATE</option>
+                                                    <option value="HackAnalysis">HackAnalysis</option>
                                                     <option value="Combine">Combine</option>
                                                     <option value="rivet">Rivet</option>
                                                     <option value="fastnlo">fastNLO</option>

--- a/hepdata/modules/records/utils/analyses.py
+++ b/hepdata/modules/records/utils/analyses.py
@@ -44,11 +44,11 @@ log = logging.getLogger(__name__)
 @shared_task
 def update_analyses(endpoint=None):
     """
-    Update (Rivet, MadAnalysis 5, SModelS, CheckMATE and Combine) analyses and remove outdated resources.
+    Update (Rivet, MadAnalysis 5, SModelS, CheckMATE, HackAnalysis and Combine) analyses and remove outdated resources.
     Allow bulk subscription to record update notifications if "subscribe_user_id" in endpoint.
     Add optional "description" and "license" fields if present in endpoint.
 
-    :param endpoint: either "rivet" or "MadAnalysis" or "SModelS" or "CheckMATE" or "Combine" or None (default) for all
+    :param endpoint: either "rivet" or "MadAnalysis" or "SModelS" or "CheckMATE" or "HackAnalysis" or "Combine" or None (default) for all
     """
     endpoints = current_app.config["ANALYSES_ENDPOINTS"]
     for analysis_endpoint in endpoints:

--- a/hepdata/modules/search/templates/hepdata_search/modals/search_help.html
+++ b/hepdata/modules/search/templates/hepdata_search/modals/search_help.html
@@ -250,6 +250,13 @@
                                     </span>
                                 </li>
                                 <li>
+                                    <a href='/search?q=analysis:HackAnalysis&sort_by=latest'
+                                       target="_new">analysis:HackAnalysis</a>
+                                    <span class="text-muted">
+                                       (HackAnalysis analysis)
+                                    </span>
+                                </li>
+                                <li>
                                     <a href='/search?q=analysis:Combine&sort_by=latest'
                                        target="_new">analysis:Combine</a>
                                     <span class="text-muted">

--- a/tests/records_test.py
+++ b/tests/records_test.py
@@ -1031,7 +1031,7 @@ def test_create_breadcrumb_text():
 
 
 def test_update_analyses(app):
-    """ Test update of Rivet, MadAnalyses 5, SModelS, CheckMATE and Combine analyses """
+    """ Test update of Rivet, MadAnalyses 5, SModelS, CheckMATE, HackAnalysis and Combine analyses """
 
     # Import a record that already has a Rivet analysis attached (but with '#' in the URL)
     import_records(['ins1203852'], synchronous=True)
@@ -1084,6 +1084,19 @@ def test_update_analyses(app):
     analysis_resources = DataResource.query.filter_by(file_type='CheckMATE').all()
     assert len(analysis_resources) == 1
     assert analysis_resources[0].file_location == 'https://checkmate.hepforge.org/AnalysesList/ATLAS_13TeV.html#atlas_2102_10874'
+    submission = get_latest_hepsubmission(inspire_id='1847779', overall_status='finished')
+    assert is_current_user_subscribed_to_record(submission.publication_recid, user)
+
+    # ins1847779 also has a HackAnalysis analysis, so don't need to import another record
+    analysis_resources = DataResource.query.filter_by(file_type='HackAnalysis').all()
+    assert len(analysis_resources) == 0
+    user = User(email='test3@test.com', password='hello1', active=True, id=7919)
+    db.session.add(user)
+    db.session.commit()
+    update_analyses('HackAnalysis')
+    analysis_resources = DataResource.query.filter_by(file_type='HackAnalysis').all()
+    assert len(analysis_resources) == 1
+    assert analysis_resources[0].file_location == 'https://goodsell.pages.in2p3.fr/hackanalysis/page/analyses/atlas_exot_2018_06/'
     submission = get_latest_hepsubmission(inspire_id='1847779', overall_status='finished')
     assert is_current_user_subscribed_to_record(submission.publication_recid, user)
 


### PR DESCRIPTION
* Add [HackAnalysis](https://goodsell.pages.in2p3.fr/hackanalysis/) to `ANALYSES_ENDPOINTS`.
* Also add `description` to other analysis endpoints.  The database will need to be updated, which can be done by running the following Python code in the `hepdata shell` environment:
```python
from flask import current_app
from hepdata.modules.submission.models import DataResource
from invenio_db import db
endpoints = current_app.config["ANALYSES_ENDPOINTS"]
for analysis_endpoint in endpoints:
    analysis_resources = DataResource.query.filter_by(file_type=analysis_endpoint).all()
    for resource in analysis_resources:
        if "description" in endpoints[analysis_endpoint]:
            resource.file_description = str(endpoints[analysis_endpoint]["description"])
db.session.commit()
```
The OpenSearch index should also be updated using `hepdata utils reindex -b 1`.