### PR TITLE
ci: pin urllib3 for compatibility w/ opensearch-py

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,8 +135,7 @@ jobs:
           ${{ runner.os }}-test-${{ env.cache-name }}-
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip "setuptools<82" py
-        python -m pip install twine wheel requirements-builder
+        python -m pip install --upgrade pip "setuptools<82" wheel
         python -m pip install --force-reinstall -r requirements.txt
         python -m pip install -e .[tests]
     - name: Initialise hepdata

--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20260429"
+__version__ = "0.9.4dev20260507"

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,8 @@ tests_require = [
     'pytest-mock>=3.1.0',
     'pytest-timeout>=1.4.2',
     'requests-mock>=1.8.0',
-    'selenium>=4.0.0'
+    'selenium>=4.0.0',
+    'urllib3<1.27,'
 ]
 
 extras_require = {


### PR DESCRIPTION
This PR pins `urllib3<1.27` in `tests_require` of `setup.py` for compatibility with `opensearch-py` to avoid a `pip` dependency resolver error.  The pin can be removed after upgrading from Python 3.9 (#851).  The PR also removes the unused `twine`, `requirements-builder` and `py` packages from being installed in the CI.  It closes #977.