### PR TITLE
Fix CACHE_TYPE value for Flask-Caching update to 2.5.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     - "APP_ENVIRONMENT=local"
     - "APP_BROKER_URL=redis://cache:6379/0"
     - "APP_CACHE_REDIS_URL=redis://cache:6379/0"
-    - "APP_CACHE_TYPE=redis"
+    - "APP_CACHE_TYPE=RedisCache"
     - "APP_CELERY_RESULT_BACKEND=redis://cache:6379/2"
     - "APP_OPENSEARCH_HOST=os:9200"
     - "APP_SECRET_KEY=CHANGE_ME"
@@ -37,7 +37,7 @@ services:
     environment:
     - "APP_BROKER_URL=redis://cache:6379/0"
     - "APP_CACHE_REDIS_URL=redis://cache:6379/0"
-    - "APP_CACHE_TYPE=redis"
+    - "APP_CACHE_TYPE=RedisCache"
     - "APP_CELERY_RESULT_BACKEND=redis://cache:6379/2"
     - "APP_OPENSEARCH_HOST=os:9200"
     - "APP_SECRET_KEY=CHANGE_ME"

--- a/hepdata/config.py
+++ b/hepdata/config.py
@@ -115,7 +115,7 @@ CELERY_TASK_ANNOTATIONS = {
 # Cache
 CACHE_KEY_PREFIX = "cache::"
 CACHE_REDIS_URL = "redis://localhost:6379/0"
-CACHE_TYPE = "redis"
+CACHE_TYPE = "RedisCache"
 
 # Session
 ACCOUNTS_RETENTION_PERIOD = timedelta(days=7)


### PR DESCRIPTION
This pull request solves an issue caused by a deprecation of the lower case class names used in [Flask-Caching](https://github.com/pallets-eco/flask-caching/) v2.5.0. No functionality has been changed, it appears that the class names have been changed to improve clarity and naming. In the case of HEPData, CACHE_TYPE entries for _"redis"_ have been replaced with _"RedisCache"_.

See the [Flask-Caching GitHub releases](https://github.com/pallets-eco/flask-caching/releases) page for the change log.