### PR TITLE
Reinstate upload to Coveralls in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,10 +155,10 @@ jobs:
         cp hepdata/config_local.gh.py hepdata/config_local.py
     - name: Run tests
       env:
-        COVERAGE_FILE: '.coverage_func.xml'
+        COVERAGE_FILE: '.coverage_func'
         SQLALCHEMY_WARN_20: 1
       run: |
-        pytest --cov-report xml tests/*_test.py tests/test_*.py
+        pytest -v --cov-report xml:.coverage_func.xml tests/*_test.py tests/test_*.py
     - name: Setup Sauce Connect
       uses: saucelabs/sauce-connect-action@v3
       if: startsWith(matrix.python-version, '3.9')
@@ -174,21 +174,24 @@ jobs:
       env:
         SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
         SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-        COVERAGE_FILE: '.coverage_e2e.xml'
+        COVERAGE_FILE: '.coverage_e2e'
         SQLALCHEMY_WARN_20: 1
       run: |
-        if [[ -n ${{ secrets.SAUCE_USERNAME }} && -n ${{ secrets.SAUCE_ACCESS_KEY}} ]]; then pytest --cov-report xml tests/e2e; fi
-    - name: Combine coverage files
-      if: startsWith(matrix.python-version, '3.9')
-      run: |
-        coverage combine .coverage_func.xml .coverage_e2e.xml
+        if [[ -n ${{ secrets.SAUCE_USERNAME }} && -n ${{ secrets.SAUCE_ACCESS_KEY}} ]]; then pytest -v --cov-report xml:.coverage_e2e.xml tests/e2e; fi
     - name: Upload to Codecov
       if: ${{ startsWith(matrix.python-version, '3.9') && !env.ACT }}
       uses: codecov/codecov-action@v5
       with:
-        files: .coverage.xml
+        files: .coverage_func.xml,.coverage_e2e.xml
         fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
+    - name: Upload to Coveralls
+      if: ${{ startsWith(matrix.python-version, '3.9') && !env.ACT }}
+      uses: coverallsapp/github-action@v2
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        files: .coverage_func .coverage_e2e
+        fail-on-error: false
     - name: Build docs
       run: |
         python -m pip install -e .[docs]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,11 +178,16 @@ jobs:
         SQLALCHEMY_WARN_20: 1
       run: |
         if [[ -n ${{ secrets.SAUCE_USERNAME }} && -n ${{ secrets.SAUCE_ACCESS_KEY}} ]]; then pytest -v --cov-report xml:.coverage_e2e.xml tests/e2e; fi
+    - name: Combine coverage files
+      if: startsWith(matrix.python-version, '3.9')
+      run: |
+        coverage combine --data-file=.coverage.xml .coverage_func.xml .coverage_e2e.xml
+        coverage combine --data-file=.coverage .coverage_func .coverage_e2e
     - name: Upload to Codecov
       if: ${{ startsWith(matrix.python-version, '3.9') && !env.ACT }}
       uses: codecov/codecov-action@v5
       with:
-        files: .coverage_func.xml,.coverage_e2e.xml
+        files: .coverage.xml
         fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
     - name: Upload to Coveralls
@@ -190,7 +195,7 @@ jobs:
       uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        files: .coverage_func .coverage_e2e
+        file: .coverage
         fail-on-error: false
     - name: Build docs
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,13 +181,12 @@ jobs:
     - name: Combine coverage files
       if: startsWith(matrix.python-version, '3.9')
       run: |
-        coverage combine --data-file=.coverage.xml .coverage_func.xml .coverage_e2e.xml
         coverage combine --data-file=.coverage .coverage_func .coverage_e2e
     - name: Upload to Codecov
       if: ${{ startsWith(matrix.python-version, '3.9') && !env.ACT }}
       uses: codecov/codecov-action@v5
       with:
-        files: .coverage.xml
+        files: .coverage_func.xml,.coverage_e2e.xml
         fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
     - name: Upload to Coveralls

--- a/README.rst
+++ b/README.rst
@@ -2,15 +2,19 @@
 HEPData
 =======
 
-|GitHub Actions Build Status| |Coverage Status| |License| |Docker Image Size| |GitHub Issues| |Documentation Status|
+|GitHub Actions Build Status| |Codecov Status| |Coveralls Status| |License| |Docker Image Size| |GitHub Issues| |Documentation Status|
 
 .. |GitHub Actions Build Status| image:: https://github.com/HEPData/hepdata/actions/workflows/ci.yml/badge.svg?branch=main
    :target: https://github.com/HEPData/hepdata/actions?query=branch%3Amain
    :alt: GitHub Actions Build Status
 
-.. |Coverage Status| image:: https://codecov.io/gh/HEPData/hepdata/graph/badge.svg
+.. |Codecov Status| image:: https://codecov.io/gh/HEPData/hepdata/graph/badge.svg
    :target: https://codecov.io/gh/HEPData/hepdata
    :alt: Coverage Status
+
+.. |Coveralls Status| image:: https://coveralls.io/repos/github/HEPData/hepdata/badge.svg?branch=main
+   :target: https://coveralls.io/github/HEPData/hepdata?branch=main
+   :alt: Coveralls Status
 
 .. |License| image:: https://img.shields.io/github/license/HEPData/hepdata.svg
    :target: https://github.com/HEPData/hepdata/blob/main/LICENSE

--- a/docs/info.rst
+++ b/docs/info.rst
@@ -6,7 +6,11 @@
 
     .. image:: https://codecov.io/gh/HEPData/hepdata/graph/badge.svg
        :target: https://codecov.io/gh/HEPData/hepdata
-       :alt: Coverage Status
+       :alt: Codecov Status
+
+    .. image:: https://coveralls.io/repos/github/HEPData/hepdata/badge.svg?branch=main
+       :target: https://coveralls.io/github/HEPData/hepdata?branch=main
+       :alt: Coveralls Status
 
     .. image:: https://img.shields.io/github/license/HEPData/hepdata.svg
        :target: https://github.com/HEPData/hepdata/blob/main/LICENSE

--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20260304"
+__version__ = "0.9.4dev20260305"


### PR DESCRIPTION
The PR #950 removed upload to Coveralls in favour of Codecov after the Coveralls service was [unavailable](https://status.coveralls.io/incidents/pdbt7vdzlvpj) for multiple days.  However, the Coveralls service was subsequently restored and we've noticed some issues viewing Codecov web pages to check test coverage.  Therefore, this PR restores the upload to Coveralls while also keeping the upload to Codecov.  This time I'm using the [Coveralls GitHub Action](https://github.com/marketplace/actions/coveralls-github-action) instead of running `coveralls` directly.  The `fail-on-error: false` option is used to prevent any future Coveralls downtime from blocking the CI.  A complication is that the XML format used by Codecov is not supported by Coveralls and the native `pytest-cov` format used by Coveralls is not supported by Codecov.  Therefore, it is necessary to produce the coverage reports in two different formats.  This PR also adds a `-v` (verbosity) option when running `pytest` after the `-vv` option was removed in PR #950.