### PR TITLE
global: upgrade from Python 3.9 to 3.14

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,4 +31,3 @@ updates:
       - dependency-name: "invenio-userprofiles"  # see https://github.com/HEPData/hepdata/issues/848
       - dependency-name: "setuptools"  # see https://github.com/HEPData/hepdata/issues/946
       - dependency-name: "Flask-Security-Invenio"  # see https://github.com/HEPData/hepdata/issues/957
-      - dependency-name: "urllib3"  # see https://github.com/HEPData/hepdata/issues/851

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       matrix:
         postgres-version: [ 16 ]
         os-version: [ '3.4.0' ]
-        python-version: [ '3.9' ]
+        python-version: [ '3.14' ]
 
     # Service containers to run with `runner-job`
     services:
@@ -160,7 +160,7 @@ jobs:
         pytest -v --cov-report xml:.coverage_func.xml tests/*_test.py tests/test_*.py
     - name: Setup Sauce Connect
       uses: saucelabs/sauce-connect-action@v3
-      if: startsWith(matrix.python-version, '3.9')
+      if: startsWith(matrix.python-version, '3.14')
       with:
         username: ${{ secrets.SAUCE_USERNAME }}
         accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
@@ -169,7 +169,7 @@ jobs:
         proxyLocalhost: direct
         scVersion: 5.5.1
     - name: Run end-to-end tests
-      if: startsWith(matrix.python-version, '3.9')
+      if: startsWith(matrix.python-version, '3.14')
       env:
         SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
         SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
@@ -178,18 +178,18 @@ jobs:
       run: |
         if [[ -n ${{ secrets.SAUCE_USERNAME }} && -n ${{ secrets.SAUCE_ACCESS_KEY}} ]]; then pytest -v --cov-report xml:.coverage_e2e.xml tests/e2e; fi
     - name: Combine coverage files
-      if: startsWith(matrix.python-version, '3.9')
+      if: startsWith(matrix.python-version, '3.14')
       run: |
         coverage combine --data-file=.coverage .coverage_func .coverage_e2e
     - name: Upload to Codecov
-      if: ${{ startsWith(matrix.python-version, '3.9') && !env.ACT }}
+      if: ${{ startsWith(matrix.python-version, '3.14') && !env.ACT }}
       uses: codecov/codecov-action@v6
       with:
         files: .coverage_func.xml,.coverage_e2e.xml
         fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
     - name: Upload to Coveralls
-      if: ${{ startsWith(matrix.python-version, '3.9') && !env.ACT }}
+      if: ${{ startsWith(matrix.python-version, '3.14') && !env.ACT }}
       uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,15 +1,15 @@
 # .readthedocs.yml
 # Read the Docs configuration file
-# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+# See https://docs.readthedocs.com/platform/stable/config-file/v2.html for details
 
 # Required
 version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-22.04
+  os: ubuntu-26.04
   tools:
-    python: "3.9"
+    python: "3.14"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -97,7 +97,7 @@ Before you submit a pull request, check that it meets these guidelines:
 1. The pull request should include tests and must not decrease test coverage.
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring.
-3. The pull request should work for Python 3.9. Check
+3. The pull request should work for Python 3.14. Check
    https://github.com/HEPData/hepdata/actions?query=event%3Apull_request
    and make sure that the tests pass.  Sometimes there are temporary failures,
    for example, due to unavailability of an external service or the test infrastructure.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9 as build
+FROM python:3.14 as build
 
 WORKDIR /usr/src/app
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -29,7 +29,7 @@ Running services locally
 Prerequisites
 =============
 
-HEPData runs with Python 3.9. It also uses several services, which you will need to install before running HEPData.
+HEPData runs with Python 3.14. It also uses several services, which you will need to install before running HEPData.
 
 These services can be installed using the relevant package manager for your system,
 for example, using ``yum`` or ``apt-get`` for Linux or ``brew`` for macOS:
@@ -96,7 +96,7 @@ Installation
 
 Python
 ------
-The HEPData code is only compatible with Python 3.9 (not Python 2 or other 3.x versions).
+The HEPData code is only compatible with Python 3.14 (not Python 2 or other 3.x versions).
 
 First install all requirements in a Python virtual environment.
 (Use `virtualenv <https://virtualenv.pypa.io/en/stable/installation.html>`_ or
@@ -108,7 +108,7 @@ with a target directory also called ``venv`` (change it if you prefer).
 
    $ git clone https://github.com/HEPData/hepdata.git
    $ cd hepdata
-   $ python3.9 -m venv venv
+   $ python3.14 -m venv venv
    $ source venv/bin/activate
    (venv)$ pip install --upgrade pip
    (venv)$ pip install -e ".[all]" --upgrade -r requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -341,7 +341,7 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3.9', None),
+    'python': ('https://docs.python.org/3.14', None),
     'sqlalchemy': ('https://docs.sqlalchemy.org/en/20/', None)
 }
 

--- a/fixes/cleanup_index.py
+++ b/fixes/cleanup_index.py
@@ -60,7 +60,8 @@ def cleanup_index_batch(hepsubmission_record_ids, index):
     log.info('Cleaning up index for data records for hepsubmission IDs {0} to {1}'.format(hepsubmission_record_ids[0], hepsubmission_record_ids[-1]))
     # Find all datasubmission entries matching the given hepsubmission ids,
     # where the version is not the highest version present (i.e. there is not
-    # a v2 record with the same associated_recid)
+    # a v2 record with the same associated_recid).
+    # This function does not work if there is a v3 or greater.
     d1 = aliased(DataSubmission)
     d2 = aliased(DataSubmission)
     qry = db.session.query(d1.associated_recid) \

--- a/hepdata/modules/records/api.py
+++ b/hepdata/modules/records/api.py
@@ -798,6 +798,7 @@ def process_zip_archive(file_path, id, old_schema=False):
                 try:
                     unzipped_path = extract(file_path, submission_temp_path)
                 except TarError as e:
+                    shutil.rmtree(submission_temp_path, ignore_errors=True)
                     message = clean_error_message_for_display(
                         "The archive file {} is not a valid tar file. {}".format(file_path, e),
                         file_save_directory

--- a/hepdata/modules/records/api.py
+++ b/hepdata/modules/records/api.py
@@ -37,6 +37,7 @@ from invenio_db import db
 from sqlalchemy import and_, func, select
 from sqlalchemy.orm.exc import NoResultFound
 from werkzeug.utils import secure_filename
+from tarfile import TarError
 
 from hepdata.modules.converter import convert_oldhepdata_to_yaml
 from hepdata.modules.email.api import send_cookie_email, notify_submission_created
@@ -794,7 +795,20 @@ def process_zip_archive(file_path, id, old_schema=False):
         else:
             # we are dealing with a zip, tar, etc. so we extract the contents
             try:
-                unzipped_path = extract(file_path, submission_temp_path)
+                try:
+                    unzipped_path = extract(file_path, submission_temp_path)
+                except TarError as e:
+                    message = clean_error_message_for_display(
+                        "The archive file {} is not a valid tar file. {}".format(file_path, e),
+                        file_save_directory
+                    )
+                    return {
+                        "Archive file extractor": [{
+                            "level": "error",
+                            "message": message
+                        }]
+                    }
+
             except Exception as e:
                 # Log the exception and raise it so that celery can retry
                 log.exception(f"Unable to extract file {file_path}")

--- a/hepdata/version.py
+++ b/hepdata/version.py
@@ -28,4 +28,4 @@ This file is imported by ``HEPData.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.4dev20260525"
+__version__ = "0.9.4dev20260602"

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ tests_require = [
     'pytest-timeout>=1.4.2',
     'requests-mock>=1.8.0',
     'selenium>=4.0.0',
-    'urllib3<1.27,'
 ]
 
 extras_require = {
@@ -142,8 +141,8 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.14',
         'Development Status :: Production',
     ],
-    python_requires='>=3.9, <3.10',
+    python_requires='>=3.14, <3.15',
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -173,6 +173,7 @@ def get_identifiers():
              "title": "High-statistics study of $K^0_S$ pair production in two-photon collisions",
              "data_tables": 40,
              "arxiv": "arXiv:1307.7457"},
+
             {"hepdata_id": "ins2751932", "inspire_id": '2751932',
              "title": "Search for pair production of higgsinos in events with two Higgs bosons and missing "
                       "transverse momentum in $\\sqrt{s}=13$ TeV $pp$ collisions at the ATLAS experiment",

--- a/tests/e2e/test_general.py
+++ b/tests/e2e/test_general.py
@@ -217,7 +217,7 @@ def _check_table_links(browser, table_full_name, url=None):
            == f'attachment; filename="HEPData-ins1206352-v1-{filename_table}.yaml"')
 
 
-def test_general_pages(live_server, env_browser):
+def test_general_pages(app, live_server, env_browser):
     """Test general pages can be loaded without errors"""
     browser = env_browser
 
@@ -249,10 +249,14 @@ def test_general_pages(live_server, env_browser):
     browser.get(url)
     assert url in browser.current_url
 
-    import_records(['ins1748602'], synchronous=True)
+    # Test version of /formats that requires ins1748602 to be loaded
+    import_default_data(app, [{'hepdata_id': 'ins1748602'}])
     url = flask.url_for('hepdata_theme.formats', _external=True)
     browser.get(url)
     assert url in browser.current_url
+    submission = get_latest_hepsubmission(inspire_id='1748602')
+    unload_submission(submission.publication_recid)
+    reindex_all(recreate=True)
 
 
 def test_accept_headers(app, live_server, e2e_identifiers):

--- a/tests/e2e/test_general.py
+++ b/tests/e2e/test_general.py
@@ -38,6 +38,7 @@ from hepdata.ext.opensearch.api import reindex_all
 from hepdata.modules.submission.api import get_latest_hepsubmission
 from hepdata.modules.records.utils.submission import unload_submission
 from hepdata_validator import LATEST_SCHEMA_VERSION, RAW_SCHEMAS_URL
+from hepdata.modules.records.importer.api import import_records
 
 
 def test_home(app, live_server, env_browser, e2e_identifiers):
@@ -248,7 +249,8 @@ def test_general_pages(live_server, env_browser):
     browser.get(url)
     assert url in browser.current_url
 
-    url = flask.url_for('hepdata_theme.ping', _external=True)
+    import_records(['ins1748602'], synchronous=True)
+    url = flask.url_for('hepdata_theme.formats', _external=True)
     browser.get(url)
     assert url in browser.current_url
 

--- a/tests/fixes_test.py
+++ b/tests/fixes_test.py
@@ -92,18 +92,20 @@ def test_cleanup_index_batch(app, load_default_data, identifiers, mocker):
 
     # Reindex submission id 1 (pub_recid=1)
     # New version means the original data submissions (2-16) are
-    # superceded so can be cleaned up
+    # superseded so can be cleaned up
     cleanup_index_batch([1], index)
-    assert mock_records_search.has_calls([
-        call('terms', _id=list(range(2,16)))
+    mock_records_search.assert_has_calls([
+        call('terms', _id=list(range(2, 16))),
+        call().delete()
     ])
     mock_records_search.reset_mock()
 
     # Create more new versions
     _create_new_versions(3, list(range(126, 131)))
     cleanup_index_batch([1], index)
-    assert mock_records_search.has_calls([
-        call('terms', _id=list(range(2,16)) + list(range(126, 131)))
+    mock_records_search.assert_has_calls([
+        call('terms', _id=list(range(2,16))),  # note: v2 data submissions (126-130) not deleted
+        call().delete()
     ])
     mock_records_search.reset_mock()
 

--- a/tests/records_test.py
+++ b/tests/records_test.py
@@ -548,6 +548,45 @@ def test_move_files_invalid_path():
            )
 
 
+def test_process_zip_archive_returns_copy_errors(app):
+    base_dir = os.path.dirname(os.path.realpath(__file__))
+    file_path = os.path.join(base_dir, 'test_data/1396331.zip')
+    expected_errors = {
+        "Exceptions when copying files": [{
+            "level": "error",
+            "message": "forced copy error"
+        }]
+    }
+
+    def _mock_move_files(submission_temp_path, submission_path):
+        # Cleanup temporary extraction dir because we bypass the real move_files finally block.
+        shutil.rmtree(submission_temp_path, ignore_errors=True)
+        return expected_errors
+
+    with patch('hepdata.modules.records.api.move_files', side_effect=_mock_move_files):
+        errors = process_zip_archive(file_path, 1)
+
+    assert errors == expected_errors
+
+
+def test_move_files_shutil_error_formats_messages():
+    submission_temp_path = tempfile.mkdtemp(dir=CFG_TMPDIR)
+    submission_path = tempfile.mkdtemp(dir=CFG_TMPDIR)
+    srcname = os.path.join(submission_temp_path, 'bad.txt')
+    dstname = os.path.join(submission_path, 'bad.txt')
+
+    copy_error = shutil.Error([(srcname, dstname, 'permission denied')])
+    with patch('hepdata.modules.records.api.shutil.copytree', side_effect=copy_error):
+        errors = move_files(submission_temp_path, submission_path)
+
+    assert errors == {
+        "Exceptions when copying files": [{
+            "level": "error",
+            "message": "Invalid file bad.txt: permission denied"
+        }]
+    }
+
+
 def test_get_updated_records_since_date(app):
     ids_since = get_inspire_records_updated_since(3)
     ids_on = get_inspire_records_updated_on(0)

--- a/tests/records_test.py
+++ b/tests/records_test.py
@@ -478,13 +478,12 @@ def test_process_zip_archive_invalid(app):
     shutil.copy2(file_path, tmp_path)
     tmp_file_path = os.path.join(tmp_path, 'submission_invalid_symlink.tgz')
     errors = process_zip_archive(tmp_file_path, 1)
-    assert("Exceptions when copying files" in errors)
-    assert(len(errors["Exceptions when copying files"]) == 1)
-    assert(errors["Exceptions when copying files"][0].get("level") == "error")
-    assert(errors["Exceptions when copying files"][0].get("message")
-           == "Invalid file TestHEPSubmissionInvalidSymlink/invalid_file_name.txt: "
-           "[Errno 2] No such file or directory: "
-           "'TestHEPSubmissionInvalidSymlink/invalid_file_name.txt'"
+    assert("Archive file extractor" in errors)
+    assert(len(errors["Archive file extractor"]) == 1)
+    assert(errors["Archive file extractor"][0].get("level") == "error")
+    assert(errors["Archive file extractor"][0].get("message")
+           == "The archive file submission_invalid_symlink.tgz is not a valid tar file. "
+              "'TestHEPSubmissionInvalidSymlink/invalid_file_name.txt' is a link to an absolute path"
            )
     shutil.rmtree(tmp_path)
 

--- a/tests/test_theme_views.py
+++ b/tests/test_theme_views.py
@@ -1,0 +1,173 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of HEPData.
+# Copyright (C) 2016 CERN.
+#
+# HEPData is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# HEPData is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with HEPData; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Tests for hepdata/modules/theme/views.py."""
+
+from unittest.mock import patch
+
+from hepdata.modules.theme.views import (
+    invalid_doi,
+    page_forbidden,
+    page_not_found,
+    internal_error,
+    redirect_nonwww,
+    ping,
+)
+
+
+class TestInvalidDoi:
+    """Tests for the invalid_doi view."""
+
+    def test_invalid_doi_returns_410(self, app):
+        """GET /record/invalid_doi returns 410 status code."""
+        with app.test_client() as client:
+            response = client.get('/record/invalid_doi')
+            assert response.status_code == 410
+
+    def test_invalid_doi_renders_template(self, app):
+        """invalid_doi renders the template from INVALID_DOI_TEMPLATE config."""
+        with app.test_request_context('/record/invalid_doi'):
+            with patch('hepdata.modules.theme.views.render_template') as mock_render:
+                mock_render.return_value = 'rendered'
+                result, status = invalid_doi()
+                mock_render.assert_called_once_with(
+                    app.config['INVALID_DOI_TEMPLATE']
+                )
+                assert status == 410
+
+
+class TestPageForbidden:
+    """Tests for the page_forbidden error handler."""
+
+    def test_page_forbidden_returns_403(self, app):
+        """page_forbidden returns 403 status code."""
+        with app.test_request_context('/'):
+            error = PermissionError("Access denied")
+            _, status = page_forbidden(error)
+            assert status == 403
+
+    def test_page_forbidden_renders_template_with_context(self, app):
+        """page_forbidden renders THEME_403_TEMPLATE with error info in ctx."""
+        with app.test_request_context('/'):
+            with patch('hepdata.modules.theme.views.render_template') as mock_render:
+                mock_render.return_value = 'rendered'
+                error = PermissionError("Not allowed")
+                result, status = page_forbidden(error)
+                mock_render.assert_called_once_with(
+                    app.config['THEME_403_TEMPLATE'],
+                    ctx={"name": "PermissionError", "error": "Not allowed"}
+                )
+                assert status == 403
+
+
+class TestPageNotFound:
+    """Tests for the page_not_found error handler."""
+
+    def test_page_not_found_returns_404(self, app):
+        """page_not_found returns 404 status code."""
+        with app.test_request_context('/'):
+            error = LookupError("Resource missing")
+            _, status = page_not_found(error)
+            assert status == 404
+
+    def test_page_not_found_renders_template_with_context(self, app):
+        """page_not_found renders THEME_404_TEMPLATE with error info in ctx."""
+        with app.test_request_context('/'):
+            with patch('hepdata.modules.theme.views.render_template') as mock_render:
+                mock_render.return_value = 'rendered'
+                error = LookupError("Not found")
+                result, status = page_not_found(error)
+                mock_render.assert_called_once_with(
+                    app.config['THEME_404_TEMPLATE'],
+                    ctx={"name": "LookupError", "error": "Not found"}
+                )
+                assert status == 404
+
+
+class TestInternalError:
+    """Tests for the internal_error error handler."""
+
+    def test_internal_error_returns_500(self, app):
+        """internal_error returns 500 status code."""
+        with app.test_request_context('/'):
+            error = RuntimeError("Something went wrong")
+            _, status = internal_error(error)
+            assert status == 500
+
+    def test_internal_error_renders_template_with_context(self, app):
+        """internal_error renders THEME_500_TEMPLATE with error info in ctx."""
+        with app.test_request_context('/'):
+            with patch('hepdata.modules.theme.views.render_template') as mock_render:
+                mock_render.return_value = 'rendered'
+                error = RuntimeError("Internal failure")
+                result, status = internal_error(error)
+                mock_render.assert_called_once_with(
+                    app.config['THEME_500_TEMPLATE'],
+                    ctx={"name": "RuntimeError", "error": "Internal failure"}
+                )
+                assert status == 500
+
+
+class TestRedirectNonwww:
+    """Tests for the redirect_nonwww before-request hook."""
+
+    def test_redirect_nonwww_in_production_without_www(self, app):
+        """redirect_nonwww redirects to www URL in production mode when 'www' is absent."""
+        app.config['PRODUCTION_MODE'] = True
+        with app.test_request_context('http://hepdata.net/about'):
+            response = redirect_nonwww()
+            assert response is not None
+            assert response.status_code == 301
+            assert 'www.hepdata.net' in response.location
+
+    def test_redirect_nonwww_in_production_with_www(self, app):
+        """redirect_nonwww does NOT redirect when 'www' is already in the URL."""
+        app.config['PRODUCTION_MODE'] = True
+        with app.test_request_context('http://www.hepdata.net/about'):
+            response = redirect_nonwww()
+            assert response is None
+
+    def test_redirect_nonwww_not_in_production(self, app):
+        """redirect_nonwww does NOT redirect when PRODUCTION_MODE is False."""
+        app.config['PRODUCTION_MODE'] = False
+        with app.test_request_context('http://hepdata.net/about'):
+            response = redirect_nonwww()
+            assert response is None
+
+
+class TestPing:
+    """Tests for the ping view."""
+
+    def test_ping_returns_ok(self, app):
+        """GET /ping returns 'OK' with 200 status."""
+        with app.test_client() as client:
+            response = client.get('/ping')
+            assert response.status_code == 200
+            assert response.data == b'OK'
+
+    def test_ping_directly(self, app):
+        """ping() function returns the string 'OK'."""
+        with app.test_request_context('/ping'):
+            assert ping() == 'OK'
+


### PR DESCRIPTION
* Upgraded from Python 3.9 to 3.14 in `setup.py`, Dockerfile, CI, installation docs, and *Read the Docs* build.
* Removed pin `urllib3<1.27` in `tests_require` of `setup.py` added in PR #978.
* Fixed a bug apparent in Python 3.12 in `test_cleanup_index_batch` to replace `has_calls` by `assert_has_calls` that was hidden in previous Python versions.  After fixing the bug, `cleanup_index_batch` does not seem to work if there are three versions of the same publication record where data records have the same `associated_recid`.  I modified `test_cleanup_index_batch` and added comments in commit b202cef.  This functionality is anyway no longer needed and the `fixes/cleanup_index.py` file could in future be removed from the code.
* The `tarfile` module in Python 3.14 includes a breaking change to the default `tarfile.extractall()` filter from `fully_trusted` to `data` ([PEP 706](https://peps.python.org/pep-0706/)) which triggers a `tarfile.AbsoluteLinkError` if the tar file contains a symlink.  I modified the `process_zip_archive` function to catch `tarfile.TarError` exceptions explicitly and also modified the corresponding test in the `test_process_zip_archive_invalid` function in commit 685615c.
* The `move_files` function was uncovered following the above change to the `process_zip_archive` function, so tests to improve coverage were added in commit acc3b70.
* Coverage of `hepdata/modules/theme/views.py` was extended in commit 7867d06.
* Closes #851.