### PR TITLE
Add GAMBIT analyses JSON

### DIFF
--- a/hepdata/cli.py
+++ b/hepdata/cli.py
@@ -35,7 +35,7 @@ from hepdata.modules.records.utils.common import record_exists, get_record_by_id
 from hepdata.modules.submission.models import HEPSubmission
 from hepdata.modules.submission.api import get_latest_hepsubmission
 from .factory import create_app
-from hepdata.config import CFG_PUB_TYPE
+from hepdata.config import CFG_PUB_TYPE, ANALYSES_ENDPOINTS
 from hepdata.ext.opensearch.api import reindex_all, get_records_matching_field
 from hepdata.modules.records.importer import api as importer_api
 from hepdata.modules.records.utils import data_files
@@ -55,7 +55,7 @@ from invenio_db import db
 cli = create_cli(create_app=create_app)
 
 default_recids = 'ins1283842,ins1245023,ins1311487'
-
+endpoints_as_string = '"' + '" or "'.join(ANALYSES_ENDPOINTS.keys()) + '"'
 
 @cli.group()
 def importer():
@@ -223,9 +223,9 @@ def do_unload(records_to_unload):
 
 @utils.command()
 @with_appcontext
-@click.option('--endpoint', '-e', type=str, help='Specific endpoint to update (e.g. "rivet" or "MadAnalysis" or "SModelS" or "CheckMATE" or "HackAnalysis" or "Combine" or "GAMBIT"). Omit for all.')
+@click.option('--endpoint', '-e', type=str, help=f'Specific endpoint to update (e.g. {endpoints_as_string}). Omit for all.')
 def find_and_add_record_analyses(endpoint):
-    """Finds analyses such as Rivet, MadAnalysis 5, SModelS, CheckMATE, HackAnalysis, Combine and GAMBIT and adds them to records."""
+    """Finds analyses from tools such as Rivet, MadAnalysis 5, etc. and adds them to records."""
     update_analyses(endpoint)
 
 

--- a/hepdata/cli.py
+++ b/hepdata/cli.py
@@ -223,9 +223,9 @@ def do_unload(records_to_unload):
 
 @utils.command()
 @with_appcontext
-@click.option('--endpoint', '-e', type=str, help='Specific endpoint to update (e.g. "rivet" or "MadAnalysis" or "SModelS" or "CheckMATE" or "HackAnalysis" or "Combine"). Omit for all.')
+@click.option('--endpoint', '-e', type=str, help='Specific endpoint to update (e.g. "rivet" or "MadAnalysis" or "SModelS" or "CheckMATE" or "HackAnalysis" or "Combine" or "GAMBIT"). Omit for all.')
 def find_and_add_record_analyses(endpoint):
-    """Finds analyses such as Rivet, MadAnalysis 5, SModelS, CheckMATE, HackAnalysis and Combine and adds them to records."""
+    """Finds analyses such as Rivet, MadAnalysis 5, SModelS, CheckMATE, HackAnalysis, Combine and GAMBIT and adds them to records."""
     update_analyses(endpoint)
 
 

--- a/hepdata/config.py
+++ b/hepdata/config.py
@@ -361,6 +361,9 @@ ANALYSES_ENDPOINTS = {
             'url': 'https://creativecommons.org/licenses/by/4.0'
          },
     },
+    'GAMBIT': {
+        'endpoint_url': 'https://gambitbsm.org/analyses.json',
+    },
     #'ufo': {},
     #'xfitter': {},
     #'applgrid': {},

