### PR TITLE
Clear dashboard reminder message textarea upon confirmation

### DIFF
--- a/hepdata/modules/dashboard/assets/js/hepdata_dashboard_manage_scripts.js
+++ b/hepdata/modules/dashboard/assets/js/hepdata_dashboard_manage_scripts.js
@@ -43,7 +43,7 @@ $(document).ready(function() {
         confirmation_html += '<p>This action will send an email immediately to invite the user to join the ' + window.data_person_type + ' process.</p>';
       }
       show_confirmation(confirmation_html);
-      
+
       // Hide the review message textarea for remove action since no email is sent
       if (window.action == 'remove') {
         $('#review-message-container').hide();
@@ -53,12 +53,13 @@ $(document).ready(function() {
   });
 
   $(document).on('click', '.confirm-move-action', function () {
+      let review_message = $("#review-message");
       $.ajax({
           dataType: "json",
           url: '/permissions/manage/' + window.recid + '/' + window.data_person_type + '/' + window.action + '/' + window.userid,
           type: 'POST',
           data: {
-              review_message: $("#review-message").val()
+              review_message: review_message.val()
           },
           success: function (data) {
               if (data.success) {
@@ -69,6 +70,7 @@ $(document).ready(function() {
               }
           }
       })
+      review_message.val('');
   });
 
   $(document).on('click', '.confirm-add-user-action', function (event) {

--- a/hepdata/modules/dashboard/assets/js/hepdata_dashboard_manage_scripts.js
+++ b/hepdata/modules/dashboard/assets/js/hepdata_dashboard_manage_scripts.js
@@ -65,6 +65,7 @@ $(document).ready(function() {
               if (data.success) {
                   process_reviews(data['recid']);
                   hide_pane("#confirmation");
+                  review_message.val('');
               } else {
                   alert("Error! " + data.message)
               }

--- a/tests/e2e/test_dashboard.py
+++ b/tests/e2e/test_dashboard.py
@@ -155,7 +155,9 @@ def test_dashboard(live_server, logged_in_browser):
     # Open again and check review message text has cleared
     reminder_button = manage_widget.find_element(By.CSS_SELECTOR, '.trigger-actions .btn-primary')
     reminder_button.click()
-    assert review_message_area.text == ''
+    
+    review_message_area = manage_widget.find_element(By.ID, 'review-message')
+    assert review_message_area.get_attribute('value') == ''
 
     # Close and check with cancel button
     confirmation_panel = manage_widget.find_element(By.ID, 'confirmation')

--- a/tests/e2e/test_dashboard.py
+++ b/tests/e2e/test_dashboard.py
@@ -144,9 +144,13 @@ def test_dashboard(live_server, logged_in_browser):
     review_message_area.send_keys('some text!')
 
     # Confirm and check it closes upon confirmation
+    confirmation_panel = manage_widget.find_element(By.ID, 'confirmation')
     confirmation_button = manage_widget.find_element(By.CSS_SELECTOR, '.confirm-move-action')
     confirmation_button.click()
-    assert not manage_widget.find_element(By.ID, 'confirmation').is_displayed()
+    WebDriverWait(browser, 10).until(
+        EC.invisibility_of_element(confirmation_panel)
+    )
+    assert not confirmation_panel.is_displayed()
 
     # Open again and check review message text has cleared
     reminder_button = manage_widget.find_element(By.CSS_SELECTOR, '.trigger-actions .btn-primary')
@@ -154,9 +158,13 @@ def test_dashboard(live_server, logged_in_browser):
     assert review_message_area.text == ''
 
     # Close and check with cancel button
+    confirmation_panel = manage_widget.find_element(By.ID, 'confirmation')
     cancel_button = manage_widget.find_element(By.CSS_SELECTOR, '.reject-move-action')
     cancel_button.click()
-    assert not manage_widget.find_element(By.ID, 'confirmation').is_displayed()
+    WebDriverWait(browser, 10).until(
+        EC.invisibility_of_element(confirmation_panel)
+    )
+    assert not confirmation_panel.is_displayed()
 
     # Get the submission ID from the anchor tag href attr
     sub_item = browser.find_element(By.CSS_SELECTOR, '.row div h4 a').get_attribute("href")

--- a/tests/e2e/test_dashboard.py
+++ b/tests/e2e/test_dashboard.py
@@ -129,7 +129,7 @@ def test_dashboard(live_server, logged_in_browser):
     manage_widget = WebDriverWait(browser, 10).until(
         EC.visibility_of_element_located((By.ID, 'manageWidget'))
     )
-    
+
     assert manage_widget.find_element(By.CLASS_NAME,'modal-title').text == 'Manage Submission'
 
     # Check reminder email button works
@@ -138,8 +138,24 @@ def test_dashboard(live_server, logged_in_browser):
     reminder_button.click()
     confirmation_message = manage_widget.find_element(By.ID, 'confirmation_message').text
     assert confirmation_message == 'Are you sure you want to email this uploader?'
+
+    # Add some text to the review message box
+    review_message_area = manage_widget.find_element(By.ID, 'review-message')
+    review_message_area.send_keys('some text!')
+
+    # Confirm and check it closes upon confirmation
     confirmation_button = manage_widget.find_element(By.CSS_SELECTOR, '.confirm-move-action')
     confirmation_button.click()
+    assert not manage_widget.find_element(By.ID, 'confirmation').is_displayed()
+
+    # Open again and check review message text has cleared
+    reminder_button = manage_widget.find_element(By.CSS_SELECTOR, '.trigger-actions .btn-primary')
+    reminder_button.click()
+    assert review_message_area.text == ''
+
+    # Close and check with cancel button
+    cancel_button = manage_widget.find_element(By.CSS_SELECTOR, '.reject-move-action')
+    cancel_button.click()
     assert not manage_widget.find_element(By.ID, 'confirmation').is_displayed()
 
     # Get the submission ID from the anchor tag href attr


### PR DESCRIPTION
Closes #960 by now clearing the reminder message box after the coordinator clicks confirm and adds test case.

One thing: Should the user click cancel or close the window, their original message will stay. I think this maybe should also clear when the user clicks cancel explicitly too. Just closing the window may happen accidentally, although clearing upon confirmation is an improvement.