### PR TITLE
Switch from Coveralls to Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip "setuptools<82" py
-        python -m pip install twine wheel coveralls requirements-builder
+        python -m pip install twine wheel requirements-builder
         python -m pip install --force-reinstall -r requirements.txt
         python -m pip install -e .[tests]
     - name: Initialise hepdata
@@ -155,10 +155,10 @@ jobs:
         cp hepdata/config_local.gh.py hepdata/config_local.py
     - name: Run tests
       env:
-        COVERAGE_FILE: '.coverage_func'
+        COVERAGE_FILE: '.coverage_func.xml'
         SQLALCHEMY_WARN_20: 1
       run: |
-        py.test -vv tests/*_test.py tests/test_*.py
+        pytest --cov-report xml tests/*_test.py tests/test_*.py
     - name: Setup Sauce Connect
       uses: saucelabs/sauce-connect-action@v3.0.0
       if: startsWith(matrix.python-version, '3.9')
@@ -174,18 +174,21 @@ jobs:
       env:
         SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
         SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-        COVERAGE_FILE: '.coverage_e2e'
+        COVERAGE_FILE: '.coverage_e2e.xml'
         SQLALCHEMY_WARN_20: 1
       run: |
-        if [[ -n ${{ secrets.SAUCE_USERNAME }} && -n ${{ secrets.SAUCE_ACCESS_KEY}} ]]; then py.test -vv tests/e2e; fi
-    - name: Run coveralls
-      if: ${{ startsWith(matrix.python-version, '3.9') && !env.ACT }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        COVERALLS_SERVICE_NAME: github
+        if [[ -n ${{ secrets.SAUCE_USERNAME }} && -n ${{ secrets.SAUCE_ACCESS_KEY}} ]]; then pytest --cov-report xml tests/e2e; fi
+    - name: Combine coverage files
+      if: startsWith(matrix.python-version, '3.9')
       run: |
-        coverage combine .coverage_func .coverage_e2e
-        coveralls
+        coverage combine .coverage_func.xml .coverage_e2e.xml
+    - name: Upload to Codecov
+      if: ${{ startsWith(matrix.python-version, '3.9') && !env.ACT }}
+      uses: codecov/codecov-action@v5
+      with:
+        files: .coverage.xml
+        fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}
     - name: Build docs
       run: |
         python -m pip install -e .[docs]

--- a/README.rst
+++ b/README.rst
@@ -2,15 +2,15 @@
 HEPData
 =======
 
-|GitHub Actions Build Status| |Coveralls Status| |License| |Docker Image Size| |GitHub Issues| |Documentation Status|
+|GitHub Actions Build Status| |Coverage Status| |License| |Docker Image Size| |GitHub Issues| |Documentation Status|
 
 .. |GitHub Actions Build Status| image:: https://github.com/HEPData/hepdata/actions/workflows/ci.yml/badge.svg?branch=main
    :target: https://github.com/HEPData/hepdata/actions?query=branch%3Amain
    :alt: GitHub Actions Build Status
 
-.. |Coveralls Status| image:: https://coveralls.io/repos/github/HEPData/hepdata/badge.svg?branch=main
-   :target: https://coveralls.io/github/HEPData/hepdata?branch=main
-   :alt: Coveralls Status
+.. |Coverage Status| image:: https://codecov.io/gh/HEPData/hepdata/graph/badge.svg
+   :target: https://codecov.io/gh/HEPData/hepdata
+   :alt: Coverage Status
 
 .. |License| image:: https://img.shields.io/github/license/HEPData/hepdata.svg
    :target: https://github.com/HEPData/hepdata/blob/main/LICENSE

--- a/docs/info.rst
+++ b/docs/info.rst
@@ -4,9 +4,9 @@
        :target: https://github.com/HEPData/hepdata/actions?query=branch%3Amain
        :alt: GitHub Actions Build Status
 
-    .. image:: https://coveralls.io/repos/github/HEPData/hepdata/badge.svg?branch=main
-       :target: https://coveralls.io/github/HEPData/hepdata?branch=main
-       :alt: Coveralls Status
+    .. image:: https://codecov.io/gh/HEPData/hepdata/graph/badge.svg
+       :target: https://codecov.io/gh/HEPData/hepdata
+       :alt: Coverage Status
 
     .. image:: https://img.shields.io/github/license/HEPData/hepdata.svg
        :target: https://github.com/HEPData/hepdata/blob/main/LICENSE

--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20260220"
+__version__ = "0.9.4dev20260227"


### PR DESCRIPTION
* Need to write coverage files in `.xml` format for use by Codecov.
* Remove `-vv` (verbosity) option when running `pytest`.
* Closes #949.