### PR TITLE
Improve `get_metadata_by_alternative_id` and upgrade Sauce Connect version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
         COVERAGE_FILE: '.coverage_func'
         SQLALCHEMY_WARN_20: 1
       run: |
-        py.test -vv tests/*_test.py
+        py.test -vv tests/*_test.py tests/test_*.py
     - name: Setup Sauce Connect
       uses: saucelabs/sauce-connect-action@v3.0.0
       if: startsWith(matrix.python-version, '3.9')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
         region: eu
         tunnelName: ${{ github.run_id }}
         proxyLocalhost: direct
-        scVersion: 5.2.3
+        scVersion: 5.3.0
     - name: Run end-to-end tests
       if: startsWith(matrix.python-version, '3.9')
       env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,8 @@ RUN hepdata collect -v  && \
 
 RUN bash -c "echo $APP_ENVIRONMENT"
 
-RUN bash -c "set -x; [[ ${APP_ENVIRONMENT:-prod} = local-web ]] && (cd /usr/local/var && wget https://saucelabs.com/downloads/sauce-connect/5.2.3/sauce-connect-5.2.3_${SAUCE_OS:-linux.x86_64}.tar.gz && \
-  tar -xvf sauce-connect-5.2.3_${SAUCE_OS:-linux.x86_64}.tar.gz) || echo 'Not installing SC on prod or worker build'"
+RUN bash -c "set -x; [[ ${APP_ENVIRONMENT:-prod} = local-web ]] && (cd /usr/local/var && wget https://saucelabs.com/downloads/sauce-connect/5.3.0/sauce-connect-5.3.0_${SAUCE_OS:-linux.x86_64}.tar.gz && \
+  tar -xvf sauce-connect-5.3.0_${SAUCE_OS:-linux.x86_64}.tar.gz) || echo 'Not installing SC on prod or worker build'"
 
 WORKDIR /code
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -384,7 +384,7 @@ To run the tests:
 
 .. code-block:: console
 
-   $ docker-compose exec web bash -c "/usr/local/var/sauce-connect-5.2.3_${SAUCE_OS:-linux.x86_64}/sc -u $SAUCE_USERNAME -k $SAUCE_ACCESS_KEY --region eu-central -i ${SAUCE_USERNAME}_tunnel_name --proxy-localhost direct & ./run-tests.sh"
+   $ docker-compose exec web bash -c "/usr/local/var/sauce-connect-5.3.0_${SAUCE_OS:-linux.x86_64}/sc -u $SAUCE_USERNAME -k $SAUCE_ACCESS_KEY --region eu-central -i ${SAUCE_USERNAME}_tunnel_name --proxy-localhost direct & ./run-tests.sh"
 
 .. _docker-compose-tips:
 

--- a/hepdata/modules/records/views.py
+++ b/hepdata/modules/records/views.py
@@ -133,32 +133,28 @@ def sandbox_display(id):
 def get_metadata_by_alternative_id(recid):
 
     try:
-        if "ins" in recid:
-            recid = recid.replace("ins", "")
-            record = get_records_matching_field('inspire_id', recid,
-                                                doc_type=CFG_PUB_TYPE)
-            record = record['hits']['hits'][0].get("_source")
-            try:
-                version = int(request.args.get('version', -1))
-            except ValueError:
-                version = -1
+        inspire_id = int(recid.replace('ins', ''))  # raises ValueError if not integer
+        record = get_records_matching_field('inspire_id', inspire_id,
+                                            doc_type=CFG_PUB_TYPE)
+        record = record['hits']['hits'][0].get("_source")
+        try:
+            version = int(request.args.get('version', -1))
+        except ValueError:
+            version = -1
 
-            output_format = request.args.get('format', 'html')
-            light_mode = bool(request.args.get('light', False))
+        output_format = request.args.get('format', 'html')
+        light_mode = bool(request.args.get('light', False))
 
-            # Check the Accept header to determine whether to send JSON-LD
-            if output_format == 'html' and should_send_json_ld(request):
-                output_format = 'json_ld'
+        # Check the Accept header to determine whether to send JSON-LD
+        if output_format == 'html' and should_send_json_ld(request):
+            output_format = 'json_ld'
 
-            return render_record(recid=record['recid'], record=record, version=version, output_format=output_format,
-                                 light_mode=light_mode)
-        else:
-            log.error("Unable to find %s.", recid)
-            return abort(404)
+        return render_record(recid=record['recid'], record=record, version=version, output_format=output_format,
+                             light_mode=light_mode)
 
     except Exception as e:
-        log.error("Unable to find %s.", recid)
-        log.error(e)
+        log.warning("Unable to find %s.", recid)
+        log.warning(e)
         return abort(404)
 
 

--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20250708"
+__version__ = "0.9.4dev20250717"

--- a/tests/test_records_views.py
+++ b/tests/test_records_views.py
@@ -1,0 +1,137 @@
+import pytest
+from unittest.mock import Mock, patch
+from flask import Flask, request
+from hepdata.modules.records.views import get_metadata_by_alternative_id
+
+
+class TestGetMetadataByAlternativeId:
+    """Test cases for get_metadata_by_alternative_id function."""
+
+    def test_valid_inspire_id_success(self, app):
+        """Test successful retrieval with valid inspire ID format."""
+        with app.test_request_context('/record/ins12345?version=1&format=json'):
+            # Mock the database search to return a valid record
+            mock_record = {
+                'recid': 1,
+                'inspire_id': 12345,
+                'title': 'Test Record'
+            }
+            mock_search_result = {
+                'hits': {
+                    'hits': [{'_source': mock_record}]
+                }
+            }
+            
+            with patch('hepdata.modules.records.views.get_records_matching_field') as mock_search, \
+                 patch('hepdata.modules.records.views.render_record') as mock_render, \
+                 patch('hepdata.modules.records.views.should_send_json_ld') as mock_json_ld:
+                
+                mock_search.return_value = mock_search_result
+                mock_json_ld.return_value = False
+                mock_render.return_value = 'rendered_record'
+                
+                result = get_metadata_by_alternative_id('ins12345')
+                
+                # Verify the inspire_id was extracted correctly
+                mock_search.assert_called_once_with('inspire_id', 12345, doc_type='publication')
+                
+                # Verify render_record was called with correct parameters
+                mock_render.assert_called_once_with(
+                    recid=1, 
+                    record=mock_record, 
+                    version=1, 
+                    output_format='json',
+                    light_mode=False
+                )
+                
+                assert result == 'rendered_record'
+
+    def test_invalid_inspire_id_format_non_numeric(self, app):
+        """Test handling of invalid inspire ID format with non-numeric part."""
+        with app.test_request_context('/record/ins_abc'):
+            with patch('hepdata.modules.records.views.log') as mock_log, \
+                 patch('hepdata.modules.records.views.abort') as mock_abort:
+                
+                mock_abort.return_value = 'aborted_404'
+                
+                result = get_metadata_by_alternative_id('ins_abc')
+                
+                # Verify warning was logged
+                mock_log.warning.assert_called()
+                assert 'Unable to find ins_abc' in str(mock_log.warning.call_args[0])
+                
+                # Verify abort(404) was called
+                mock_abort.assert_called_once_with(404)
+                assert result == 'aborted_404'
+
+    def test_invalid_inspire_id_format_no_ins_prefix(self, app):
+        """Test handling of invalid inspire ID format without 'ins' prefix."""
+        with app.test_request_context('/record/12345'):
+            with patch('hepdata.modules.records.views.log') as mock_log, \
+                 patch('hepdata.modules.records.views.abort') as mock_abort:
+                
+                mock_abort.return_value = 'aborted_404'
+                
+                result = get_metadata_by_alternative_id('12345')
+                
+                # Verify warning was logged
+                mock_log.warning.assert_called()
+                assert 'Unable to find 12345' in str(mock_log.warning.call_args[0])
+                
+                # Verify abort(404) was called
+                mock_abort.assert_called_once_with(404)
+                assert result == 'aborted_404'
+
+    def test_record_not_found(self, app):
+        """Test handling when no record is found for valid inspire ID."""
+        with app.test_request_context('/record/ins99999'):
+            # Mock empty search results
+            mock_search_result = {
+                'hits': {
+                    'hits': []
+                }
+            }
+            
+            with patch('hepdata.modules.records.views.get_records_matching_field') as mock_search, \
+                 patch('hepdata.modules.records.views.log') as mock_log, \
+                 patch('hepdata.modules.records.views.abort') as mock_abort:
+                
+                mock_search.return_value = mock_search_result
+                mock_abort.return_value = 'aborted_404'
+                
+                result = get_metadata_by_alternative_id('ins99999')
+                
+                # Verify search was attempted
+                mock_search.assert_called_once_with('inspire_id', 99999, doc_type='publication')
+                
+                # Verify warning was logged (IndexError causes exception handling)
+                mock_log.warning.assert_called()
+                
+                # Verify abort(404) was called
+                mock_abort.assert_called_once_with(404)
+                assert result == 'aborted_404'
+
+    def test_json_ld_format_detection(self, app):
+        """Test JSON-LD format detection based on Accept header."""
+        with app.test_request_context('/record/ins12345', headers={'Accept': 'application/ld+json'}):
+            mock_record = {'recid': 1, 'inspire_id': 12345}
+            mock_search_result = {'hits': {'hits': [{'_source': mock_record}]}}
+            
+            with patch('hepdata.modules.records.views.get_records_matching_field') as mock_search, \
+                 patch('hepdata.modules.records.views.render_record') as mock_render, \
+                 patch('hepdata.modules.records.views.should_send_json_ld') as mock_json_ld:
+                
+                mock_search.return_value = mock_search_result
+                mock_json_ld.return_value = True
+                mock_render.return_value = 'json_ld_record'
+                
+                result = get_metadata_by_alternative_id('ins12345')
+                
+                # Verify JSON-LD format was used
+                mock_render.assert_called_once_with(
+                    recid=1, 
+                    record=mock_record, 
+                    version=-1, 
+                    output_format='json_ld',
+                    light_mode=False
+                )


### PR DESCRIPTION
* Ensure `inspire_id` is integer before OpenSearch query.
* Log exceptions as warnings not errors in `get_metadata_by_alternative_id`.
* Closes #891.
* Also upgrade Sauce Connect version from 5.2.3 to 5.3.0.
* Try using [codecov-ai](https://github.com/apps/codecov-ai) to generate unit tests in PR #893.