--- a/hepdata/ext/opensearch/document_enhancers.py
+++ b/hepdata/ext/opensearch/document_enhancers.py
@@ -94,7 +94,7 @@ def add_shortened_authors(doc):
 
 def add_analyses(doc):
     """
-    Add analyses links such as Rivet, MadAnalysis 5, SModelS, CheckMATE, HackAnalysis, Combine, HistFactory, NUISANCE and GAMBIT to the index.
+    Add analyses links to tools such as Rivet, MadAnalysis 5, etc. to the index.
 
     :param doc:
     :return:

--- a/hepdata/ext/opensearch/document_enhancers.py
+++ b/hepdata/ext/opensearch/document_enhancers.py
@@ -94,7 +94,7 @@ def add_shortened_authors(doc):
 
 def add_analyses(doc):
     """
-    Add analyses links such as Rivet, MadAnalysis 5, SModelS, CheckMATE, HackAnalysis, Combine, HistFactory and NUISANCE to the index.
+    Add analyses links such as Rivet, MadAnalysis 5, SModelS, CheckMATE, HackAnalysis, Combine, HistFactory, NUISANCE and GAMBIT to the index.
 
     :param doc:
     :return:

--- a/hepdata/modules/records/assets/js/hepdata_common.js
+++ b/hepdata/modules/records/assets/js/hepdata_common.js
@@ -49,6 +49,7 @@ HEPDATA.file_type_to_details = {
   "checkmate": {"icon": "area-chart", "description": "CheckMATE Analysis"},
   "hackanalysis": {"icon": "area-chart", "description": "HackAnalysis Analysis"},
   "combine": {"icon": "area-chart", "description": "Combine Analysis"},
+  "gambit": {"icon": "area-chart", "description": "GAMBIT analysis"},
   "xfitter": {"icon": "area-chart", "description": "xFitter Analysis"},
   "applgrid": {"icon": "area-chart", "description": "APPLgrid Analysis"},
   "ufo": {"icon": "rocket", "description": "Universal Feynrules Output (UFO)"},

--- a/hepdata/modules/records/templates/hepdata_records/components/resources-widget.html
+++ b/hepdata/modules/records/templates/hepdata_records/components/resources-widget.html
@@ -39,13 +39,6 @@
                                                 <select name="analysisType" id="analysisType" class="form-control">
                                                     <option disabled>Analyses</option>
                                                     <option value="applgrid">APPLgrid</option>
-                                                    <option value="MadAnalysis">MadAnalysis 5</option>
-                                                    <option value="SModelS">SModelS</option>
-                                                    <option value="CheckMATE">CheckMATE</option>
-                                                    <option value="HackAnalysis">HackAnalysis</option>
-                                                    <option value="Combine">Combine</option>
-                                                    <option value="rivet">Rivet</option>
-                                                    <option value="GAMBIT">GAMBIT</option>
                                                     <option value="fastnlo">fastNLO</option>
                                                     <option value="ufo">Universal Feynrules Output (UFO)</option>
                                                     <option value="xfitter">xFitter</option>

--- a/hepdata/modules/records/templates/hepdata_records/components/resources-widget.html
+++ b/hepdata/modules/records/templates/hepdata_records/components/resources-widget.html
@@ -45,6 +45,7 @@
                                                     <option value="HackAnalysis">HackAnalysis</option>
                                                     <option value="Combine">Combine</option>
                                                     <option value="rivet">Rivet</option>
+                                                    <option value="GAMBIT">GAMBIT</option>
                                                     <option value="fastnlo">fastNLO</option>
                                                     <option value="ufo">Universal Feynrules Output (UFO)</option>
                                                     <option value="xfitter">xFitter</option>

--- a/hepdata/modules/records/utils/analyses.py
+++ b/hepdata/modules/records/utils/analyses.py
@@ -52,11 +52,11 @@ def test_analyses_schema(json_file, schema_version="1.0.0"):
 @shared_task
 def update_analyses(endpoint=None):
     """
-    Update (Rivet, MadAnalysis 5, SModelS, CheckMATE, HackAnalysis, Combine, and GAMBIT) analyses and remove outdated resources.
+    Update tools (Rivet, MadAnalysis 5, etc.) analyses and remove outdated resources.
     Allow bulk subscription to record update notifications if "subscribe_user_id" in endpoint.
     Add optional "description" and "license" fields if present in endpoint.
 
-    :param endpoint: either "rivet" or "MadAnalysis" or "SModelS" or "CheckMATE" or "HackAnalysis" or "Combine" or "GAMBIT" or None (default) for all
+    :param endpoint: any one from config.ANALYSES_ENDPOINTS ("rivet", "MadAnalysis", etc.) or None (default) for all
     """
 
     endpoints = current_app.config["ANALYSES_ENDPOINTS"]

--- a/hepdata/modules/records/utils/analyses.py
+++ b/hepdata/modules/records/utils/analyses.py
@@ -244,5 +244,8 @@ def update_analyses(endpoint=None):
                                 if submission and not is_current_user_subscribed_to_record(submission.publication_recid, user):
                                     subscribe(submission.publication_recid, user)
 
-        else:
+            else:  # if response.status_code != 200
+                log.error(f"Error accessing {endpoints[analysis_endpoint]['endpoint_url']}")
+
+        else:  # if "endpoint_url" not in endpoints[analysis_endpoint]
             log.debug("No endpoint_url configured for {0}".format(analysis_endpoint))

--- a/hepdata/modules/search/templates/hepdata_search/modals/search_help.html
+++ b/hepdata/modules/search/templates/hepdata_search/modals/search_help.html
@@ -277,6 +277,13 @@
                                        (ProSelecta analysis for use with NUISANCE)
                                     </span>
                                 </li>
+                                <li>
+                                    <a href='/search?q=analysis:GAMBIT&sort_by=latest'
+                                       target="_new">analysis:GAMBIT</a>
+                                    <span class="text-muted">
+                                       (GAMBIT analysis)
+                                    </span>
+                                </li>
                             </ul>
                         </li>
 

--- a/hepdata/modules/search/templates/hepdata_search/modals/search_help.html
+++ b/hepdata/modules/search/templates/hepdata_search/modals/search_help.html
@@ -264,6 +264,13 @@
                                     </span>
                                 </li>
                                 <li>
+                                    <a href='/search?q=analysis:GAMBIT&sort_by=latest'
+                                       target="_new">analysis:GAMBIT</a>
+                                    <span class="text-muted">
+                                       (GAMBIT analysis)
+                                    </span>
+                                </li>
+                                <li>
                                     <a href='/search?q=analysis:HistFactory&sort_by=latest'
                                        target="_new">analysis:HistFactory</a>
                                     <span class="text-muted">
@@ -275,13 +282,6 @@
                                        target="_new">analysis:NUISANCE</a>
                                     <span class="text-muted">
                                        (ProSelecta analysis for use with NUISANCE)
-                                    </span>
-                                </li>
-                                <li>
-                                    <a href='/search?q=analysis:GAMBIT&sort_by=latest'
-                                       target="_new">analysis:GAMBIT</a>
-                                    <span class="text-muted">
-                                       (GAMBIT analysis)
                                     </span>
                                 </li>
                             </ul>

--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20250905"
+__version__ = "0.9.4dev20250912"

--- a/tests/records_test.py
+++ b/tests/records_test.py
@@ -1131,14 +1131,13 @@ def test_update_analyses(app):
     assert license_data.name == 'cc-by-4.0'
     assert license_data.url == 'https://creativecommons.org/licenses/by/4.0'
 
-    # Import a record that has an associated GAMBIT analysis
-    import_records(['ins1827025'], synchronous=True)
+    # ins1847779 also has a GAMBIT analysis, so don't need to import another record
     analysis_resources = DataResource.query.filter_by(file_type='GAMBIT').all()
     assert len(analysis_resources) == 0
     update_analyses('GAMBIT')
     analysis_resources = DataResource.query.filter_by(file_type='GAMBIT').all()
     assert len(analysis_resources) == 1
-    assert analysis_resources[0].file_location == 'https://github.com/GambitBSM/gambit_2.6/blob/release_2.6/ColliderBit/src/analyses/Analysis_ATLAS_13TeV_0LEP_139invfb.cpp'
+    assert analysis_resources[0].file_location == 'https://github.com/GambitBSM/gambit_2.6/blob/release_2.6/ColliderBit/src/analyses/Analysis_ATLAS_13TeV_MONOJET_139infb.cpp'
 
     # Call update_analysis using an endpoint with no endpoint_url
     current_app.config["ANALYSES_ENDPOINTS"]["TestAnalysis"] = {}

--- a/tests/records_test.py
+++ b/tests/records_test.py
@@ -1147,6 +1147,7 @@ def test_update_analyses(app):
     current_app.config["ANALYSES_ENDPOINTS"]["TestAnalysis"]['endpoint_url'] = 'https://www.hepdata.net/search/?format=json&size=1'
     update_analyses('TestAnalysis')
 
+
 def test_generate_license_data_by_id(app):
     """
     Tests the generate_license_data_by_id function which

--- a/tests/records_test.py
+++ b/tests/records_test.py
@@ -1143,8 +1143,12 @@ def test_update_analyses(app):
     current_app.config["ANALYSES_ENDPOINTS"]["TestAnalysis"] = {}
     update_analyses('TestAnalysis')
 
-    # Call update_analyses using an endpoint_url that will fail validation.
+    # Call update_analyses using an endpoint_url that will fail validation
     current_app.config["ANALYSES_ENDPOINTS"]["TestAnalysis"]['endpoint_url'] = 'https://www.hepdata.net/search/?format=json&size=1'
+    update_analyses('TestAnalysis')
+
+    # Call update_analyses using an invalid endpoint_URL
+    current_app.config["ANALYSES_ENDPOINTS"]["TestAnalysis"]['endpoint_url'] = 'https://www.hepdata.net/analyses.json'
     update_analyses('TestAnalysis')
 
 

--- a/tests/records_test.py
+++ b/tests/records_test.py
@@ -1117,6 +1117,14 @@ def test_update_analyses(app):
     assert license_data.name == 'cc-by-4.0'
     assert license_data.url == 'https://creativecommons.org/licenses/by/4.0'
 
+    # Import a record that has an associated GAMBIT analysis
+    import_records(['ins1827025'], synchronous=True)
+    analysis_resources = DataResource.query.filter_by(file_type='GAMBIT').all()
+    assert len(analysis_resources) == 0
+    update_analyses('GAMBIT')
+    analysis_resources = DataResource.query.filter_by(file_type='GAMBIT').all()
+    assert len(analysis_resources) == 1
+    assert analysis_resources[0].file_location == 'https://github.com/GambitBSM/gambit_2.6/blob/release_2.6/ColliderBit/src/analyses/Analysis_ATLAS_13TeV_0LEP_139invfb.cpp'
 
 def test_generate_license_data_by_id(app):
     """

--- a/tests/records_test.py
+++ b/tests/records_test.py
@@ -1038,7 +1038,7 @@ def test_create_breadcrumb_text():
 
 
 def test_update_analyses(app):
-    """ Test update of Rivet, MadAnalyses 5, SModelS, CheckMATE, HackAnalysis and Combine analyses """
+    """ Test update of Rivet, MadAnalyses 5, etc. analyses """
 
     # Import a record that already has a Rivet analysis attached (but with '#' in the URL)
     import_records(['ins1203852'], synchronous=True)


### PR DESCRIPTION
Replacement of #886, now based on HEPData branch instead of fork.

https://github.com/HEPData/hepdata/pull/886#discussion_r2316767037 regarding always listing all reinterpretation tools is addressed in 5fe8ac33edf273b854e974bf3baf40f9f65c7c14.

CI will currently fail because GAMBIT analyses JSON is not fully up to latest schema standard, yet. GAMBIT devs are notified so will hopefully be fixed soon.